### PR TITLE
Update 500-fluentd-daemonset.yaml

### DIFF
--- a/config/_ytt_lib/github.com/cloudfoundry/cf-k8s-logging/config/manifests/500-fluentd-daemonset.yaml
+++ b/config/_ytt_lib/github.com/cloudfoundry/cf-k8s-logging/config/manifests/500-fluentd-daemonset.yaml
@@ -1,6 +1,6 @@
 #@ load("@ytt:data", "data")
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1 
 kind: DaemonSet
 metadata:
   name: fluentd


### PR DESCRIPTION
DaemonSet 
extensions/v1beta have been Deprectaed in 1.16, uase apps/v1 instead

## Please take a moment to review the questions before submitting the PR

🚫 We only accept PRs to `master` branch. If this is an exception, please specify why 🚫

### WHAT is this change about?

> _Please describe the change._

### Please provide any contextual information.

> _Include any links to other PRs, stories, slack discussions, etc... that will help establish context._

### Have you read the [contributing guidelines](https://github.com/cloudfoundry/cf-for-k8s/blob/master/.github/contributing.md)?

- [x] YES
- [ ] NO

### Does this PR introduce a new ytt library?

- [ ] YES - please specify
- [x] NO

### Please provide Acceptance Criteria for this change?

> _Please specify either kubectl or cf cli commands for our team (and cf operators) to verify the changes._

> _Few examples_
> 1. For a PR with a new ytt library that contains a Deployment resource definition, `kubectl get deployment <NAME_OF_DEPLOYMENT_RESOURCE>` can verify the new deployment is created. You can provide additional commands to verify the new resources are created/functional

### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [x] **Slightly Less than Urgent**

### Tag your pair, your PM, and/or team!

> _It's helpful to tag a few other folks on your team or your team alias in case we need to follow up later._
