### PR TITLE
Bump capi-k8s-release

### DIFF
--- a/config/_ytt_lib/github.com/cloudfoundry/capi-k8s-release/templates/cf-autodetect-clusterbuilder.yml
+++ b/config/_ytt_lib/github.com/cloudfoundry/capi-k8s-release/templates/cf-autodetect-clusterbuilder.yml
@@ -1,0 +1,7 @@
+---
+apiVersion: build.pivotal.io/v1alpha1
+kind: ClusterBuilder
+metadata:
+  name: cf-autodetect-builder
+spec:
+  image: cloudfoundry/cnb:bionic

--- a/vendir.lock.yml
+++ b/vendir.lock.yml
@@ -10,8 +10,8 @@ directories:
       sha: fdb136c345fe00e4d526aa959a306e19f8760e84
     path: github.com/cloudfoundry/cf-k8s-networking
   - git:
-      commitTitle: 'Merge pull request #13 from MasslessParticle/patch-1...'
-      sha: ec3ca8912105598c895f43a2d07a229f83fcab00
+      commitTitle: Add auto detect cluster builder...
+      sha: 332c231e9a8eb039b748a57d445e785e2d0c6b59
     path: github.com/cloudfoundry/capi-k8s-release
   - git:
       commitTitle: clean up interface for PR...

--- a/vendir.yml
+++ b/vendir.yml
@@ -21,7 +21,7 @@ directories:
   - path: github.com/cloudfoundry/capi-k8s-release
     git:
       url: https://github.com/cloudfoundry/capi-k8s-release
-      ref: ec3ca8912105598c895f43a2d07a229f83fcab00
+      ref: 332c231e9a8eb039b748a57d445e785e2d0c6b59
     includePaths:
     - templates/**/*
     - values.yml


### PR DESCRIPTION
This bump brings in support for a kpack autodetect ClusterBuilder.

[#171363959] https://www.pivotaltracker.com/story/show/171363959

Co-authored-by: Sannidhi Jalukar <sjalukar@pivotal.io>
Co-authored-by: Chris Tarazi <ctarazi@pivotal.io>

### Have you read the [contributing guidelines](https://github.com/cloudfoundry/cf-for-k8s/blob/master/.github/contributing.md)?

- [X] YES
- [ ] NO

### Does this PR introduce a new ytt library?

- [X] YES - please specify
- [ ] NO

### Please provide Acceptance Criteria for this change?

```
kubectl get clusterbuilder -A
```

You should see something like this:

```
NAME                    AGE
cf-autodetect-builder   77m
```

### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [X] **Slightly Less than Urgent**

### Tag your pair, your PM, and/or team!

@sannidhi && @christarazi 