### PR TITLE
Update networking release

### DIFF
--- a/config/_ytt_lib/github.com/cloudfoundry/cf-k8s-networking/config/cfroutesync/cfroutesync.yaml
+++ b/config/_ytt_lib/github.com/cloudfoundry/cf-k8s-networking/config/cfroutesync/cfroutesync.yaml
@@ -10,7 +10,7 @@ kind: CompositeController
 metadata:
   name: cfroutesync
 spec:
-  resyncPeriodSeconds: 5
+  resyncPeriodSeconds: 1
   parentResource:
     apiVersion: apps.cloudfoundry.org/v1alpha1
     resource: routebulksyncs

--- a/config/_ytt_lib/github.com/cloudfoundry/cf-k8s-networking/config/istio-generated/xxx-generated-istio.yaml
+++ b/config/_ytt_lib/github.com/cloudfoundry/cf-k8s-networking/config/istio-generated/xxx-generated-istio.yaml
@@ -10244,3 +10244,123 @@ metadata:
   labels:
     app: istio-telemetry
     release: istio
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: pilot-network-policy
+  namespace: istio-system
+spec:
+  podSelector:
+    matchLabels:
+      app: pilot
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          cf-for-k8s.cloudfoundry.org/istio-system-ns: ""
+    ports:
+    - port: 15004
+  - ports:
+    - port: 15010
+    - port: 15011
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: citadel-network-policy
+  namespace: istio-system
+spec:
+  podSelector:
+    matchLabels:
+      app: citadel
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          cf-for-k8s.cloudfoundry.org/istio-system-ns: ""
+    ports:
+    - port: 8060
+    - port: 8080
+    - port: 15014
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: mixer-network-policy
+  namespace: istio-system
+spec:
+  podSelector:
+    matchLabels:
+      app: mixer
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          cf-for-k8s.cloudfoundry.org/istio-system-ns: ""
+    ports:
+    - port: 9091
+    - port: 15004
+    - port: 15090
+    - port: 42422
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: sidecar-injector-network-policy
+  namespace: istio-system
+spec:
+  podSelector:
+    matchLabels:
+      app: sidecarInjectorWebhook
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          cf-for-k8s.cloudfoundry.org/istio-system-ns: ""
+    ports:
+    - port: 9091
+    - port: 15004
+    - port: 15090
+    - port: 42422
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: ingressgateway-network-policy-pilot
+  namespace: istio-system
+spec:
+  podSelector:
+    matchLabels:
+      app: istio-ingressgateway
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          cf-for-k8s.cloudfoundry.org/istio-system-ns: ""
+    ports:
+    - port: 15443
+    - port: 15020
+  - ports:
+    - port: 80
+    - port: 443
+---
+apiVersion: networking.istio.io/v1alpha3
+kind: Sidecar
+metadata:
+  name: default
+  namespace: cf-workloads
+spec:
+  egress:
+  - hosts:
+    - cf-system/*

--- a/vendir.lock.yml
+++ b/vendir.lock.yml
@@ -6,8 +6,8 @@ directories:
       sha: eacb75b4d562e3fb158eb2147a6768407ab374d4
     path: github.com/GoogleCloudPlatform/metacontroller
   - git:
-      commitTitle: 'feat: enable SDS for ingressgateway certs...'
-      sha: 592babdf2842d4e46797fd6782b1215bd8b7fb6b
+      commitTitle: 'Merge pull request #28 from cloudfoundry/DocumentManagingCertificatesForApplicationIngress...'
+      sha: 73b9fed1cbc2793f31e44509b78bb9ba6cd70835
     path: github.com/cloudfoundry/cf-k8s-networking
   - git:
       commitTitle: make rubocop happy

--- a/vendir.yml
+++ b/vendir.yml
@@ -14,7 +14,7 @@ directories:
   - path: github.com/cloudfoundry/cf-k8s-networking
     git:
       url: https://github.com/cloudfoundry/cf-k8s-networking
-      ref: 592babdf2842d4e46797fd6782b1215bd8b7fb6b
+      ref: 73b9fed1cbc2793f31e44509b78bb9ba6cd70835
     includePaths:
     - cfroutesync/crds/**/*
     - config/cfroutesync/**/*


### PR DESCRIPTION
### WHAT is this change about?

This updates cf-k8s-networking to include several minor updates to security and performance.

* [Operators can confirm that sidecars are not configured for app to app communication](https://www.pivotaltracker.com/story/show/171731831)
* [Operator does not have to wait for metacontroller's polling interval to see their route live](https://www.pivotaltracker.com/story/show/171737550)
* [Operator does not have to wait for cfroutesync's polling interval to see their route live ](https://www.pivotaltracker.com/story/show/171758861)
* [Operators can verify that debug endpoints on istio control plane components are inaccessible](https://www.pivotaltracker.com/story/show/171498802)
* [CF apps are accessible via HTTPS using operator-provided wildcard certificates](https://www.pivotaltracker.com/story/show/171238418)

### Please provide any contextual information.

Should be plenty of delicious info in the stories.

### Have you read the [contributing guidelines](https://github.com/cloudfoundry/cf-for-k8s/blob/develop/docs/contributing.md)?

- [X] YES
- [ ] NO

### Does this PR introduce a new ytt library?

- [ ] YES - please specify
- [X] NO

### Please provide Acceptance Criteria for this change?

```gherkin
WHEN I cf push an application
    `cf push bin -o cfrouting/httpbin8080`
THEN I see my application is reachable within 10 seconds 95% of the time
    `watch curl bin.<apps-domain>` and see that it is live shortly
```

and

```gherkin
WHEN ssh into a pod in the cf-workloads namespace
    `cf push bin -o cfrouting/httpbin8080`
    `kubectl exec -it -n cf-workloads bin-s-<some nonsense> -c opi /bin/bash
AND I try to reach a debug endpoint on an istio component
    `curl istio-pilot.istio-system.svc.cluster.local:8080/debug/edsz`
THEN I see a failure in my curl, NOT delicious json configuration
```

and

```gherkin
WHEN ssh into a pod in the cf-workloads namespace
    `cf push bin -o cfrouting/httpbin8080`
    `kubectl exec -it -n cf-workloads bin-s-<some nonsense> -c opi /bin/bash
AND I try to reach another app within the cf-workloads namespace
    get <svc-name> with `kubectl get svc -n cf-workloads | tail -n1 | awk '{print $1}'` in another tab
    `curl <svc-name>.cf-workloads-svc.cluster.local:8080`
THEN I see a failure in my curl
```
    

### What is the level of urgency for publishing this change?

- [X] **Urgent** - unblocks current or future work (our pipeline)
- [ ] **Slightly Less than Urgent**

### Tag your pair, your PM, and/or team!

@rodolfo2488 @rosenhouse @tcdowney @ndhanushkodi
