### PR TITLE
Add option to skip ssl validation to smoke test

### DIFF
--- a/ci/pipelines/cf-for-k8s.yml
+++ b/ci/pipelines/cf-for-k8s.yml
@@ -242,6 +242,7 @@ jobs:
           export SMOKE_TEST_APPS_DOMAIN="${DNS_DOMAIN}"
           export SMOKE_TEST_USERNAME=admin
           export SMOKE_TEST_PASSWORD=$(cat env-metadata/cf-admin-password.txt)
+          export SMOKE_TEST_SKIP_SSL=true
           cf-for-k8s-develop/hack/run-smoke-tests.sh
 
   - task: delete-cf
@@ -361,6 +362,7 @@ jobs:
           export SMOKE_TEST_APPS_DOMAIN="${DNS_DOMAIN}"
           export SMOKE_TEST_USERNAME=admin
           export SMOKE_TEST_PASSWORD=$(cat env-metadata/cf-admin-password.txt)
+          export SMOKE_TEST_SKIP_SSL=true
           cf-for-k8s-master/hack/run-smoke-tests.sh
 
   - task: delete-cf
@@ -513,6 +515,7 @@ jobs:
               export SMOKE_TEST_APPS_DOMAIN="${DNS_DOMAIN}"
               export SMOKE_TEST_USERNAME=admin
               export SMOKE_TEST_PASSWORD=$(cat env-metadata/cf-admin-password.txt)
+              export SMOKE_TEST_SKIP_SSL=true
               cf-for-k8s-pr-all-branches/hack/run-smoke-tests.sh
 
       - task: delete-cf

--- a/docs/deploy-in-ci.md
+++ b/docs/deploy-in-ci.md
@@ -33,6 +33,7 @@ The following scripts are designed to be executable in a CI system, as well as l
    $ export SMOKE_TEST_APPS_DOMAIN=<domain>
    $ export SMOKE_TEST_USERNAME=<cf-admin-user>
    $ export SMOKE_TEST_PASSWORD=<cf-admin-password>
+   $ export SMOKE_TEST_SKIP_SSL=true
    $ ./hack/run-smoke-tests.sh
    ```
     

--- a/docs/development.md
+++ b/docs/development.md
@@ -19,7 +19,7 @@ To run:
 
 ```
 cd tests/smoke
-SMOKE_TEST_API_ENDPOINT=https://api.system.cf.example.com SMOKE_TEST_USERNAME=admin SMOKE_TEST_PASSWORD=cfadminpassword SMOKE_TEST_APPS_DOMAIN=apps.cf.example.com ginkgo ./...
+SMOKE_TEST_API_ENDPOINT=https://api.system.cf.example.com SMOKE_TEST_USERNAME=admin SMOKE_TEST_PASSWORD=cfadminpassword SMOKE_TEST_APPS_DOMAIN=apps.cf.example.com SMOKE_TEST_SKIP_SSL=true ginkgo ./...
 ```
 
 ## Directory structure

--- a/tests/smoke/smoke_test.go
+++ b/tests/smoke/smoke_test.go
@@ -39,8 +39,14 @@ var _ = Describe("Smoke Tests", func() {
 			password := GetRequiredEnvVar("SMOKE_TEST_PASSWORD")
 			appsDomain = GetRequiredEnvVar("SMOKE_TEST_APPS_DOMAIN")
 
+			apiArguments := []string{"api", apiEndpoint}
+			_, ok := os.LookupEnv("SMOKE_TEST_SKIP_SSL")
+			if ok {
+				apiArguments = append(apiArguments, "--skip-ssl-validation")
+			}
+
 			// Target CF and auth
-			cfAPI := cf.Cf("api", "--skip-ssl-validation", apiEndpoint)
+			cfAPI := cf.Cf(apiArguments...)
 			Eventually(cfAPI).Should(Exit(0))
 
 			// Authenticate


### PR DESCRIPTION
### WHAT is this change about?

Add option to skip ssl validation to smoke test.
- by default ssl validation is enabled

### Have you read the [contributing guidelines](https://github.com/cloudfoundry/cf-for-k8s/blob/develop/docs/contributing.md)?

- [x] YES
- [ ] NO

### Does this PR introduce a new ytt library?

- [ ] YES - please specify
- [x] NO

### Please provide Acceptance Criteria for this change?

go test tests/smoke/...

### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [x] **Slightly Less than Urgent**
