### PR TITLE
bump capi-k8s-release

### DIFF
--- a/config/_ytt_lib/github.com/cloudfoundry/capi-k8s-release/templates/api_server_deployment.yml
+++ b/config/_ytt_lib/github.com/cloudfoundry/capi-k8s-release/templates/api_server_deployment.yml
@@ -4,7 +4,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: capi-api-server
-  namespace: cf-system
+  namespace: #@ data.values.namespace
 spec:
   replicas: 2
   strategy:
@@ -23,7 +23,7 @@ spec:
       imagePullSecrets: #@ data.values.imagePullSecrets
       initContainers:
         - name: pre-start
-          image: #@ data.values.image
+          image: #@ data.values.images.ccng
           imagePullPolicy: Always
           command: ['bundle', 'exec', 'rake', 'db:setup_database']
           volumeMounts:
@@ -31,7 +31,7 @@ spec:
             mountPath: /config
       containers:
         - name: capi-api-server
-          image: #@ data.values.image
+          image: #@ data.values.images.ccng
           imagePullPolicy: Always
           volumeMounts:
           - name: server-sock
@@ -45,7 +45,7 @@ spec:
           - name: eirini-certs
             mountPath: /config/eirini/certs
         - name: nginx
-          image: nginx:latest
+          image: #@ data.values.images.nginx
           imagePullPolicy: Always
           ports:
           - containerPort: 80

--- a/config/_ytt_lib/github.com/cloudfoundry/capi-k8s-release/templates/ccng-config.lib.yml
+++ b/config/_ytt_lib/github.com/cloudfoundry/capi-k8s-release/templates/ccng-config.lib.yml
@@ -123,7 +123,7 @@ login:
 #! TODO: change the UAA's Kube DNS name when the service is named correctly later
 uaa:
   url: #@ "https://uaa.{}".format(data.values.system_domain)
-  internal_url: http://uaa.cf-system.svc.cluster.local:8080
+  internal_url: #@ "http://uaa.{}.svc.cluster.local:8080".format(data.values.namespace)
   resource_id: cloud_controller,cloud_controller_service_permissions
   client_timeout: 60
   ca_file: /config/uaa/certs/uaa.crt
@@ -326,7 +326,7 @@ diego:
   use_privileged_containers_for_staging: false
 
 opi:
-  url: "https://eirini.cf-system.svc.cluster.local:8085"
+  url: #@ "http://eirini.{}.svc.cluster.local:8085".format(data.values.namespace)
   opi_staging: true
   enabled: true
   cc_uploader_url: "https://TODO.TODO"

--- a/config/_ytt_lib/github.com/cloudfoundry/capi-k8s-release/templates/ccng-configmap.yml
+++ b/config/_ytt_lib/github.com/cloudfoundry/capi-k8s-release/templates/ccng-configmap.yml
@@ -6,6 +6,8 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: cloud-controller-ng-yaml
-  namespace: cf-system
+  namespace: #@ data.values.namespace
+  annotations:
+    kapp.k14s.io/versioned: ""
 data:
   cloud_controller_ng.yml: #@ yaml.encode(ccng_config())

--- a/config/_ytt_lib/github.com/cloudfoundry/capi-k8s-release/templates/clock_deployment.yml
+++ b/config/_ytt_lib/github.com/cloudfoundry/capi-k8s-release/templates/clock_deployment.yml
@@ -4,7 +4,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: capi-clock
-  namespace: cf-system
+  namespace: #@ data.values.namespace
 spec:
   replicas: 1
   strategy:
@@ -26,17 +26,19 @@ spec:
           workingDir: "/cloud_controller_ng"
           command: ["/usr/local/bin/bundle"]
           args: ["exec", "rake", "clock:start"]
-          image: #@ data.values.image
+          image: #@ data.values.images.ccng
           imagePullPolicy: Always
           volumeMounts:
           - name: cloud-controller-ng-yaml
             mountPath: /config
-          - name: opi-secrets
-            mountPath: /config/opi/certs
+          #@ if/end data.values.eirini.serverCerts.secretName:
+          - name: eirini-certs
+            mountPath: /config/eirini/certs
       volumes:
       - name: cloud-controller-ng-yaml
         configMap:
           name: cloud-controller-ng-yaml
-      - name: opi-secrets
+      #@ if/end data.values.eirini.serverCerts.secretName:
+      - name: eirini-certs
         secret:
-          secretName: opi-secrets
+          secretName: #@ data.values.eirini.serverCerts.secretName

--- a/config/_ytt_lib/github.com/cloudfoundry/capi-k8s-release/templates/deployment_updater_deployment.yml
+++ b/config/_ytt_lib/github.com/cloudfoundry/capi-k8s-release/templates/deployment_updater_deployment.yml
@@ -4,7 +4,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: capi-deployment-updater
-  namespace: cf-system
+  namespace: #@ data.values.namespace
 spec:
   replicas: 1
   strategy:
@@ -26,7 +26,7 @@ spec:
           workingDir: "/cloud_controller_ng"
           command: ["/usr/local/bin/bundle"]
           args: ["exec", "rake", "deployment_updater:start"]
-          image: #@ data.values.image
+          image: #@ data.values.images.ccng
           imagePullPolicy: Always
           volumeMounts:
           - name: cloud-controller-ng-yaml

