### PR TITLE
fix: put CF vars to unique temp dir

### DIFF
--- a/hack/generate-values.sh
+++ b/hack/generate-values.sh
@@ -8,8 +8,8 @@ set -eu
 # Make sure bosh binary exists
 bosh --version >/dev/null
 
-VARS_FILE=/tmp/cf-vars.yaml
 DOMAIN=$1
+VARS_FILE="/tmp/${DOMAIN}/cf-vars.yaml"
 
 bosh interpolate --vars-store=${VARS_FILE} <(cat <<EOF
 variables:


### PR DESCRIPTION
* `bosh interpolate` reuses vars from varstore file if the file exists
so if you reuse this scipt for a new environment the certificate
generation won't happen and they will contain old domains

## Please take a moment to review the questions before submitting the PR

🚫 We only accept PRs to `master` branch. If this is an exception, please specify why 🚫

### WHAT is this change about?

Put CF vars to unique temp dir

### Please provide any contextual information.

`bosh interpolate` reuses vars from varstore file if the file exists
    so if you reuse this scipt for a new environment the certificate
    generation won't happen and they will contain old domains

### Have you read the [contributing guidelines](https://github.com/cloudfoundry/cf-for-k8s/blob/master/.github/contributing.md)?

- [x] YES
- [ ] NO

### Does this PR introduce a new ytt library?

- [ ] YES - please specify
- [x] NO

### Please provide Acceptance Criteria for this change?

> _Please specify either kubectl or cf cli commands for our team (and cf operators) to verify the changes._

Redeploy using hack scripts and check that system components can communicate with UAA. Or check the certificates that SAN field contains the right domain.

### What is the level of urgency for publishing this change?

- [x] **Urgent** - unblocks current or future work
- [ ] **Slightly Less than Urgent**

### Tag your pair, your PM, and/or team!

cc @ndhanushkodi 