### PR TITLE
Change update-gcp-dns.sh to exclude 'Address' with # in addition to :

### DIFF
--- a/hack/update-gcp-dns.sh
+++ b/hack/update-gcp-dns.sh
@@ -40,7 +40,7 @@ resolved_ip=''
 while [ "$resolved_ip" != "$external_static_ip" ]; do
   echo "Waiting for DNS to propagate..."
   sleep 5
-  resolved_ip=$(nslookup "*.$DNS_DOMAIN" | grep Address | grep -v ':53' | cut -d ' ' -f2)
+  resolved_ip=$(nslookup "*.$DNS_DOMAIN" | grep Address | grep -v ':53' | grep -v '#53' | cut -d ' ' -f2)
 done
 
 gcloud dns record-sets list --zone="${DNS_ZONE_NAME}" --filter="Type=A"


### PR DESCRIPTION
When we run `nslookup "*.$DNS_DOMAIN"`, our output includes the following line:

`Address:	10.35.30.10#53`

This causes the script to hang forever, since it should ignore that Address line.

This change excludes that line.