### PR TITLE
Enable faster feedback to PR submitters that a check is pending

### DIFF
--- a/ci/pipelines/cf-for-k8s-prs.yml
+++ b/ci/pipelines/cf-for-k8s-prs.yml
@@ -49,24 +49,22 @@ test-runner-config: &common-test-config
 jobs:
 - name: run-tests-on-cf-for-k8s-pr
   public: true
-  serial: true
   plan:
-  - timeout: 4h
-    do:
+  - in_parallel:
+    - get: runtime-ci
+    - get: cf-for-k8s-pr
+      params:
+        integration_tool: rebase
+      trigger: true
+      version: every
+  - put: cf-for-k8s-pr
+    params:
+      path: cf-for-k8s-pr
+      status: pending
+      context: tests
+  - do:
     - put: pool
       params: {acquire: true}
-    - in_parallel:
-      - get: runtime-ci
-      - get: cf-for-k8s-pr
-        params:
-          integration_tool: rebase
-        trigger: true
-        version: every
-    - put: cf-for-k8s-pr
-      params:
-        path: cf-for-k8s-pr
-        status: pending
-        context: tests
     - do:
       - task: delete-cf
         config:


### PR DESCRIPTION
If the PR pipeline takes a while to get to the step that tells GitHub
that a check is pending, it will appear to the PR submitter that there
PR has passed all checks, even if this job hasn't run yet.

This commit addresses reduces or eliminates that delay by changing two
things:
1. Have the job tell GitHub that the check is pending as the first thing
the job does. Previously, this only happened after we acquired a lock on
the environment. In some cases, it can take hours or even days to get
that lock (over a holiday weekend, for example).
2. No longer have the job run in serial. Waiting to acquire the
environment lock is enough to prevent different PRs from interfering with each
other.

Previously, we also had a 4 hour timeout on acquiring the lock. This
meant that if we couldn't get a lock within 4 hours, we wouldn't
run the tests on that PR at all. This commit removes that timeout.


