### PR TITLE
check logs based on --recent rather than streaming

### DIFF
--- a/tests/smoke/smoke_test.go
+++ b/tests/smoke/smoke_test.go
@@ -10,8 +10,8 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	. "github.com/onsi/gomega/gexec"
 	. "github.com/onsi/gomega/gbytes"
+	. "github.com/onsi/gomega/gexec"
 
 	"github.com/cloudfoundry-incubator/cf-test-helpers/cf"
 	"github.com/cloudfoundry-incubator/cf-test-helpers/generator"
@@ -105,7 +105,7 @@ var _ = Describe("Smoke Tests", func() {
 			Expect(appResponse.VcapServices).NotTo(BeEmpty())
 
 			By("verifying that the application's logs are available.")
-			cfLogs := cf.Cf("logs", appName)
+			cfLogs := cf.Cf("logs", "--recent", appName)
 			Eventually(cfLogs.Out).Should(Say("Hello World from index"))
 		})
 
@@ -131,7 +131,7 @@ var _ = Describe("Smoke Tests", func() {
 			Expect(string(body)).To(Equal("Hello World\n"))
 
 			By("verifying that the application's logs are available.")
-			cfLogs := cf.Cf("logs", appName)
+			cfLogs := cf.Cf("logs", "--recent", appName)
 			Eventually(cfLogs.Out).Should(Say("Console output from test-node-app"))
 		})
 	})


### PR DESCRIPTION
> _Please describe the change._ 

---

- Make sure this PR is based off the `develop` branch
- Let us know if getting this merged is urgent.
- Checkout the [contributing guidelines](https://github.com/cloudfoundry/cf-for-k8s/blob/develop/docs/contributing.md)

Streaming logs is missing the single log line emitted by these apps. Check recent logs instead.

AC: smoke tests should pass and be less flaky

_Resources_

Merging this bocks this story: https://www.pivotaltracker.com/story/show/171779821
and additional merges to cf-for-k8s