--- a/config/_ytt_lib/github.com/cloudfoundry/capi-k8s-release/templates/namespace.yml
+++ b/config/_ytt_lib/github.com/cloudfoundry/capi-k8s-release/templates/namespace.yml
@@ -1,5 +1,0 @@
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: cf-system
-

--- a/config/_ytt_lib/github.com/cloudfoundry/capi-k8s-release/templates/nginx-configmap.yml
+++ b/config/_ytt_lib/github.com/cloudfoundry/capi-k8s-release/templates/nginx-configmap.yml
@@ -1,9 +1,12 @@
+#@ load("@ytt:data", "data")
 ---
 apiVersion: v1
 kind: ConfigMap
 metadata:
   name: nginx
-  namespace: cf-system
+  namespace: #@ data.values.namespace
+  annotations:
+    kapp.k14s.io/versioned: ""
 data:
   nginx.conf: |
     error_log /cloud_controller_ng/nginx-error.log error;

--- a/config/_ytt_lib/github.com/cloudfoundry/capi-k8s-release/templates/opi-secrets.yml
+++ b/config/_ytt_lib/github.com/cloudfoundry/capi-k8s-release/templates/opi-secrets.yml
@@ -6,7 +6,7 @@ kind: Secret
 type: Opaque
 metadata:
   name: opi-secrets
-  namespace: cf-system
+  namespace: #@ data.values.namespace
 data:
   opi.ca: #@ base64.encode(data.values.apiServer.opi.ca)
   opi.crt: #@ base64.encode(data.values.apiServer.opi.client_cert)

--- a/config/_ytt_lib/github.com/cloudfoundry/capi-k8s-release/templates/service.yml
+++ b/config/_ytt_lib/github.com/cloudfoundry/capi-k8s-release/templates/service.yml
@@ -1,8 +1,9 @@
+#@ load("@ytt:data", "data")
 apiVersion: v1
 kind: Service
 metadata:
   name: capi
-  namespace: cf-system
+  namespace: #@ data.values.namespace
 spec:
   type: ClusterIP
   ports:

--- a/config/_ytt_lib/github.com/cloudfoundry/capi-k8s-release/templates/worker_deployment.yml
+++ b/config/_ytt_lib/github.com/cloudfoundry/capi-k8s-release/templates/worker_deployment.yml
@@ -4,7 +4,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: capi-worker
-  namespace: cf-system
+  namespace: #@ data.values.namespace
 spec:
   replicas: 1
   selector:
@@ -22,7 +22,7 @@ spec:
           workingDir: "/cloud_controller_ng"
           command: ["/usr/local/bin/bundle"]
           args: ["exec", "rake", "jobs:generic"]
-          image: #@ data.values.image
+          image: #@ data.values.images.ccng
           imagePullPolicy: Always
           volumeMounts:
           - name: cloud-controller-ng-yaml

--- a/config/_ytt_lib/github.com/cloudfoundry/capi-k8s-release/values.yml
+++ b/config/_ytt_lib/github.com/cloudfoundry/capi-k8s-release/values.yml
@@ -2,7 +2,10 @@
 ---
 replicaCount: 1
 
-image: cloudfoundry/cloud-controller-ng
+images:
+  ccng: cloudfoundry/cloud-controller-ng
+  nginx: nginx:latest
+namespace: cf-system
 
 nginx:
   image:

--- a/vendir.lock.yml
+++ b/vendir.lock.yml
@@ -11,8 +11,8 @@ directories:
       sha: b4375d0b13cb853ee402a9530b54188772c24ff6
     path: github.com/cloudfoundry/cf-k8s-networking
   - git:
-      commitTitle: Fix marshalling json issue...
-      sha: f81af71437191466afe9d46439d3c3a3401898d8
+      commitTitle: delete namespace template...
+      sha: 26aa96fed336505b048030c120266aa4a4871092
     path: github.com/cloudfoundry/capi-k8s-release
   - git:
       commitTitle: Add liveness, readiness, and startup probes to pod...

--- a/vendir.yml
+++ b/vendir.yml
@@ -20,7 +20,7 @@ directories:
   - path: github.com/cloudfoundry/capi-k8s-release
     git:
       url: https://github.com/cloudfoundry/capi-k8s-release
-      ref: f81af71437191466afe9d46439d3c3a3401898d8
+      ref: 26aa96fed336505b048030c120266aa4a4871092
     includePaths:
     - templates/**/*
     - values.yml


### PR DESCRIPTION
### WHAT is this change about?

@tcdowney & friends were having issues with the way capi-k8s-release adds an extra namespace template to the whole cf-for-k8s collection. We removed that template and bumped capi-k8s-release. That brings in a few more changes, like versioned ConfigMaps and templating the namespace in other contexts (service dns names, mostly).

### Please provide any contextual information.

https://github.com/cloudfoundry/cf-for-k8s/pull/12 the PR this should hopefully unblock

### Does this PR introduce a new ytt library?

- [ ] YES - please specify
- [x] NO

### Please provide Acceptance Criteria for this change?

1. It still kapp deploys
2. only 1 system namespace appears in the pre-deploy templates
3. capi deployments roll when ConfigMaps change. 

### What is the level of urgency for publishing this change?

- [x] **Urgent** - unblocks current or future work
- [ ] **Slightly Less than Urgent**

### Tag your pair, your PM, and/or team!

@cwlbraa 

> _It's helpful to tag a few other folks on your team or your team alias in case we need to follow up later._
