### PR TITLE
Integrates metric-proxy to return app metrics

### DIFF
--- a/config/_ytt_lib/github.com/cloudfoundry/metric-proxy/LICENSE
+++ b/config/_ytt_lib/github.com/cloudfoundry/metric-proxy/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/config/_ytt_lib/github.com/cloudfoundry/metric-proxy/config/manifests/100-metric-proxy-service-account.yml
+++ b/config/_ytt_lib/github.com/cloudfoundry/metric-proxy/config/manifests/100-metric-proxy-service-account.yml
@@ -1,0 +1,33 @@
+#@ load("@ytt:data", "data")
+---
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  name: metric-proxy
+  namespace: #@ data.values.system_namespace
+
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: metric-proxy
+  namespace: #@ data.values.system_namespace
+rules:
+  - apiGroups: ["*"]
+    resources: ["pods", "namespaces"]
+    verbs: ["get", "watch", "list"]
+
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: metric-proxy
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: metric-proxy
+subjects:
+  - kind: ServiceAccount
+    name: metric-proxy
+    namespace: #@ data.values.system_namespace
+

--- a/config/_ytt_lib/github.com/cloudfoundry/metric-proxy/config/manifests/400-metric-proxy-service.yml
+++ b/config/_ytt_lib/github.com/cloudfoundry/metric-proxy/config/manifests/400-metric-proxy-service.yml
@@ -1,0 +1,15 @@
+#@ load("@ytt:data", "data")
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: metric-proxy
+  namespace: #@ data.values.system_namespace
+spec:
+  selector:
+    app: metric-proxy
+  ports:
+    - protocol: TCP
+      port: 8080
+      name: https
+

--- a/config/_ytt_lib/github.com/cloudfoundry/metric-proxy/config/manifests/50-metric-proxy-secrets.yml
+++ b/config/_ytt_lib/github.com/cloudfoundry/metric-proxy/config/manifests/50-metric-proxy-secrets.yml
@@ -1,0 +1,23 @@
+#@ load("@ytt:data", "data")
+---
+apiVersion: v1
+kind: Secret
+type: kubernetes.io/tls
+metadata:
+  name: #@ data.values.metric_proxy.cert.secret_name
+  namespace: #@ data.values.system_namespace
+data:
+  tls.crt: #@ data.values.metric_proxy.cert.crt
+  tls.key: #@ data.values.metric_proxy.cert.key
+
+---
+apiVersion: v1
+kind: Secret
+type: kubernetes.io/tls
+metadata:
+  name: #@ data.values.metric_proxy.ca.secret_name
+  namespace: #@ data.values.system_namespace
+data:
+  tls.crt: #@ data.values.metric_proxy.ca.crt
+  tls.key: #@ data.values.metric_proxy.ca.key
+

--- a/config/_ytt_lib/github.com/cloudfoundry/metric-proxy/config/manifests/500-metric-proxy-deployment.yml
+++ b/config/_ytt_lib/github.com/cloudfoundry/metric-proxy/config/manifests/500-metric-proxy-deployment.yml
@@ -1,0 +1,56 @@
+#@ load("@ytt:data", "data")
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: metric-proxy
+  namespace: #@ data.values.system_namespace
+  labels:
+    app: metric-proxy
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: metric-proxy
+  template:
+    metadata:
+      labels:
+        app: metric-proxy
+    spec:
+      serviceAccountName: metric-proxy
+      containers:
+      - name: metric-proxy
+        image: #@ data.values.images.metric_proxy
+        imagePullPolicy: Always
+        ports:
+        - containerPort: 8080
+        env:
+        - name: ADDR
+          value: :8080
+        - name: APP_SELECTOR
+          value: cloudfoundry.org/app_guid
+        - name: NAMESPACE
+          value: cf-workloads
+        - name: QUERY_TIMEOUT
+          value: "5"
+        - name: CA_PATH
+          value: /ca/tls.crt
+        - name: CERT_PATH
+          value: /metric-proxy-certs/tls.crt
+        - name: KEY_PATH
+          value: /metric-proxy-certs/tls.key
+        volumeMounts:
+        - mountPath: /ca
+          name: ca
+          readOnly: true
+        - mountPath: /metric-proxy-certs
+          name: metric-proxy-certs
+          readOnly: true
+      volumes:
+      - name: ca
+        secret:
+          secretName: #@ data.values.metric_proxy.ca.secret_name
+      - name: metric-proxy-certs
+        secret:
+          secretName: #@ data.values.metric_proxy.cert.secret_name
+

