### PR TITLE
bump capi-k8s-release to include log-cache url

### DIFF
--- a/config/_ytt_lib/github.com/cloudfoundry/capi-k8s-release/templates/ccng-config.lib.yml
+++ b/config/_ytt_lib/github.com/cloudfoundry/capi-k8s-release/templates/ccng-config.lib.yml
@@ -114,7 +114,7 @@ db: &db
 
 telemetry_log_path: "/dev/null"
 log_cache:
-  url: "TODO.TODO"
+  url: #@ "log-cache.{}".format(data.values.system_domain)
 threadpool_size: 20
 internal_route_vip_range: ""
 

--- a/vendir.lock.yml
+++ b/vendir.lock.yml
@@ -10,8 +10,8 @@ directories:
       sha: eb3bad0ae52316cf992a5da1fcdec15715f5ab07
     path: github.com/cloudfoundry/cf-k8s-networking
   - git:
-      commitTitle: enable capi syncing with eirini...
-      sha: 1bc5ea5eac9359af22fb2088c21a27f5a4b356aa
+      commitTitle: 'Merge pull request #13 from MasslessParticle/patch-1...'
+      sha: ec3ca8912105598c895f43a2d07a229f83fcab00
     path: github.com/cloudfoundry/capi-k8s-release
   - git:
       commitTitle: clean up interface for PR...

--- a/vendir.yml
+++ b/vendir.yml
@@ -21,7 +21,7 @@ directories:
   - path: github.com/cloudfoundry/capi-k8s-release
     git:
       url: https://github.com/cloudfoundry/capi-k8s-release
-      ref: 1bc5ea5eac9359af22fb2088c21a27f5a4b356aa
+      ref: ec3ca8912105598c895f43a2d07a229f83fcab00
     includePaths:
     - templates/**/*
     - values.yml


### PR DESCRIPTION
Signed-off-by: Melena Suliteanu <msuliteanu@pivotal.io>

## Please take a moment to review the questions before submitting the PR

🚫 We only accept PRs to `master` branch. If this is an exception, please specify why 🚫

### WHAT is this change about?

Adds the log cache url to capi config so logs are discoverable out of the box

### Please provide any contextual information.

https://www.pivotaltracker.com/story/show/171164346

### Have you read the [contributing guidelines](https://github.com/cloudfoundry/cf-for-k8s/blob/master/.github/contributing.md)?

- [x] YES
- [ ] NO

### Does this PR introduce a new ytt library?

- [ ] YES - please specify
- [x] NO

### Please provide Acceptance Criteria for this change?

- deploy cf-for-k8s
- install cf log cache cli
- cf tail -f <app_name> ought to work without extra configuration

### What is the level of urgency for publishing this change?

- [x] **Urgent** - unblocks current or future work
- [ ] **Slightly Less than Urgent**

### Tag your pair, your PM, and/or team!

@farmermel @pianohacker