### PR TITLE
Enable Istio automatic sidecar injection

### DIFF
--- a/config/metacontroller-namespace-overlay.yml
+++ b/config/metacontroller-namespace-overlay.yml
@@ -1,0 +1,9 @@
+#@ load("@ytt:overlay", "overlay")
+
+#@overlay/match by=overlay.subset({"kind":"Namespace", "metadata":{"name":"metacontroller"}})
+---
+metadata:
+  #@overlay/match missing_ok=True
+  labels:
+    #@overlay/match missing_ok=True
+    istio-injection: enabled

--- a/config/system-namespace.yml
+++ b/config/system-namespace.yml
@@ -4,3 +4,5 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: #@ data.values.system_namespace
+  labels:
+    istio-injection: enabled

--- a/config/workloads-namespace.yml
+++ b/config/workloads-namespace.yml
@@ -4,3 +4,5 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: #@ data.values.workloads_namespace
+  labels:
+    istio-injection: enabled


### PR DESCRIPTION
We want to enable automatic sidecar injection to have automatic mTLS between cf-for-k8s workloads (both system components and apps). See [our ADR](https://github.com/cloudfoundry/cf-k8s-networking/blob/master/doc/architecture-decisions/0004-strategy-for-securing-network-traffic.md) for a bit more explanation.

As we discussed on Slack, we attempted the `ytt` overlay approach. Happy to pair with y'all on this if you would like it to work differently.

Fixes https://github.com/cloudfoundry/cf-for-k8s/issues/3.

[Story: #170980509](https://www.pivotaltracker.com/story/show/170980509)

Thanks!
@mike1808 && @tcdowney