--- a/config/_ytt_lib/github.com/cloudfoundry/metric-proxy/config/manifests/500-metric-proxy-deployment.yml
+++ b/config/_ytt_lib/github.com/cloudfoundry/metric-proxy/config/manifests/500-metric-proxy-deployment.yml
@@ -13,6 +13,10 @@ spec:
     matchLabels:
       app: metric-proxy
   template:
+    annotations:
+      prometheus.io/scrape: true
+      prometheus.io/port: 9090
+      prometheus.io/path: /metrics
     metadata:
       labels:
         app: metric-proxy
@@ -24,6 +28,7 @@ spec:
         imagePullPolicy: Always
         ports:
         - containerPort: 8080
+        - containerPort: 9090
         env:
         - name: ADDR
           value: :8080

--- a/config/_ytt_lib/github.com/cloudfoundry/metric-proxy/config/values.yml
+++ b/config/_ytt_lib/github.com/cloudfoundry/metric-proxy/config/values.yml
@@ -1,0 +1,18 @@
+#@data/values
+---
+system_domain: ""
+system_namespace: ""
+
+images:
+  metric_proxy: "oratos/metric-proxy"
+
+metric_proxy:
+  ca:
+    secret_name: "metric-proxy-ca"
+    crt: "" #! Base64-encoded ca for the metric-proxy-ca
+    key: "" #! Base64-encoded private key for the cert above
+  cert:
+    secret_name: "metric-proxy-cert"
+    crt: "" #! Base64-encoded cert for the metric-proxy server requires CN of metric-proxy
+    key: "" #! Base64-encoded private key for the cert above
+

--- a/config/_ytt_lib/github.com/cloudfoundry/metric-proxy/config/values.yml
+++ b/config/_ytt_lib/github.com/cloudfoundry/metric-proxy/config/values.yml
@@ -4,7 +4,7 @@ system_domain: ""
 system_namespace: ""
 
 images:
-  metric_proxy: "oratos/metric-proxy"
+  metric_proxy: "oratos/metric-proxy@sha256:a2a0d2201d1a57602a3db337bfa256d6e042dfc09a63ba1b6f39c952847e00dc"
 
 metric_proxy:
   ca:

--- a/config/capi.yml
+++ b/config/capi.yml
@@ -58,6 +58,12 @@ apiServer:
     client_key: #@ data.values.eirini.tls.key
     ca: #@ data.values.system_certificate.ca
 
+metric_proxy:
+  ca:
+    secret_name: #@ data.values.metric_proxy.ca.secret_name
+  cert:
+    secret_name: #@ data.values.metric_proxy.cert.secret_name
+
 uaa:
   serverCerts:
     secretName: uaa-certs

--- a/config/metrics.yml
+++ b/config/metrics.yml
@@ -1,0 +1,24 @@
+#@ load("@ytt:data", "data")
+#@ load("@ytt:library", "library")
+#@ load("@ytt:overlay", "overlay")
+#@ load("@ytt:template", "template")
+#@ load("@ytt:base64", "base64")
+
+#@ def metrics_values():
+system_domain: #@ data.values.system_domain
+system_namespace: #@ data.values.system_namespace
+
+metric_proxy:
+  ca:
+    secret_name: "metric-proxy-ca"
+    crt: #@ data.values.metric_proxy.ca.crt
+    key: #@ data.values.metric_proxy.ca.key
+  cert:
+    secret_name: "metric-proxy-cert"
+    crt: #@ data.values.metric_proxy.cert.crt
+    key: #@ data.values.metric_proxy.cert.key
+#@ end
+
+#@ metrics = library.get("github.com/cloudfoundry/metric-proxy")
+--- #@ template.replace(metrics.with_data_values(metrics_values()).eval())
+

