### PR TITLE
docs: clarify that the BOSH cli is required for generating values

### DIFF
--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -27,7 +27,7 @@ Make sure that your Kubernetes config (e.g, `~/.kube/config`) is pointing to the
    You have the option of auto-generating the installation values or creating the values by yourself. 
 
    #### Option 1 - Generate the install values
-   The script relies on bosh [interpolate](https://bosh.io/docs/cli-v2-install/#install) to generate the install values
+   **NOTE:** The script relies on [bosh interpolate](https://bosh.io/docs/cli-v2-install/#install) to generate the install values
    ```bash
    # expects bosh cli
    $ ./hack/generate-values.sh cf.example.com > /tmp/cf-values.yml


### PR DESCRIPTION
### WHAT is this change about?

My pair and I were deploying cf-for-k8s this morn and were shocked (🤯) to discover we needed to have the `bosh` (BOSH Outer Shell) CLI  installed for generating values. Can we note this in the requirements? Thanks!

### Please provide any contextual information.

https://github.com/cloudfoundry/cf-for-k8s/blob/73f18c5733b25e291a0a4bd7d4dd4bfeeda43032/hack/generate-values.sh#L66-L70
### Have you read the [contributing guidelines](https://github.com/cloudfoundry/cf-for-k8s/blob/master/.github/contributing.md)?

- [x] YES
- [] NO

### Does this PR introduce a new ytt library?

- [ ] YES - please specify
- [x] NO

### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [x] **Slightly Less than Urgent**

### Pair
@ndhanushkodi 

## Alternative Solutions
You could also add `ytt interpolate`. 👍 