### PR TITLE
Bump capi to label build pods with source_type STG

### DIFF
--- a/config/_ytt_lib/github.com/cloudfoundry/capi-k8s-release/values.yml
+++ b/config/_ytt_lib/github.com/cloudfoundry/capi-k8s-release/values.yml
@@ -3,7 +3,7 @@
 replicaCount: 1
 
 images:
-  ccng: cloudfoundry/cloud-controller-ng:93db92c130d287debf6c5eb376fdf81f4e2cf1a4@sha256:612a92a7a761ce15260121ea5336839d3d05e79385f5f6c8dd27a74a9ad5bb0d
+  ccng: cloudfoundry/cloud-controller-ng:33f461df533c7174241b00759bb7622ea37c58c7@sha256:0bc1b2b3e0c2fcfbd76d7c4a311b728a240b928fcd8d2b2b1e057de88a0adacf
   nginx: cloudfoundry/capi:nginx
   capi_kpack_watcher: cloudfoundry/capi-kpack-watcher:latest
 system_namespace: cf-system

--- a/vendir.lock.yml
+++ b/vendir.lock.yml
@@ -10,8 +10,8 @@ directories:
       sha: 5efa247a8f46953e9cb88f71b3ef47c2cdd39385
     path: github.com/cloudfoundry/cf-k8s-networking
   - git:
-      commitTitle: Do not try to interpolate image location from hostname...
-      sha: 9e7bb239bc6c9ac8e633d29ad181832e90251a83
+      commitTitle: Bump ccng image to label kpack build pods with STG...
+      sha: d188d77a878241d685b93ec159eba1318a53ae03
     path: github.com/cloudfoundry/capi-k8s-release
   - githubRelease:
       url: https://api.github.com/repos/cloudfoundry/cf-k8s-logging/releases/24864777

--- a/vendir.yml
+++ b/vendir.yml
@@ -22,7 +22,7 @@ directories:
   - path: github.com/cloudfoundry/capi-k8s-release
     git:
       url: https://github.com/cloudfoundry/capi-k8s-release
-      ref: 9e7bb239bc6c9ac8e633d29ad181832e90251a83
+      ref: d188d77a878241d685b93ec159eba1318a53ae03
     includePaths:
     - templates/**/*
     - values.yml


### PR DESCRIPTION
This is to support staging logs being shown by the cli when pushing an app
See https://github.com/cloudfoundry/cf-k8s-logging/issues/18

> _Please describe the change._ 

kpack build pods now have the label `cloudfoundry.org/source_type=STG`.  This will allow the logging framework to set the source type on log envelopes containing the output of builds.  The cli will then be able to display these logs during a push.

I believe that there will also have to be a change to the logging infrastructure before the source type will be set and we'll actually see push logs via the cli. (cc @pianohacker)

---

_Resources_

Two slack threads,
one large: https://cloudfoundry.slack.com/archives/CH9LF6V1P/p1584638456029000
and one small: https://cloudfoundry.slack.com/archives/CH9LF6V1P/p1585175250043300


_Tag your pair, your PM, and/or team_

@cloudfoundry/cf-capi 