### PR TITLE
Bump capi to use namespaced kpack `Builder`

### DIFF
--- a/config/_ytt_lib/github.com/cloudfoundry/capi-k8s-release/templates/ccng-config.lib.yml
+++ b/config/_ytt_lib/github.com/cloudfoundry/capi-k8s-release/templates/ccng-config.lib.yml
@@ -5,10 +5,10 @@ local_route: 0.0.0.0
 
 external_port: 9022
 tls_port: 9023
-readiness_ports:
+readiness_port:
   cloud_controller_worker: 4444
-  cc_deployment_updater: 4445
-  cloud_controller_clock: 4446
+  deployment_updater: 4445
+  clock: 4446
 
 internal_service_hostname: cloud_controller_ng
 
@@ -55,7 +55,7 @@ nginx:
 index: 0
 name: ""
 route_services_enabled: true
-volume_services_enabled: false
+volume_services_enabled: true
 
 info:
   name: ""
@@ -361,7 +361,7 @@ kubernetes:
     token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
   ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
   kpack:
-    builder_namespace: #@ data.values.system_namespace
+    builder_namespace: #@ data.values.staging_namespace
     registry_service_account_name: cc-kpack-registry-service-account
     registry_tag_base: #@ "{}/{}".format(data.values.kpack.registry.hostname, data.values.kpack.registry.repository)
 

--- a/config/_ytt_lib/github.com/cloudfoundry/capi-k8s-release/templates/cf-autodetect-builder.yml
+++ b/config/_ytt_lib/github.com/cloudfoundry/capi-k8s-release/templates/cf-autodetect-builder.yml
@@ -1,0 +1,14 @@
+#@ load("@ytt:data", "data")
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: #@ data.values.staging_namespace
+---
+apiVersion: build.pivotal.io/v1alpha1
+kind: Builder
+metadata:
+  name: cf-autodetect-builder
+  namespace: #@ data.values.staging_namespace
+spec:
+  image: cloudfoundry/cnb:0.0.55-bionic

--- a/config/_ytt_lib/github.com/cloudfoundry/capi-k8s-release/templates/cf-autodetect-clusterbuilder.yml
+++ b/config/_ytt_lib/github.com/cloudfoundry/capi-k8s-release/templates/cf-autodetect-clusterbuilder.yml
@@ -1,7 +1,0 @@
----
-apiVersion: build.pivotal.io/v1alpha1
-kind: ClusterBuilder
-metadata:
-  name: cf-autodetect-builder
-spec:
-  image: cloudfoundry/cnb:bionic

--- a/config/_ytt_lib/github.com/cloudfoundry/capi-k8s-release/templates/service-accounts.yml
+++ b/config/_ytt_lib/github.com/cloudfoundry/capi-k8s-release/templates/service-accounts.yml
@@ -25,7 +25,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: cc-kpack-registry-auth-secret
-  namespace: #@ data.values.system_namespace
+  namespace: #@ data.values.staging_namespace
   annotations:
     build.pivotal.io/docker: #@ data.values.kpack.registry.hostname
 type: kubernetes.io/basic-auth
@@ -37,7 +37,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: cc-kpack-registry-service-account
-  namespace: #@ data.values.system_namespace
+  namespace: #@ data.values.staging_namespace
 secrets:
   - name: cc-kpack-registry-auth-secret
 

--- a/config/_ytt_lib/github.com/cloudfoundry/capi-k8s-release/values.yml
+++ b/config/_ytt_lib/github.com/cloudfoundry/capi-k8s-release/values.yml
@@ -3,11 +3,12 @@
 replicaCount: 1
 
 images:
-  ccng: cloudfoundry/cloud-controller-ng:0e40bf23675df21be5b9f29492c46bea7fe156ac@sha256:e466dbda51fbb1ad7613194204c47d2dcfc860f93a578eb9db1b5967009dd9c7
+  ccng: cloudfoundry/cloud-controller-ng:93db92c130d287debf6c5eb376fdf81f4e2cf1a4@sha256:612a92a7a761ce15260121ea5336839d3d05e79385f5f6c8dd27a74a9ad5bb0d
   nginx: cloudfoundry/capi:nginx
   capi_kpack_watcher: cloudfoundry/capi-kpack-watcher:latest
 system_namespace: cf-system
 workloads_namespace: cf-workloads
+staging_namespace: cf-workloads-staging
 imagePullSecrets:
 
 app_domains: []

--- a/config/capi.yml
+++ b/config/capi.yml
@@ -96,9 +96,3 @@ spec:
         host: #@ "capi." + data.values.system_namespace + ".svc.cluster.local"
         port:
           number: 80
-
-#! pin cnb image to last known good: 0.0.55-bionic
-#@overlay/match by=overlay.subset({"kind": "ClusterBuilder", "metadata": {"name": "cf-autodetect-builder"}})
----
-spec:
-  image: cloudfoundry/cnb:0.0.55-bionic

--- a/vendir.lock.yml
+++ b/vendir.lock.yml
@@ -10,8 +10,8 @@ directories:
       sha: 5efa247a8f46953e9cb88f71b3ef47c2cdd39385
     path: github.com/cloudfoundry/cf-k8s-networking
   - git:
-      commitTitle: Use in-cluster DNS for kubernetes api...
-      sha: f96d1d1ded000f8dc102a6343e55dee67551aab3
+      commitTitle: Use namespaced kpack `Builder`...
+      sha: 685f10eadf7d767ccd977ec773b672e68154ccf5
     path: github.com/cloudfoundry/capi-k8s-release
   - git:
       commitTitle: update log-cache-deployment for plain text communication...

--- a/vendir.yml
+++ b/vendir.yml
@@ -22,7 +22,7 @@ directories:
   - path: github.com/cloudfoundry/capi-k8s-release
     git:
       url: https://github.com/cloudfoundry/capi-k8s-release
-      ref: f96d1d1ded000f8dc102a6343e55dee67551aab3
+      ref: 685f10eadf7d767ccd977ec773b672e68154ccf5
     includePaths:
     - templates/**/*
     - values.yml


### PR DESCRIPTION
> _Please describe the change._ 

Use namespaced kpack `Builder`

- This allows for the use of `ImagePullSecrets` for the builder image, which is not allowed for the previous `CustomBuilder`-type builder
- Moves kpack builds to their own namespace - defaulted to `cf-workloads-staging`, where the builder also lives
- Update ccng image to take this into account
---

- Make sure this PR is based off the `develop` branch
- Let us know if getting this merged is urgent.
- Checkout the [contributing guidelines](https://github.com/cloudfoundry/cf-for-k8s/blob/develop/docs/contributing.md)

_Special notes for your reviewer /  **Acceptance Criteria** (if applicable)_

`cf push` should still work :)

_Resources_

> _Include any links to other PRs, stories, slack discussions, etc... that will help establish context._


_Tag your pair, your PM, and/or team_

@cloudfoundry/cf-capi 