### PR TITLE
feat: ensure traffic on the mesh is encrypted

### DIFF
--- a/config/_ytt_lib/github.com/cloudfoundry/cf-k8s-networking/config/istio-generated/xxx-generated-istio.yaml
+++ b/config/_ytt_lib/github.com/cloudfoundry/cf-k8s-networking/config/istio-generated/xxx-generated-istio.yaml
@@ -7542,7 +7542,7 @@ metadata:
 spec:
   peers:
   - mtls:
-      mode: PERMISSIVE
+      mode: STRICT
 ---
 apiVersion: policy/v1beta1
 kind: PodDisruptionBudget

--- a/config/logging.yml
+++ b/config/logging.yml
@@ -38,3 +38,16 @@ spec:
   ports:
   #@overlay/match by=overlay.subset({"name": "http"})
   - name: https
+---
+apiVersion: "authentication.istio.io/v1alpha1"
+kind: "Policy"
+metadata:
+  name: "log-cache-allow-plaintext"
+  namespace: #@ data.values.system_namespace
+spec:
+  targets:
+  - name: log-cache
+  peers:
+  - mtls:
+      mode: PERMISSIVE
+

--- a/config/logging.yml
+++ b/config/logging.yml
@@ -38,7 +38,8 @@ spec:
   ports:
   #@overlay/match by=overlay.subset({"name": "http"})
   - name: https
----
+--- #! explanation: the log-cache http proxy terminates its own TLS and the istio-ingressgateway is configured
+    #! with a DestinationRule to establish SIMPLE TLS with it. This is incompatible with Istio STRICT mTLS.
 apiVersion: "authentication.istio.io/v1alpha1"
 kind: "Policy"
 metadata:

--- a/config/postgres.yml
+++ b/config/postgres.yml
@@ -49,3 +49,17 @@ data:
     psql -U postgres -d (@= uaadb.name @) -c "CREATE EXTENSION citext"
 
 --- #@ template.replace(overlay.apply(library.get("postgres").eval(), add_cf_db_namespace()))
+---
+apiVersion: "authentication.istio.io/v1alpha1"
+kind: "Policy"
+metadata:
+  name: "cf-db-allow-plaintext"
+  namespace: "cf-db"
+spec:
+  targets:
+  - name: cf-db-postgresql
+  - name: cf-db-postgresql-headless
+  peers:
+  - mtls:
+      mode: PERMISSIVE
+

--- a/config/postgres.yml
+++ b/config/postgres.yml
@@ -49,7 +49,8 @@ data:
     psql -U postgres -d (@= uaadb.name @) -c "CREATE EXTENSION citext"
 
 --- #@ template.replace(overlay.apply(library.get("postgres").eval(), add_cf_db_namespace()))
----
+--- #! explanation: the capi-db's sidecar needs to accept plain text connections from capi's init container.
+    #! see https://github.com/cloudfoundry/capi-k8s-release/issues/12
 apiVersion: "authentication.istio.io/v1alpha1"
 kind: "Policy"
 metadata:

--- a/vendir.lock.yml
+++ b/vendir.lock.yml
@@ -6,8 +6,8 @@ directories:
       sha: eacb75b4d562e3fb158eb2147a6768407ab374d4
     path: github.com/GoogleCloudPlatform/metacontroller
   - git:
-      commitTitle: update requirements for hack script...
-      sha: eb3bad0ae52316cf992a5da1fcdec15715f5ab07
+      commitTitle: 'feat: introduce mesh-wide strict mtls mode...'
+      sha: fdb136c345fe00e4d526aa959a306e19f8760e84
     path: github.com/cloudfoundry/cf-k8s-networking
   - git:
       commitTitle: enable capi syncing with eirini...

--- a/vendir.yml
+++ b/vendir.yml
@@ -13,7 +13,7 @@ directories:
   - path: github.com/cloudfoundry/cf-k8s-networking
     git:
       url: https://github.com/cloudfoundry/cf-k8s-networking
-      ref: eb3bad0ae52316cf992a5da1fcdec15715f5ab07
+      ref: fdb136c345fe00e4d526aa959a306e19f8760e84
     includePaths:
     - cfroutesync/crds/**/*
     - config/cfroutesync/**/*


### PR DESCRIPTION
### WHAT is this change about?

all unencrypted requests on the mesh will now be rejected

### Please provide any contextual information.

there are two exceptions:
  - capi requires an exception so that its db migrations in an init
  container can still access the db before the sidecar is up
  see: https://github.com/cloudfoundry/capi-k8s-release/issues/12
  - log cache requires an exception because it terminates its own tls in
  a way incompatible with the sidecars

### Have you read the [contributing guidelines](https://github.com/cloudfoundry/cf-for-k8s/blob/master/.github/contributing.md)?

- [x] YES
- [ ] NO

### Does this PR introduce a new ytt library?

- [ ] YES - please specify
- [x] NO

### Please provide Acceptance Criteria for this change?

1. Deploy cf for k8s
2. Enable docker support 
3. Push an app `cf push httpbin -o cfrouting/httpbin8080` 
4. Identify your service `kubectl get service -n cf-workloads -l cloudfoundry.org/app_guid=$(cf app httpbin --guid)` 
  * Looks like s-GUID 
5. SSH into one of your gateways 
  * `kubectl exec -it $(kubectl get pods -n istio-system | grep ingressgateway | head -n1 | awk '{print $1}') -n istio-system /bin/bash` 
6. Go to `/etc/certs` 
7. Send a plain text request to your app 
  * `curl http://<SERVICE NAME>.cf-workloads.svc.cluster.local:8080` 
  * It should fail with something like "Connectino reset by peer" 
  * NOTE: this doesn't work right now because we have to keep things in PERMISSIVE for CAPI to be HAPI 
8. Send an encrypted and authenticated request by specifying the cert, key, and rootca 
  * `curl -k --cacert root-cert.pem --key key.pem --cert cert-chain.pem https://<SERVICE NAME>.cf-workloads.svc.cluster.local:8080` 
  * See that it succeeds!"

### What is the level of urgency for publishing this change?

- [x] **Urgent** - unblocks current or future work
- [ ] **Slightly Less than Urgent**

### Tag your pair, your PM, and/or team!

@tcdowney @rodolfo2488 @rosenhouse @ndhanushkodi @keshav-pivotal 
