### PR TITLE
use new functionality in ytt to require min ytt version

### DIFF
--- a/config/0-min-version.star
+++ b/config/0-min-version.star
@@ -1,0 +1,6 @@
+# filename starts with '0-' to make sure this file gets
+# processed first, consequently forcing version check run first
+
+load("@ytt:version", "version")
+
+version.require_at_least("0.26.0")

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -5,7 +5,7 @@
 You need the following CLIs on your system to be able to run the script:
 
 * [`kapp`](https://k14s.io/#install)
-* [`ytt`](https://k14s.io/#install)
+* [`ytt`](https://k14s.io/#install) (v0.26.0+)
 * Kubernetes cluster requirements
   * Version 1.14 or higher
   * A minimum of 5 nodes


### PR DESCRIPTION
this allows us (rel-int) to use new ytt features without worrying too much about what version of ytt users have. note that until users upgrade to ytt 0.26.0 they will not have access to `version.require_at_least`.

after accepting this pr, if someone runs with a recently old version of ytt (eg 0.25.0) they will receive this message:

```
ytt: Error: Evaluating starlark template:
- cannot load @ytt:version: Expected to find library 'ytt', but did not find ''
    in <toplevel>
      4 | load("@ytt:version", "version")
```

eventually when they are on the ytt v0.26.0+, they would receive errors like this when min version is not satisfied (which is much clearer).

```
ytt: Error: Evaluating starlark template:
- version.require_at_least: ytt version '0.100.0' does not meet the minimum required version '0.101.0'
    in <toplevel>
      6 | version.require_at_least("0.101.0")
```