### PR TITLE
specify min required version for vendir

### DIFF
--- a/vendir.yml
+++ b/vendir.yml
@@ -1,6 +1,7 @@
 ---
 apiVersion: vendir.k14s.io/v1alpha1
 kind: Config
+minimumRequiredVersion: 0.8.0
 directories:
 - path: config/_ytt_lib
   contents:


### PR DESCRIPTION
as of vendir 0.8.0 we can specify minimum required version, to be used later when we want to bump for particular features.