--- a/config/metrics.yml
+++ b/config/metrics.yml
@@ -1,8 +1,6 @@
 #@ load("@ytt:data", "data")
 #@ load("@ytt:library", "library")
-#@ load("@ytt:overlay", "overlay")
 #@ load("@ytt:template", "template")
-#@ load("@ytt:base64", "base64")
 
 #@ def metrics_values():
 system_domain: #@ data.values.system_domain

--- a/config/values.yml
+++ b/config/values.yml
@@ -140,3 +140,14 @@ app_registry:
   repository: ""
   username: ""
   password: ""
+
+metric_proxy:
+  ca:
+    secret_name: "metric-proxy-ca"
+    crt: ""
+    key: ""
+  cert:
+    secret_name: "metric-proxy-cert"
+    crt: ""
+    key: ""
+

--- a/hack/generate-values.sh
+++ b/hack/generate-values.sh
@@ -162,6 +162,21 @@ variables:
     extended_key_usage:
     - client_auth
     - server_auth
+
+- name: metric_proxy_ca
+  type: certificate
+  options:
+    is_ca: true
+    common_name: metric-proxy-ca
+
+- name: metric_proxy
+  type: certificate
+  options:
+    ca: metric_proxy_ca
+    common_name: metric-proxy
+    extended_key_usage:
+    - client_auth
+    - server_auth
 EOF
 ) >/dev/null
 
@@ -213,6 +228,14 @@ log_cache_gateway:
 log_cache_syslog:
   crt: $( bosh interpolate ${VARS_FILE} --path=/log_cache_syslog/certificate | base64 | tr -d '\n' )
   key: $( bosh interpolate ${VARS_FILE} --path=/log_cache_syslog/private_key | base64 | tr -d '\n' )
+
+metric_proxy:
+  ca:
+    crt: $( bosh interpolate ${VARS_FILE} --path=/metric_proxy_ca/certificate | base64 | tr -d '\n' )
+    key: $( bosh interpolate ${VARS_FILE} --path=/metric_proxy_ca/private_key | base64 | tr -d '\n' )
+  cert:
+    crt: $( bosh interpolate ${VARS_FILE} --path=/metric_proxy/certificate | base64 | tr -d '\n' )
+    key: $( bosh interpolate ${VARS_FILE} --path=/metric_proxy/private_key | base64 | tr -d '\n' )
 
 uaa:
   database:

--- a/sample-cf-install-values.yml
+++ b/sample-cf-install-values.yml
@@ -86,3 +86,15 @@ app_registry:
   username: _json_key
   password: |
     contents_of_service_account_json
+
+metric_proxy:
+  ca:
+    secret_name: "metric-proxy-ca"
+    crt: *crt
+    key: *key
+  cert:
+    secret_name: "metric-proxy-cert"
+    #! This certificate should be valid for metric-proxy.cf-system.svc.cluster.local
+    crt: *crt
+    key: *key
+

--- a/tests/smoke/smoke_test.go
+++ b/tests/smoke/smoke_test.go
@@ -108,6 +108,12 @@ var _ = Describe("Smoke Tests", func() {
 				cfLogs := cf.Cf("logs", appName, "--recent")
 				return string(cfLogs.Wait().Out.Contents())
 			}, 2*time.Minute, 2*time.Second).Should(ContainSubstring("Hello World from index"))
