### PR TITLE
Add ability to cf push buildpack apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,14 +8,6 @@
 - CI: https://release-integration.ci.cf-app.com/teams/main/pipelines/cf-for-k8s
 - Tracker: https://www.pivotaltracker.com/n/projects/1382120
 
-## Table of Contents
-
-* <a href='#purpose'>Purpose</a>
-* <a href='#deploy'>Deploying CF for K8s</a>
-* <a href='#for-contributors'>For Contributors</a>
-* <a href='#knownissues'>Known Issues</a>
-* <a href='#future'>What's next</a>
-
 ### <a name='purpose'></a> Purpose
 
 Cloud Foundry for Kubernetes (CF4K8s) is a deployment artifact for deploying the Cloud Foundry Application Runtime on Kubernetes. 

--- a/config/_ytt_lib/github.com/cloudfoundry/capi-k8s-release/templates/api_server_deployment.yml
+++ b/config/_ytt_lib/github.com/cloudfoundry/capi-k8s-release/templates/api_server_deployment.yml
@@ -4,7 +4,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: capi-api-server
-  namespace: #@ data.values.namespace
+  namespace: #@ data.values.system_namespace
 spec:
   replicas: 2
   strategy:
@@ -44,6 +44,16 @@ spec:
           #@ if/end data.values.eirini.serverCerts.secretName:
           - name: eirini-certs
             mountPath: /config/eirini/certs
+        - name: capi-local-worker
+          image: #@ data.values.images.ccng
+          imagePullPolicy: Always
+          command: ["/usr/local/bin/bundle"]
+          args: ["exec", "rake", "jobs:local"]
+          volumeMounts:
+          - name: cloud-controller-ng-yaml
+            mountPath: /config/
+          - name: nginx-uploads
+            mountPath: /tmp/uploads
         - name: nginx
           image: #@ data.values.images.nginx
           imagePullPolicy: Always
@@ -57,6 +67,9 @@ spec:
             mountPath: /data/cloud_controller_ng
           - name: nginx-logs
             mountPath: /cloud_controller_ng
+          - name: nginx-uploads
+            mountPath: /tmp/uploads
+      serviceAccountName: cc-api-service-account
       volumes:
       - name: server-sock
         emptyDir: {}
@@ -76,4 +89,6 @@ spec:
       - name: eirini-certs
         secret:
           secretName: #@ data.values.eirini.serverCerts.secretName
+      - name: nginx-uploads
+        emptyDir: {}
 

