### PR TITLE
Use internal addresses for uaa and capi

### DIFF
--- a/config/networking.yml
+++ b/config/networking.yml
@@ -14,9 +14,9 @@ cfroutesync:
   image: #@ data.values.images.cfroutesync
 
   ccCA: #@ base64.decode(data.values.system_certificate.ca)
-  ccBaseURL: http://capi.cf-system.svc.cluster.local
+  ccBaseURL: #@ "http://capi." + data.values.system_namespace + ".svc.cluster.local"
   uaaCA: #@ base64.decode(data.values.system_certificate.ca)
-  uaaBaseURL: http://uaa.cf-system.svc.cluster.local:8080
+  uaaBaseURL: #@ "http://uaa." + data.values.system_namespace + ".svc.cluster.local:8080"
   clientName: "cf-k8s-networking"
   clientSecret: #@ data.values.uaa.admin_client_secret
 #@ end

--- a/config/networking.yml
+++ b/config/networking.yml
@@ -14,9 +14,9 @@ cfroutesync:
   image: #@ data.values.images.cfroutesync
 
   ccCA: #@ base64.decode(data.values.system_certificate.ca)
-  ccBaseURL: #@ "https://api.{}".format(data.values.system_domain)
+  ccBaseURL: http://capi.cf-system.svc.cluster.local
   uaaCA: #@ base64.decode(data.values.system_certificate.ca)
-  uaaBaseURL: #@ "https://uaa.{}".format(data.values.system_domain)
+  uaaBaseURL: http://uaa.cf-system.svc.cluster.local:8080
   clientName: "cf-k8s-networking"
   clientSecret: #@ data.values.uaa.admin_client_secret
 #@ end


### PR DESCRIPTION

## Please take a moment to review the questions before submitting the PR

### WHAT is this change about?

We changed the cfroutesync configuration in a way that only internal URLs are used
for uaa and capi instead of using external URLs.


### Please provide any contextual information.

For a detailed discussion see https://cloudfoundry.slack.com/archives/CFX13JK7B/p1581953775069500.

This relates also to #29. 

### Have you read the [contributing guidelines](https://github.com/cloudfoundry/cf-for-k8s/blob/master/.github/contributing.md)?

- [X] YES
- [ ] NO

### Does this PR introduce a new ytt library?

- [ ] YES - please specify
- [X] NO

### Please provide Acceptance Criteria for this change?

* Smoke test is still running using a official signed certificate

### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [X] **Slightly Less than Urgent**

### Tag your pair, your PM, and/or team!

@loewenstein @achawki