+
+			By("verifying that the application's metrics are available.")
+			Eventually(func() string {
+				cfApp := cf.Cf("app", appName)
+				return string(cfApp.Wait().Out.Contents())
+			}).Should(ContainSubstring("cpu"))
 		})
 
 		It("creates a routable app pod in Kubernetes from a source-based app", func() {
@@ -136,6 +142,12 @@ var _ = Describe("Smoke Tests", func() {
 				cfLogs := cf.Cf("logs", appName, "--recent")
 				return string(cfLogs.Wait().Out.Contents())
 			}, 2*time.Minute, 2*time.Second).Should(ContainSubstring("Console output from test-node-app"))
+
+			By("verifying that the application's metrics are available.")
+			Eventually(func() string {
+				cfApp := cf.Cf("app", appName)
+				return string(cfApp.Wait().Out.Contents())
+			}).Should(ContainSubstring("cpu"))
 		})
 	})
 })

--- a/vendir.lock.yml
+++ b/vendir.lock.yml
@@ -17,6 +17,10 @@ directories:
       url: https://api.github.com/repos/cloudfoundry/cf-k8s-logging/releases/24864777
     path: github.com/cloudfoundry/cf-k8s-logging/config
   - git:
+      commitTitle: Update install-cf script to use new flags...
+      sha: 8ce5a76c87898be5552928e1073b7696b73b7885
+    path: github.com/cloudfoundry/metric-proxy
+  - git:
       commitTitle: Reduce the number of env vars used by UAA...
       sha: 1c19ffc2697441824d2e98e31210a82e1fbc0ac1
     path: github.com/cloudfoundry/uaa

--- a/vendir.lock.yml
+++ b/vendir.lock.yml
@@ -17,8 +17,8 @@ directories:
       url: https://api.github.com/repos/cloudfoundry/cf-k8s-logging/releases/24864777
     path: github.com/cloudfoundry/cf-k8s-logging/config
   - git:
-      commitTitle: Update install-cf script to use new flags...
-      sha: 8ce5a76c87898be5552928e1073b7696b73b7885
+      commitTitle: Fix image sha...
+      sha: 614dbcd1a80512fb707f936067d8c498e3471682
     path: github.com/cloudfoundry/metric-proxy
   - git:
       commitTitle: Reduce the number of env vars used by UAA...

--- a/vendir.yml
+++ b/vendir.yml
@@ -31,6 +31,12 @@ directories:
       slug: cloudfoundry/cf-k8s-logging
       tag: 0.1.0
       disableAutoChecksumValidation: true
+  - path: github.com/cloudfoundry/metric-proxy
+    git:
+      url: https://github.com/cloudfoundry/metric-proxy
+      ref: 8ce5a76c87898be5552928e1073b7696b73b7885
+    includePaths:
+    - config/**/*
   - path: github.com/cloudfoundry/uaa
     git:
       url: https://github.com/cloudfoundry/uaa

--- a/vendir.yml
+++ b/vendir.yml
@@ -34,7 +34,7 @@ directories:
   - path: github.com/cloudfoundry/metric-proxy
     git:
       url: https://github.com/cloudfoundry/metric-proxy
-      ref: 8ce5a76c87898be5552928e1073b7696b73b7885
+      ref: 614dbcd1a80512fb707f936067d8c498e3471682
     includePaths:
     - config/**/*
   - path: github.com/cloudfoundry/uaa


### PR DESCRIPTION
Signed-off-by: Caitlyn Yu <cyu@pivotal.io>
Signed-off-by: David Timm <dtimm@pivotal.io>

This uses the [metrics-proxy](https://github.com/cloudfoundry/metric-proxy) to return metrics for `cf push` and `cf app`. The metric-proxy makes a request to the Kube API and formats the results to match the existing log-cache API.

**_Acceptance Criteria:_**

**Given** I've deployed cf-for-k8s with this branch
**When** I run `kubectl get pod -n cf-system | grep metric-proxy`
**Then** I see the metric-proxy pod is running

**Given** I've deployed cf-for-k8s with this branch
**When** I run `cf push <my-app>` ie `cf app <my-app>`
**Then** I see cpu and memory metrics listed in the output.

For more information, see our [README](https://github.com/cloudfoundry/metric-proxy/blob/master/README.md)

_Tag your pair, your PM, and/or team_
@hev 
@heycait 
@dtimm 
