### PR TITLE
Add note about StorageClass and PersistentVolumeClaim

### DIFF
--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -13,7 +13,9 @@ You need the following CLIs on your system to be able to run the script:
 
 In addition, you will also probably want [`kubectl`](https://kubernetes.io/docs/tasks/tools/install-kubectl/) for your own debugging and inspection of the system.
 
-Make sure that your Kubernetes config (e.g, `~/.kube/config`) is pointing to the cluster you intend to deploy CF for K8s to. This cluster should be on an IaaS that supports load balancer services (e.g., GKE, AKS, etc.).
+Make sure that your Kubernetes config (e.g, `~/.kube/config`) is pointing to the cluster you intend to deploy CF for K8s to. This cluster should be on an IaaS that supports load balancer services (e.g., GKE, AKS, etc.),
+and persistent volumes (make sure you have a `StorageClass` defined in your cluster in order to create
+`PersistentVolumeClaim` objects).
 
 ## Steps to deploy
 

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -33,7 +33,7 @@ Make sure that your Kubernetes config (e.g, `~/.kube/config`) is pointing to the
    # expects bosh cli
    $ ./hack/generate-values.sh cf.example.com > /tmp/cf-values.yml
    ```
-   #### Option 2 Create the install values
+   #### Option 2 - Create the install values
    1. Create a file called `/tmp/cf-values.yml`. You can use `sample-cf-install-values.yml` in this directory as a starting point.
    1. Open the file and change the `system_domain` and `app_domain` to your desired domain address
    1. Generate certificates for the above domains and paste them in `crt`, `key`, `ca` values


### PR DESCRIPTION
### WHAT is this change about?

This is a small addon to the documentation, about the need of having a `StorageClass`
in the cluster, in order to support creation of `PersistentVolumeClaim` objects.

### Please provide any contextual information.

I had issues when deploying cf4k8s to a Kubernetes cluster on vSphere, since no
`StorageClass` is defined by default.

### Have you read the [contributing guidelines](https://github.com/cloudfoundry/cf-for-k8s/blob/master/.github/contributing.md)?

- [x] YES
- [ ] NO

### Does this PR introduce a new ytt library?

- [ ] YES - please specify
- [x] NO

### Please provide Acceptance Criteria for this change?

Only documentation.

### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [x] **Slightly Less than Urgent**