--- a/config/_ytt_lib/github.com/cloudfoundry/capi-k8s-release/templates/capi-kpack-watcher-deployment.yml
+++ b/config/_ytt_lib/github.com/cloudfoundry/capi-k8s-release/templates/capi-kpack-watcher-deployment.yml
@@ -1,0 +1,83 @@
+#@ load("@ytt:data", "data")
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: capi-kpack-watcher
+  namespace: #@ data.values.system_namespace
+  labels:
+    app.kubernetes.io/name: capi-kpack-watcher
+    app.kubernetes.io/instance: capi-kpack-watcher-0
+spec:
+  replicas: 1
+  strategy:
+    rollingUpdate:
+      maxSurge: 0
+      maxUnavailable: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: capi-kpack-watcher
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: capi-kpack-watcher
+    spec:
+      serviceAccountName: default
+      containers:
+        - name: capi-kpack-watcher
+          image: #@ data.values.images.capi_kpack_watcher
+          env:
+          - name: UAA_CLIENT_SECRET
+            value: #@ data.values.uaa.clients.capi_kpack_watcher.secret
+          - name: UAA_ENDPOINT
+            value: #@ "http://uaa.{}.svc.cluster.local:8080".format(data.values.system_namespace)
+          - name: UAA_CLIENT_NAME
+            value: capi_kpack_watcher
+          - name: CAPI_HOST
+            value: #@ "http://capi.{}.svc.cluster.local".format(data.values.system_namespace)
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kpack-watcher
+rules:
+- apiGroups: ["build.pivotal.io"]
+  resources: ["images", "builds", "builds/status", "images/status"]
+  verbs: ["get", "watch", "list"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: kpack-watcher-binding
+subjects:
+- kind: ServiceAccount
+  namespace: #@ data.values.system_namespace
+  name: default
+roleRef:
+  kind: ClusterRole
+  name: kpack-watcher
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: kpack-watcher-pod-logs-reader
+  namespace: #@ data.values.workloads_namespace
+rules:
+- apiGroups: [""]
+  resources: ["pods", "pods/log"]
+  verbs: ["get", "watch", "list"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: kpack-watcher-pod-logs-binding
+  namespace: #@ data.values.workloads_namespace
+subjects:
+- kind: ServiceAccount
+  namespace: #@ data.values.system_namespace
+  name: default
+roleRef:
+  kind: Role
+  name: kpack-watcher-pod-logs-reader
+  apiGroup: rbac.authorization.k8s.io

--- a/config/_ytt_lib/github.com/cloudfoundry/capi-k8s-release/templates/ccng-config.lib.yml
+++ b/config/_ytt_lib/github.com/cloudfoundry/capi-k8s-release/templates/ccng-config.lib.yml
@@ -5,6 +5,11 @@ local_route: 0.0.0.0
 
 external_port: 9022
 tls_port: 9023
+readiness_ports:
+  cloud_controller_worker: 4444
+  cc_deployment_updater: 4445
+  cloud_controller_clock: 4446
+
 internal_service_hostname: cloud_controller_ng
 
 pid_filename: /cloud_controller_ng/cloud_controller_ng.pid
@@ -48,7 +53,7 @@ nginx:
   instance_socket: "/data/cloud_controller_ng/cloud_controller.sock"
 
 index: 0
-name: TODO
+name: ""
 route_services_enabled: true
 volume_services_enabled: false
 
@@ -76,7 +81,7 @@ logging:
   max_retries: 1
 
 logcache:
-  host: #@ "log-cache.{}".format(data.values.system_domain)
+  host: #@ "https://log-cache.{}".format(data.values.system_domain)
   port: 8080
   temporary_ignore_server_unavailable_errors: true
 
@@ -124,7 +129,7 @@ login:
 #! TODO: change the UAA's Kube DNS name when the service is named correctly later
 uaa:
   url: #@ "https://uaa.{}".format(data.values.system_domain)
-  internal_url: #@ "http://uaa.{}.svc.cluster.local:8080".format(data.values.namespace)
+  internal_url: #@ "http://uaa.{}.svc.cluster.local:8080".format(data.values.system_namespace)
   resource_id: cloud_controller,cloud_controller_service_permissions
   client_timeout: 60
   ca_file: /config/uaa/certs/uaa.crt
@@ -159,7 +164,7 @@ quota_definitions: {"default":{"memory_limit":102400,"non_basic_services_allowed
 default_quota_definition: default
 
 resource_pool:
-  resource_directory_key: cc-resources
+  resource_directory_key: #@ data.values.blobstore.resource_directory_key
   blobstore_type: fog
   fog_connection:
     provider: AWS
@@ -167,7 +172,7 @@ resource_pool:
     aws_access_key_id: #@ data.values.blobstore.access_key_id
     aws_secret_access_key: #@ data.values.blobstore.secret_access_key
     aws_signature_version: '2'
-    region: "''"
+    region: #@ data.values.blobstore.region
     path_style: true
   minimum_size: 65536
   maximum_size: 536870912
@@ -180,7 +185,7 @@ resource_pool:
   fog_aws_storage_options: {}
 
 packages:
-  app_package_directory_key: cc-packages
+  app_package_directory_key: #@ data.values.blobstore.package_directory_key
   blobstore_type: fog
   fog_connection:
     provider: AWS
@@ -188,7 +193,7 @@ packages:
     aws_access_key_id: #@ data.values.blobstore.access_key_id
     aws_secret_access_key: #@ data.values.blobstore.secret_access_key
     aws_signature_version: '2'
-    region: "''"
+    region: #@ data.values.blobstore.region
     path_style: true
   max_valid_packages_stored: 5
   max_package_size: 1073741824
@@ -201,7 +206,7 @@ packages:
   fog_aws_storage_options: {}
 
 droplets:
-  droplet_directory_key: cc-droplets
+  droplet_directory_key: #@ data.values.blobstore.droplet_directory_key
   blobstore_type: fog
   fog_connection:
     provider: AWS
@@ -209,7 +214,7 @@ droplets:
     aws_access_key_id: #@ data.values.blobstore.access_key_id
     aws_secret_access_key: #@ data.values.blobstore.secret_access_key
     aws_signature_version: '2'
-    region: "''"
+    region: #@ data.values.blobstore.region
     path_style: true
 
   cdn:
@@ -221,7 +226,7 @@ droplets:
   max_staged_droplets_stored: 5
 
 buildpacks:
-  buildpack_directory_key: cc-buildpacks
+  buildpack_directory_key: #@ data.values.blobstore.buildpack_directory_key
   blobstore_type: fog
   fog_connection:
     provider: AWS
@@ -229,7 +234,7 @@ buildpacks:
     aws_access_key_id: #@ data.values.blobstore.access_key_id
     aws_secret_access_key: #@ data.values.blobstore.secret_access_key
     aws_signature_version: '2'
-    region: "''"
+    region: #@ data.values.blobstore.region
     path_style: true
 
   cdn:
@@ -327,7 +332,7 @@ diego:
   use_privileged_containers_for_staging: false
 
 opi:
-  url: #@ "https://eirini.{}.svc.cluster.local:8085".format(data.values.namespace)
+  url: #@ "https://eirini.{}.svc.cluster.local:8085".format(data.values.system_namespace)
   opi_staging: true
   enabled: true
   cc_uploader_url: "https://TODO.TODO"
@@ -342,6 +347,17 @@ max_labels_per_resource: 50
 max_annotations_per_resource: 200
 
 default_app_lifecycle: kpack
+
+#! kpack stager properties
+kubernetes:
+  host_url: #@ data.values.kubernetes.api.url
+  service_account:
+    token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+  ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+  kpack:
+    builder_namespace: #@ data.values.system_namespace
+    registry_service_account_name: cc-kpack-registry-service-account
+    registry_tag_base: #@ "{}/{}".format(data.values.kpack.registry.hostname, data.values.kpack.registry.repository)
 
 #! worker property
 perform_blob_cleanup: true

--- a/config/_ytt_lib/github.com/cloudfoundry/capi-k8s-release/templates/ccng-configmap.yml
+++ b/config/_ytt_lib/github.com/cloudfoundry/capi-k8s-release/templates/ccng-configmap.yml
@@ -6,7 +6,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: cloud-controller-ng-yaml
-  namespace: #@ data.values.namespace
+  namespace: #@ data.values.system_namespace
   annotations:
     kapp.k14s.io/versioned: ""
 data:

--- a/config/_ytt_lib/github.com/cloudfoundry/capi-k8s-release/templates/clock_deployment.yml
+++ b/config/_ytt_lib/github.com/cloudfoundry/capi-k8s-release/templates/clock_deployment.yml
@@ -4,7 +4,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: capi-clock
-  namespace: #@ data.values.namespace
+  namespace: #@ data.values.system_namespace
 spec:
   replicas: 1
   strategy:
@@ -28,6 +28,10 @@ spec:
           args: ["exec", "rake", "clock:start"]
           image: #@ data.values.images.ccng
           imagePullPolicy: Always
+          readinessProbe:
+            tcpSocket:
+              port: 4446
+            periodSeconds: 3
           volumeMounts:
           - name: cloud-controller-ng-yaml
             mountPath: /config

--- a/config/_ytt_lib/github.com/cloudfoundry/capi-k8s-release/templates/deployment_updater_deployment.yml
+++ b/config/_ytt_lib/github.com/cloudfoundry/capi-k8s-release/templates/deployment_updater_deployment.yml
@@ -4,7 +4,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: capi-deployment-updater
-  namespace: #@ data.values.namespace
+  namespace: #@ data.values.system_namespace
 spec:
   replicas: 1
   strategy:
@@ -28,10 +28,21 @@ spec:
           args: ["exec", "rake", "deployment_updater:start"]
           image: #@ data.values.images.ccng
           imagePullPolicy: Always
+          readinessProbe:
+            tcpSocket:
+              port: 4445
+            periodSeconds: 3
           volumeMounts:
           - name: cloud-controller-ng-yaml
             mountPath: /config
+          #@ if/end data.values.eirini.serverCerts.secretName:
+          - name: eirini-certs
+            mountPath: /config/eirini/certs
       volumes:
       - name: cloud-controller-ng-yaml
         configMap:
           name: cloud-controller-ng-yaml
+      #@ if/end data.values.eirini.serverCerts.secretName:
+      - name: eirini-certs
+        secret:
+          secretName: #@ data.values.eirini.serverCerts.secretName

--- a/config/_ytt_lib/github.com/cloudfoundry/capi-k8s-release/templates/nginx-configmap.yml
+++ b/config/_ytt_lib/github.com/cloudfoundry/capi-k8s-release/templates/nginx-configmap.yml
@@ -4,7 +4,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: nginx
-  namespace: #@ data.values.namespace
+  namespace: #@ data.values.system_namespace
   annotations:
     kapp.k14s.io/versioned: ""
 data:

--- a/config/_ytt_lib/github.com/cloudfoundry/capi-k8s-release/templates/opi-secrets.yml
+++ b/config/_ytt_lib/github.com/cloudfoundry/capi-k8s-release/templates/opi-secrets.yml
@@ -6,7 +6,7 @@ kind: Secret
 type: Opaque
 metadata:
   name: opi-secrets
-  namespace: #@ data.values.namespace
+  namespace: #@ data.values.system_namespace
 data:
   opi.ca: #@ base64.encode(data.values.apiServer.opi.ca)
   opi.crt: #@ base64.encode(data.values.apiServer.opi.client_cert)

--- a/config/_ytt_lib/github.com/cloudfoundry/capi-k8s-release/templates/service-accounts.yml
+++ b/config/_ytt_lib/github.com/cloudfoundry/capi-k8s-release/templates/service-accounts.yml
@@ -1,0 +1,43 @@
+#@ load("@ytt:data", "data")
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: cc-api-service-account
+  namespace: #@ data.values.system_namespace
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: cc-api-service-account-superuser
+subjects:
+- kind: ServiceAccount
+  name: cc-api-service-account
+  namespace: #@ data.values.system_namespace
+roleRef:
+  kind: ClusterRole
+  name: cluster-admin
+  apiGroup: rbac.authorization.k8s.io
+
+#! kpack registry credentials
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: cc-kpack-registry-auth-secret
+  namespace: #@ data.values.system_namespace
+  annotations:
+    build.pivotal.io/docker: #@ data.values.kpack.registry.hostname
+type: kubernetes.io/basic-auth
+stringData:
+  username: #@ data.values.kpack.registry.username
+  password: #@ data.values.kpack.registry.password
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: cc-kpack-registry-service-account
+  namespace: #@ data.values.system_namespace
+secrets:
+  - name: cc-kpack-registry-auth-secret
+

--- a/config/_ytt_lib/github.com/cloudfoundry/capi-k8s-release/templates/service.yml
+++ b/config/_ytt_lib/github.com/cloudfoundry/capi-k8s-release/templates/service.yml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: capi
-  namespace: #@ data.values.namespace
+  namespace: #@ data.values.system_namespace
 spec:
   type: ClusterIP
   ports:

--- a/config/_ytt_lib/github.com/cloudfoundry/capi-k8s-release/templates/worker_deployment.yml
+++ b/config/_ytt_lib/github.com/cloudfoundry/capi-k8s-release/templates/worker_deployment.yml
@@ -4,7 +4,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: capi-worker
-  namespace: #@ data.values.namespace
+  namespace: #@ data.values.system_namespace
 spec:
   replicas: 1
   selector:
@@ -24,6 +24,10 @@ spec:
           args: ["exec", "rake", "jobs:generic"]
           image: #@ data.values.images.ccng
           imagePullPolicy: Always
+          readinessProbe:
+            tcpSocket:
+              port: 4444
+            periodSeconds: 3
           volumeMounts:
           - name: cloud-controller-ng-yaml
             mountPath: /config

--- a/config/_ytt_lib/github.com/cloudfoundry/capi-k8s-release/values.yml
+++ b/config/_ytt_lib/github.com/cloudfoundry/capi-k8s-release/values.yml
@@ -3,10 +3,11 @@
 replicaCount: 1
 
 images:
-  ccng: cloudfoundry/cloud-controller-ng
+  ccng: cloudfoundry/cloud-controller-ng:0e40bf23675df21be5b9f29492c46bea7fe156ac@sha256:e466dbda51fbb1ad7613194204c47d2dcfc860f93a578eb9db1b5967009dd9c7
   nginx: cloudfoundry/capi:nginx
-namespace: cf-system
-
+  capi_kpack_watcher: cloudfoundry/capi-kpack-watcher:latest
+system_namespace: cf-system
+workloads_namespace: cf-workloads
 imagePullSecrets:
 
 app_domains: []
@@ -21,6 +22,11 @@ ccdb:
   database: cloud_controller
 
 blobstore:
+  region: "''"
+  package_directory_key: cc-packages
+  droplet_directory_key: cc-droplets
+  resource_directory_key: cc-resources
+  buildpack_directory_key: cc-buildpacks
   endpoint: http://capi-blobstore-minio.default:9000
   access_key_id: AKIAIOSFODNN7EXAMPLE
   secret_access_key: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
@@ -30,6 +36,8 @@ uaa:
     secretName:
   clients:
     cloud_controller_username_lookup:
+      secret: supers3cret
+    capi_kpack_watcher:
       secret: supers3cret
 
 eirini:
@@ -103,3 +111,13 @@ apiServer:
 
 kbld:
   destination:
+
+kubernetes:
+  api:
+    url: ""
+kpack:
+  registry:
+    hostname: ""
+    repository: ""
+    username: ""
+    password: ""

--- a/config/capi.yml
+++ b/config/capi.yml
@@ -22,8 +22,8 @@ images:
 #@ if/end data.values.images.nginx:
   nginx: #@ data.values.images.nginx
 
-namespace: #@ data.values.system_namespace
-
+system_namespace: #@ data.values.system_namespace
+workloads_namespace: #@ data.values.workloads_namespace
 system_domain: #@ data.values.system_domain
 app_domains:
 #@ for/end domain in data.values.app_domains:
@@ -32,8 +32,13 @@ app_domains:
 
 blobstore:
   endpoint: #@ data.values.capi.blobstore.endpoint
+  region: #@ data.values.capi.blobstore.region
   access_key_id: #@ data.values.cf_blobstore.access_key
   secret_access_key: #@ data.values.cf_blobstore.secret_key
+  package_directory_key: #@ data.values.capi.blobstore.package_directory_key
+  droplet_directory_key: #@ data.values.capi.blobstore.droplet_directory_key
+  resource_directory_key: #@ data.values.capi.blobstore.resource_directory_key
+  buildpack_directory_key: #@ data.values.capi.blobstore.buildpack_directory_key
 
 ccdb:
   adapter: #@ data.values.capi.database.adapter
@@ -59,6 +64,18 @@ uaa:
   clients:
     cloud_controller_username_lookup:
       secret: #@ data.values.uaa.admin_client_secret
+    capi_kpack_watcher:
+      secret: #@ data.values.uaa.admin_client_secret
+
+kubernetes:
+  api:
+    url: #@ data.values.kubernetes.api.url
+kpack:
+  registry:
+    hostname: #@ data.values.kpack.registry.hostname
+    repository: #@ data.values.kpack.registry.repository
+    username: #@ data.values.kpack.registry.username
+    password: #@ data.values.kpack.registry.password
 #@ end
 
 #@ capi = library.get("github.com/cloudfoundry/capi-k8s-release")

--- a/config/capi.yml
+++ b/config/capi.yml
@@ -99,3 +99,9 @@ spec:
         host: #@ "capi." + data.values.system_namespace + ".svc.cluster.local"
         port:
           number: 80
+
+#! pin cnb image to last known good: 0.0.55-bionic
+#@overlay/match by=overlay.subset({"kind": "ClusterBuilder", "metadata": {"name": "cf-autodetect-builder"}})
+---
+spec:
+  image: cloudfoundry/cnb:0.0.55-bionic

--- a/config/kpack.yml
+++ b/config/kpack.yml
@@ -3,3 +3,16 @@
 
 #@ kpack = library.get("github.com/pivotal/kpack")
 --- #@ template.replace(kpack.eval())
+--- #! explanation: the blobstore's sidecar needs to accept plain text connections from kpack build init containers.
+    #! see https://github.com/cloudfoundry/capi-k8s-release/issues/12
+apiVersion: "authentication.istio.io/v1alpha1"
+kind: "Policy"
+metadata:
+  name: "cf-blobstore-allow-plaintext"
+  namespace: "cf-blobstore"
+spec:
+  targets:
+  - name: cf-blobstore-minio
+  peers:
+  - mtls:
+      mode: PERMISSIVE

--- a/config/uaa.yml
+++ b/config/uaa.yml
@@ -121,6 +121,10 @@ oauth:
       authorities: scim.userids
       authorized-grant-types: client_credentials
       secret: #@ data.values.uaa.admin_client_secret
+    capi_kpack_watcher:
+      authorities: cloud_controller.write,cloud_controller.update_build_state
+      authorized-grant-types: client_credentials
+      secret: #@ data.values.uaa.admin_client_secret
 
 issuer:
   uri: #@ "https://uaa." + data.values.system_domain

--- a/config/values.yml
+++ b/config/values.yml
@@ -22,10 +22,8 @@ cf_db:
   enabled: true
 
 images:
-#! NOTE: the CAPI image reference below is needed temporarily to address a build break.
-#! See https://www.pivotaltracker.com/story/show/171522062 and https://www.pivotaltracker.com/story/show/171549565 for details
-  capi: "cloudfoundry/cloud-controller-ng@sha256:f6c25891fcd272543773dbcfd1c5387703b01e53146b8ef173be012e8055089e"
-  nginx: "cloudfoundry/capi@sha256:51e4e48c457d5cb922cf0f569e145054e557e214afa78fb2b312a39bb2f938b6"
+  capi: ""
+  nginx: ""
   cfroutesync: "gcr.io/cf-networking-images/cf-k8s-networking/cfroutesync@sha256:758abd1b6144596cef74ad4805bc7e1a6055142cab5719f0d42d0321a14a190d"
   log_cache: "logcache/log-cache@sha256:0bc1ee1934ecd2145a3372dc838747c7977d50ca58bd5c28db7f70b28b1021b4"
   syslog_server: "logcache/syslog-server@sha256:f1f6def4af1261e4cafe4745d5bab8258a2e1ff9fd835c5021e00957ea42d7d4"
@@ -43,6 +41,11 @@ system_certificate:
 
 capi:
   blobstore:
+    package_directory_key: cc-packages
+    droplet_directory_key: cc-droplets
+    resource_directory_key: cc-resources
+    buildpack_directory_key: cc-buildpacks
+    region: "''"
     endpoint: "http://cf-blobstore-minio.cf-blobstore.svc.cluster.local:9000"
   database:
     #! or mysql2, as needed
@@ -138,3 +141,13 @@ log_cache_client:
 
 docker_registry:
   http_secret: "" #! A random piece of data used to sign state that may be stored with the client to protect against tampering. For production environments you should generate a random piece of data using a cryptographically secure random generator.
+
+kubernetes:
+  api:
+    url: ""
+kpack:
+  registry:
+    hostname: ""
+    repository: ""
+    username: ""
+    password: ""

--- a/docs/deploy-in-ci.md
+++ b/docs/deploy-in-ci.md
@@ -1,8 +1,8 @@
 # Deploy CF for K8s in CI
 
-## Prerequesites
+## Prerequisites
 
-You will need the same set of prerequesites listed in the [Deploy CF for K8s](deploy.md#prerequesites) documentation. The CLIs will need to be available in the image used by your CI system.
+You will need the same set of prerequisites listed in the [Deploy CF for K8s](deploy.md#prerequisites) documentation. The CLIs will need to be available in the image used by your CI system.
 
 ## Available Scripts
 
@@ -11,7 +11,7 @@ The following scripts are designed to be executable in a CI system, as well as l
 - Generate all required configuration settings for a given domain:
 
   ```bash
-  $ ./hack/generate-values.sh <domain> > <path-to-cf-install-values-yaml>
+  $ ./hack/generate-values.sh <cf-domain> <path-to-kpack-gcr-service-account-json> > <path-to-cf-install-values-yaml>
   ```
 
 - Install CF for K8s to your target K8s cluster.
@@ -23,7 +23,7 @@ The following scripts are designed to be executable in a CI system, as well as l
 - Update the wildcard entry for the given domain with the correct load-balancer IP address (if you are using Google Cloud DNS).
 
    ```bash
-  $ ./hack/update-gcp-dns.sh <domain> <dns-zone-name>
+  $ ./hack/update-gcp-dns.sh <cf-domain> <dns-zone-name>
    ```
 
 - Run the smoke test suite against your CF for K8s installation.
@@ -36,7 +36,7 @@ The following scripts are designed to be executable in a CI system, as well as l
    $ export SMOKE_TEST_SKIP_SSL=true
    $ ./hack/run-smoke-tests.sh
    ```
-    
+
 ## Available Docker Images
 
 There are two Docker images maintained by us that can be used for a CI pipeline:

--- a/docs/deploy-local.md
+++ b/docs/deploy-local.md
@@ -2,12 +2,13 @@
 
 ## Prerequisites
 
-See the requirements in [Deploying CF for K8s](deploy.md).
+### Required Tools
 
-## IaaS Requirements
+See the requirements in [Deploying CF for K8s](deploy.md#required-tools).
 
-In addition to the requirements in [Deploying CF for K8s](deploy.md), the
-cluster should:
+### Machine Requirements
+
+In addition to the Kubernetes version requirement in [Deploying CF for K8s](deploy.md#kubernetes-cluster-requirements), the cluster should:
 
 * have a minimum of 1 node
 * have a minimum of 4 CPU, 8GB memory per node

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -2,6 +2,8 @@
 
 ## Prerequisites
 
+### Required Tools
+
 You need the following CLIs on your system to be able to run the script:
 
 * [`kapp`](https://k14s.io/#install)
@@ -11,44 +13,75 @@ In addition, you will also probably want [`kubectl`](https://kubernetes.io/docs/
 
 Make sure that your Kubernetes config (e.g, `~/.kube/config`) is pointing to the cluster you intend to deploy CF for K8s to.
 
-## IaaS Requirements
+### Kubernetes Cluster Requirements
 
 To deploy cf-for-k8s as is, the cluster should:
 * be running version 1.14.x or 1.15.x
 * have a minimum of 5 nodes
 * have a minimum of 2 CPU, 7.5GB memory per node
+
+### IaaS Requirements
+
 * support LoadBalancer services
   * requires a workaround on Minikube and Kind, for example
 * define a default StorageClass
   * requires [additional config on vSphere](https://vmware.github.io/vsphere-storage-for-kubernetes/documentation/storageclass.html), for example
 
+### (optional) Requirements for Cloud Native Buildpacks Support
+
+To be able to push source-based apps to your CF for K8s installation, you will need to enable support for Cloud Native Buildpacks.
+
+_Note: Currently, when enabling support for buildpack-based applications, CF for K8s has only been validated to work with Google Container Registry (GCR).  Soon, we intend to support any OCI registry that kpack supports._
+
+To deploy cf-for-k8s with the Cloud Native Buildpacks feature, you additionally need to:
+  1. create a GCP Service Account with `Storage/Storage Admin` role
+      * (optionally) if you want to limit the permissions this service account has, see https://cloud.google.com/container-registry/docs/access-control for the minimum permission set
+  1. create a Service Key JSON and download it to the machine from which you will install cf-for-k8s (referred to, below, as `path-to-kpack-gcr-service-account`)
+
 ## Steps to deploy
 
 1. Clone and initialize this git repository:
-   ```bash
+   ```console
    $ git clone https://github.com/cloudfoundry/cf-for-k8s.git
    $ cd cf-for-k8s
    ```
 
+1. Set your current kubectl context to your desired Kubernetes cluster
+
 1. Create a "CF Installation Values" file and configure it:
 
-   You have the option of auto-generating the installation values or creating the values by yourself.
+   You can either: a) auto-generate the installation values or b) create the values by yourself.
 
-   #### Option 1 - Run generate-values.sh to generate the install values
-   **NOTE:** The script requires the [BOSH CLI](https://bosh.io/docs/cli-v2-install/#install) to generate the install values from `bosh intepolate`
-   ```bash
-   # expects bosh cli
-   $ ./hack/generate-values.sh cf.example.com > /tmp/cf-values.yml
+   #### Option A - Use the included hack-script to generate the install values
+   **NOTE:** The script requires the [BOSH CLI](https://bosh.io/docs/cli-v2-install/#install) to generate the install values from `bosh interpolate`
+   ```console
+   $ ./hack/generate-values.sh <cf-domain> > /tmp/cf-values.yml
    ```
-   #### Option 2 - Create the install values by hand
-   1. Create a file called `/tmp/cf-values.yml`. You can use `sample-cf-install-values.yml` in this directory as a starting point.
+   (replacing `<cf-domain>` with _your_ registered DNS domain name for your CF installation)
+
+
+   If you wish to enable Cloud Native Buildpacks support, pass in the path to the GCP Service Account JSON:
+   ```console
+   $ ./hack/generate-values.sh <cf-domain> <path-to-kpack-gcr-service-account> > /tmp/cf-values.yml
+   ```
+   (replacing `<cf-domain>` with _your_ registered DNS domain name for your CF installation and `<path-to-kpack-gcr-service-account>` with the path to your GCP Service Account JSON file)
+
+   #### Option B - Create the install values by hand
+   1. Create a file called `/tmp/cf-values.yml`. You can use `sample-cf-install-values.yml` in this directory as a starting point
    1. Open the file and change the `system_domain` and `app_domain` to your desired domain address
    1. Generate certificates for the above domains and paste them in `crt`, `key`, `ca` values
+      - your certificates must include a subject alternative name entry for the internal `*.cf-system.svc.cluster.local` domain in addition to your chosen external domain
 
-   Make sure that your certificates include a subject alternative name entry for the internal `*.cf-system.svc.cluster.local` domain in addition to your chosen external domain.
+   If you wish to enable Cloud Native Buildpacks support, configure access to your Google Container Registry:
+   1. Set `kubernetes.api.url` to the URL of your Kubernetes API server (often from `kubectl cluster-info`, the address of the Kuberenetes master)
+   1. Update the "gcp_project_id" portion of `kpack.registry.repository` to your GCP Project Id
+   1. Change `contents_of_service_account_json` to be the entire contents of your GCP Service Account JSON
+
+   If you do NOT wish to enable Cloud Native Buildpacks support:
+   1. Remove the `kubernetes` and `kpack` keys from your `cf-values.yml`
 
 1. Run the install script with your "CF Install Values" file
-   ```bash
+   ```console
    $ ./bin/install-cf.sh /tmp/cf-values.yml
    ```
 
@@ -63,39 +96,144 @@ To deploy cf-for-k8s as is, the cluster should:
       e.g.
       ```
       # sample A record in Google cloud DNS. The IP address below is the address of Ingress gateway's external IP
-      Domain                  Record Type       TTL         IP Address
-      *.<system_domain>	      A	            30	      35.111.111.111
+      Domain         Record Type  TTL  IP Address
+      *.<cf-domain>  A            30   35.111.111.111
       ```
 
-## Validate the deployment
+## Validate the deployment using a image-based app
 
 1. Set up cf cli to point to CF:
-   ```bash
-   $ cf api --skip-ssl-validation https://api.<system_domain>
+   ```console
+   $ cf api --skip-ssl-validation https://api.<cf-domain>
    $ cf auth admin <cf_admin_password>
    ```
 
+1. Create an org/space for your app:
+   ```console
+   $ cf create-org test-org
+   $ cf create-space -o test-org test-space
+   $ cf target -o test-org -s test-space
+   ```
+
 1. Enable docker feature:
-   ```bash
+   ```console
    $ cf enable-feature-flag diego_docker
    ```
 
-1. Deploy an app:
-   ```bash
-   $ cf push diego-docker-app -o cloudfoundry/diego-docker-app
+1. Deploy an app based on a pre-built Docker image:
+   ```console
+   $ cf push test-app -o cloudfoundry/diego-docker-app
+   Pushing app test-app to org test / space test as admin...
+   Getting app info...
+   Creating app with these attributes...
+   + name:           test-app
+   + docker image:   cloudfoundry/diego-docker-app
+     routes:
+   +   test-app.cf.example.com
+
+   Creating app test-app...
+   Mapping routes...
+
+   Staging app and tracing logs...
+   Failed to retrieve logs from Log Cache: Get /api/v1/info: unsupported protocol scheme ""
+
+   Failed to retrieve logs from Log Cache: Get /api/v1/info: unsupported protocol scheme ""
+
+   Failed to retrieve logs from Log Cache: Get /api/v1/info: unsupported protocol scheme ""
+
+   Failed to retrieve logs from Log Cache: Get /api/v1/info: unsupported protocol scheme ""
+
+   Failed to retrieve logs from Log Cache: Get /api/v1/info: unsupported protocol scheme ""
+
+
+   Waiting for app to start...
+
+   name:                test-app
+   requested state:     started
+   isolation segment:   placeholder
+   routes:              test-app.cf.example.com
+   last uploaded:       Tue 17 Mar 15:48:28 PDT 2020
+   stack:
+   docker image:        cloudfoundry/diego-docker-app
+
+   type:           web
+   instances:      1/1
+   memory usage:   1024M
+        state     since                  cpu    memory    disk      details
+   #0   running   2020-03-17T22:48:29Z   0.0%   0 of 1G   0 of 1G
    ```
-   Note that the above command will return an error but the app is successfully pushed to CF and is routable via Http. The reason the command fails is due to a missing logging component, which we, the Release Integration, are working with the Logging team to integrate into CF4K8s
+   Note that the "`Failed to retrieve logs...`" messages are expected, at this time given that we're still working on integrating CF logging components.
 
 1. Validate the app is reachable
-   ```bash
-   $ curl http://diego-docker-app.<system-domain>/env
+   ```console
+   $ curl http://test-app.<cf-domain>/env
    # should return JSON value
+   ```
+
+## (optional) Validate the deployment using a source-based app
+
+If you have enabled support for Cloud Native Buildpacks:
+
+1. Ensure that you have targeted your CF instance, created and targeted an org/space and enabled the `diego_docker` feature flag, as described above.
+
+1. Deploy a source-based app:
+   ```console
+   $ cf push test-node-app -p docs/example-app
+   Pushing app test-node-app to org test-org / space test-space as admin...
+   Getting app info...
+   Creating app with these attributes...
+   + name:       test-node-app
+     path:       /Users/pivotal/workspace/cf-for-k8s/docs/example-app
+     routes:
+   +   test-node-app.cf.example.com
+
+   Creating app test-node-app...
+   Mapping routes...
+   Comparing local files to remote cache...
+   Packaging files to upload...
+   Uploading files...
+    498 B / 498 B [==================================================================================================================================================================================================================================================================================================] 100.00% 1s
+
+   Waiting for API to complete processing files...
+
+   Staging app and tracing logs...
+   Failed to retrieve logs from Log Cache: Get /api/v1/info: unsupported protocol scheme ""
+
+   Failed to retrieve logs from Log Cache: Get /api/v1/info: unsupported protocol scheme ""
+
+   Failed to retrieve logs from Log Cache: Get /api/v1/info: unsupported protocol scheme ""
+
+   Failed to retrieve logs from Log Cache: Get /api/v1/info: unsupported protocol scheme ""
+
+   Failed to retrieve logs from Log Cache: Get /api/v1/info: unsupported protocol scheme ""
+
+
+   Waiting for app to start...
+
+   name:                test-node-app
+   requested state:     started
+   isolation segment:   placeholder
+   routes:              test-node-app.cf.example.com
+   last uploaded:       Tue 17 Mar 19:24:21 PDT 2020
+   stack:
+   buildpacks:
+
+   type:           web
+   instances:      1/1
+   memory usage:   1024M
+        state     since                  cpu    memory    disk      details
+   #0   running   2020-03-18T02:24:51Z   0.0%   0 of 1G   0 of 1G
+   ```
+
+1. Validate that the app is reachable
+   ```console
+   $ curl http://test-node-app.<cf-domain>
+   Hello World
    ```
 
 ## Delete CF4K8s install
 You can delete CF4K8s deployment by running the following command.
-
-```
+```console
 # Assuming that you ran `bin/install.sh...`
 $ kapp delete -a cf
 ```

--- a/docs/example-app/package.json
+++ b/docs/example-app/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "example-app",
+  "version": "0.0.1"
+}

--- a/docs/example-app/server.js
+++ b/docs/example-app/server.js
@@ -1,0 +1,5 @@
+var http = require('http');
+http.createServer(function (request, response) {
+   response.writeHead(200, {'Content-Type': 'text/plain'});
+   response.end('Hello World\n');
+}).listen(process.env.PORT);

--- a/hack/README.md
+++ b/hack/README.md
@@ -1,0 +1,7 @@
+# Hack scripts
+
+These scripts are intended to help with certain tasks around integrating and
+deploying CF for Kubernetes.
+
+They are not officially supported product bits.  Their interface and behavior
+may change at any time without notice.

--- a/hack/confirm-network-policy.sh
+++ b/hack/confirm-network-policy.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+# This is a hack! see https://github.com/cloudfoundry/cf-for-k8s/blob/develop/hack/README.md
+
 cluster=$1
 zone=$2
 

--- a/hack/run-smoke-tests.sh
+++ b/hack/run-smoke-tests.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env sh
 
+# This is a hack! see https://github.com/cloudfoundry/cf-for-k8s/blob/develop/hack/README.md
+
 set -eu
 
 cd "`dirname $0`/../tests/smoke"

--- a/hack/update-gcp-dns.sh
+++ b/hack/update-gcp-dns.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+# This is a hack! see https://github.com/cloudfoundry/cf-for-k8s/blob/develop/hack/README.md
+
 set -eu
 
 if [ $# -lt 2 ]; then

--- a/sample-cf-install-values.yml
+++ b/sample-cf-install-values.yml
@@ -58,3 +58,16 @@ eirini:
 
 docker_registry:
   http_secret: dockerregistryhttpsecret
+
+
+kubernetes:
+  api:
+    url: kubernetes_api_url
+
+kpack:
+  registry:
+    hostname: gcr.io
+    repository: gcp_project_id/cf-workloads
+    username: _json_key
+    password: |
+      contents_of_service_account_json

--- a/vendir.lock.yml
+++ b/vendir.lock.yml
@@ -10,8 +10,8 @@ directories:
       sha: 592babdf2842d4e46797fd6782b1215bd8b7fb6b
     path: github.com/cloudfoundry/cf-k8s-networking
   - git:
-      commitTitle: make rubocop happy
-      sha: e4d57b3f39246fb4c9a733da041d73f7264f9efc
+      commitTitle: README updates and images that work with cf push...
+      sha: 2443b69dcf60ea39b075bc5fd4ef258d6a4ef292
     path: github.com/cloudfoundry/capi-k8s-release
   - git:
       commitTitle: update log-cache-deployment for plain text communication...

--- a/vendir.yml
+++ b/vendir.yml
@@ -22,7 +22,7 @@ directories:
   - path: github.com/cloudfoundry/capi-k8s-release
     git:
       url: https://github.com/cloudfoundry/capi-k8s-release
-      ref: e4d57b3f39246fb4c9a733da041d73f7264f9efc
+      ref: 2443b69dcf60ea39b075bc5fd4ef258d6a4ef292
     includePaths:
     - templates/**/*
     - values.yml


### PR DESCRIPTION
## Please take a moment to review the questions before submitting the PR

🚫 We only accept PRs to `develop` branch. If this is an exception, please specify why 🚫

### WHAT is this change about?

`cf push`! !!! 🎉 

Please merge, test it out, and give us lots of feedback!

#### Known issues:

- uses `cloudfoundry/cnb:bionic` builder image, with the buildpacks included listed [here](https://hub.docker.com/r/cloudfoundry/cnb)
- unknown scaling characteristics
- logs do not appear to stream for staging yet
- service account used for the cloud controller is currently overly-scoped as a cluster admin
- only supports apps with a single `web` process

### Please provide any contextual information.

Important: see https://github.com/cloudfoundry/capi-k8s-release#configuring-pushes-of-buildpack-apps for how to configure your k8s endpoint and registry location/creds

Handy thing: to see the progress of the staging process, check the logs of the `capi-kpack-watcher` pod.

### Have you read the [contributing guidelines](https://github.com/cloudfoundry/cf-for-k8s/blob/develop/docs/contributing.md)?

- [x] YES
- [ ] NO

### Does this PR introduce a new ytt library?

- [ ] YES - please specify
- [x] NO

### Please provide Acceptance Criteria for this change?

`cf push` of buildpack apps works

### What is the level of urgency for publishing this change?

- [x] **Urgent** - unblocks current or future work
- [ ] **Slightly Less than Urgent**

### Tag your pair, your PM, and/or team!

@cloudfoundry/cf-capi 
