### PR TITLE
Bump capi-k8s-release with various enhancements

### DIFF
--- a/config/_ytt_lib/github.com/cloudfoundry/capi-k8s-release/templates/api_server_deployment.yml
+++ b/config/_ytt_lib/github.com/cloudfoundry/capi-k8s-release/templates/api_server_deployment.yml
@@ -44,6 +44,12 @@ spec:
           #@ if/end data.values.eirini.serverCerts.secretName:
           - name: eirini-certs
             mountPath: /config/eirini/certs
+          #@ if/end data.values.metric_proxy.cert.secret_name:
+          - name: metric-proxy-certs
+            mountPath: /config/metric_proxy/certs
+          #@ if/end data.values.metric_proxy.ca.secret_name:
+          - name: metric-proxy-ca
+            mountPath: /config/metric_proxy/ca
         - name: capi-local-worker
           image: #@ data.values.images.ccng
           imagePullPolicy: Always
@@ -89,6 +95,14 @@ spec:
       - name: eirini-certs
         secret:
           secretName: #@ data.values.eirini.serverCerts.secretName
+      #@ if/end data.values.metric_proxy.cert.secret_name:
+      - name: metric-proxy-certs
+        secret:
+          secretName: #@ data.values.metric_proxy.cert.secret_name
+      #@ if/end data.values.metric_proxy.ca.secret_name:
+      - name: metric-proxy-ca
+        secret:
+          secretName: #@ data.values.metric_proxy.ca.secret_name
       - name: nginx-uploads
         emptyDir: {}
 

--- a/config/_ytt_lib/github.com/cloudfoundry/capi-k8s-release/templates/ccng-config.lib.yml
+++ b/config/_ytt_lib/github.com/cloudfoundry/capi-k8s-release/templates/ccng-config.lib.yml
@@ -81,15 +81,21 @@ logging:
   max_retries: 1
 
 logcache:
-  host: #@ "https://log-cache.{}".format(data.values.system_domain)
+  host: metric-proxy
   port: 8080
   temporary_ignore_server_unavailable_errors: true
 
 logcache_tls:
-  key_file: "/dev/null"
-  cert_file: "/dev/null"
+  #@ if data.values.metric_proxy.cert.secret_name:
+  ca_file: "/config/metric_proxy/ca/tls.crt"
+  cert_file: "/config/metric_proxy/certs/tls.crt"
+  key_file: "/config/metric_proxy/certs/tls.key"
+  #@ else:
   ca_file: "/dev/null"
-  subject_name: log_cache
+  cert_file: "/dev/null"
+  key_file: "/dev/null"
+  #@ end
+  subject_name: metric-proxy
 
 loggregator:
   router: 127.0.0.1:3457
@@ -120,7 +126,7 @@ db: &db
 
 telemetry_log_path: "/dev/null"
 log_cache:
-  url: #@ "log-cache.{}".format(data.values.system_domain)
+  url: #@ "https://log-cache.{}".format(data.values.system_domain)
 threadpool_size: 20
 internal_route_vip_range: ""
 
@@ -350,7 +356,7 @@ default_app_lifecycle: kpack
 
 #! kpack stager properties
 kubernetes:
-  host_url: #@ data.values.kubernetes.api.url
+  host_url: https://kubernetes.default
   service_account:
     token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
   ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt

--- a/config/_ytt_lib/github.com/cloudfoundry/capi-k8s-release/values.yml
+++ b/config/_ytt_lib/github.com/cloudfoundry/capi-k8s-release/values.yml
@@ -44,6 +44,12 @@ eirini:
   serverCerts:
     secretName:
 
+metric_proxy:
+  ca:
+    secret_name:
+  cert:
+    secret_name:
+
 apiServer:
   opi:  #! these certs were manually generated for dev purposes, they are not real eirini certs and don't have SANs.
     client_key: |
@@ -112,9 +118,6 @@ apiServer:
 kbld:
   destination:
 
-kubernetes:
-  api:
-    url: ""
 kpack:
   registry:
     hostname: ""

--- a/config/capi.yml
+++ b/config/capi.yml
@@ -67,9 +67,6 @@ uaa:
     capi_kpack_watcher:
       secret: #@ data.values.uaa.admin_client_secret
 
