### PR TITLE
Fail on unknown environment variable

### DIFF
--- a/bin/install-cf.sh
+++ b/bin/install-cf.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -eo pipefail
+set -euo pipefail
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 CONFIG_DIR="${SCRIPT_DIR}/../config"


### PR DESCRIPTION
The values file is required. 
There is a comment about improving it, but failing fast would be more visible