### PR TITLE
Bump capi to enable dockerhub use

### DIFF
--- a/config/_ytt_lib/github.com/cloudfoundry/capi-k8s-release/templates/ccng-config.lib.yml
+++ b/config/_ytt_lib/github.com/cloudfoundry/capi-k8s-release/templates/ccng-config.lib.yml
@@ -363,7 +363,7 @@ kubernetes:
   kpack:
     builder_namespace: #@ data.values.staging_namespace
     registry_service_account_name: cc-kpack-registry-service-account
-    registry_tag_base: #@ "{}/{}".format(data.values.kpack.registry.hostname, data.values.kpack.registry.repository)
+    registry_tag_base: #@ data.values.kpack.registry.repository
 
 #! worker property
 perform_blob_cleanup: true

--- a/config/_ytt_lib/github.com/cloudfoundry/capi-k8s-release/values.yml
+++ b/config/_ytt_lib/github.com/cloudfoundry/capi-k8s-release/values.yml
@@ -121,7 +121,7 @@ kbld:
 
 kpack:
   registry:
-    hostname: ""
-    repository: ""
+    hostname: "" #! Used to fill in the hostname of the kpack registry auth secret
+    repository: "" #! Passed as spec.tag to the kpack Image resource
     username: ""
     password: ""

--- a/vendir.lock.yml
+++ b/vendir.lock.yml
@@ -10,8 +10,8 @@ directories:
       sha: 5efa247a8f46953e9cb88f71b3ef47c2cdd39385
     path: github.com/cloudfoundry/cf-k8s-networking
   - git:
-      commitTitle: Use namespaced kpack `Builder`...
-      sha: 685f10eadf7d767ccd977ec773b672e68154ccf5
+      commitTitle: Do not try to interpolate image location from hostname...
+      sha: 9e7bb239bc6c9ac8e633d29ad181832e90251a83
     path: github.com/cloudfoundry/capi-k8s-release
   - git:
       commitTitle: update log-cache-deployment for plain text communication...

--- a/vendir.yml
+++ b/vendir.yml
@@ -22,7 +22,7 @@ directories:
   - path: github.com/cloudfoundry/capi-k8s-release
     git:
       url: https://github.com/cloudfoundry/capi-k8s-release
-      ref: 685f10eadf7d767ccd977ec773b672e68154ccf5
+      ref: 9e7bb239bc6c9ac8e633d29ad181832e90251a83
     includePaths:
     - templates/**/*
     - values.yml


### PR DESCRIPTION
> _Please describe the change._ 

Directly pass through `kpack.registry.hostname` to kpack's
`Image.spec.tag` property.  This allows dockerhub to be used as a registry for images built by
kpack.  See the updated documentation for examples: https://github.com/cloudfoundry/capi-k8s-release#configuring-pushes-of-buildpack-apps

Fixes https://github.com/cloudfoundry/cf-for-k8s/issues/71
---

- Make sure this PR is based off the `develop` branch
- Let us know if getting this merged is urgent.
- Checkout the [contributing guidelines](https://github.com/cloudfoundry/cf-for-k8s/blob/develop/docs/contributing.md)


> **_Example Acceptance Criteria:_**

both dockerhub and gcr should still work as image destinations