-kubernetes:
-  api:
-    url: #@ data.values.kubernetes.api.url
 kpack:
   registry:
     hostname: #@ data.values.kpack.registry.hostname

--- a/config/values.yml
+++ b/config/values.yml
@@ -142,9 +142,6 @@ log_cache_client:
 docker_registry:
   http_secret: "" #! A random piece of data used to sign state that may be stored with the client to protect against tampering. For production environments you should generate a random piece of data using a cryptographically secure random generator.
 
-kubernetes:
-  api:
-    url: ""
 kpack:
   registry:
     hostname: ""

--- a/hack/generate-values.sh
+++ b/hack/generate-values.sh
@@ -210,17 +210,7 @@ docker_registry:
 EOF
 
 if [[ -n "${GCP_SERVICE_ACCOUNT_JSON:=}" ]]; then
-  KUBECONF_FILE=$( mktemp )
-  kubectl config view >${KUBECONF_FILE}
-  CURRENT_KUBE_CONTEXT_NAME=$(kubectl config current-context)
-  CURRENT_KUBE_CLUSTER_NAME=$( bosh interpolate ${KUBECONF_FILE} --path=/contexts/name=${CURRENT_KUBE_CONTEXT_NAME}/context/cluster )
-  KUBE_API_SERVER_URL=$( bosh interpolate ${KUBECONF_FILE} --path=/clusters/name=${CURRENT_KUBE_CLUSTER_NAME}/cluster/server )
-
   cat <<EOF
-
-kubernetes:
-  api:
-    url: ${KUBE_API_SERVER_URL}
 
 kpack:
   registry:

--- a/vendir.lock.yml
+++ b/vendir.lock.yml
@@ -10,8 +10,8 @@ directories:
       sha: 5efa247a8f46953e9cb88f71b3ef47c2cdd39385
     path: github.com/cloudfoundry/cf-k8s-networking
   - git:
-      commitTitle: README updates and images that work with cf push...
-      sha: 2443b69dcf60ea39b075bc5fd4ef258d6a4ef292
+      commitTitle: Use in-cluster DNS for kubernetes api...
+      sha: f96d1d1ded000f8dc102a6343e55dee67551aab3
     path: github.com/cloudfoundry/capi-k8s-release
   - git:
       commitTitle: update log-cache-deployment for plain text communication...

--- a/vendir.yml
+++ b/vendir.yml
@@ -22,7 +22,7 @@ directories:
   - path: github.com/cloudfoundry/capi-k8s-release
     git:
       url: https://github.com/cloudfoundry/capi-k8s-release
-      ref: 2443b69dcf60ea39b075bc5fd4ef258d6a4ef292
+      ref: f96d1d1ded000f8dc102a6343e55dee67551aab3
     includePaths:
     - templates/**/*
     - values.yml


### PR DESCRIPTION
## Please take a moment to review the questions before submitting the PR

🚫 We only accept PRs to `develop` branch. If this is an exception, please specify why 🚫

### WHAT is this change about?

- Fix `log_cache` property so logs work via the `cf` cli [see
https://github.com/cloudfoundry/capi-k8s-release/pull/18]
- Remove the ability to configure the kubernetes api url - since we're
running in the cluster itself, we are fine using
`https://kubernetes.default`
  - No longer need to look at current kubeconfig to determine kubernetes
  api url, so removed that section of `hack/generate-values.sh`
- Enable `metric-proxy` communication instead of logcache for metrics
usage [see https://github.com/cloudfoundry/capi-k8s-release/pull/16]

### Please provide any contextual information.

https://www.pivotaltracker.com/story/show/171735462
https://cloudfoundry.slack.com/archives/CH9LF6V1P/p1584553698495500

### Have you read the [contributing guidelines](https://github.com/cloudfoundry/cf-for-k8s/blob/develop/docs/contributing.md)?

- [x] YES
- [ ] NO

### Does this PR introduce a new ytt library?

- [ ] YES - please specify
- [x] NO

### Please provide Acceptance Criteria for this change?

- You should be able to see logs for an app
- You should no longer need/be able to configure the kubernetes api url

### What is the level of urgency for publishing this change?

- [ ] **Urgent** - unblocks current or future work
- [ ] **Slightly Less than Urgent**

### Tag your pair, your PM, and/or team!

@cloudfoundry/cf-capi 
