### PR TITLE
Add support for cert-manager to manage *.system_domain certs

### DIFF
--- a/config-optional/cert-manager/use-cert-manager-istio-ingress.yml
+++ b/config-optional/cert-manager/use-cert-manager-istio-ingress.yml
@@ -1,0 +1,25 @@
+#@ load("@ytt:data", "data")
+#@ load("@ytt:overlay", "overlay")
+
+#! This certificate will cause cert-manager to create the secret istio-ingressgateway-certs
+---
+apiVersion: cert-manager.io/v1alpha2
+kind: Certificate
+metadata:
+  name: istio-ingressgateway
+  namespace: istio-system
+spec:
+  secretName: istio-ingressgateway-certs
+  dnsNames:
+  - #@ "*." + data.values.system_domain
+#@ for/end domain in data.values.app_domains:
+#@overlay/append
+  - #@ "*." + domain
+  issuerRef:
+    name: #@ data.values.istio_cert_issuer_name
+    kind: #@ data.values.istio_cert_issuer_kind
+
+#! make sure the ingress cert secret isn't being created
+#@overlay/match by=overlay.subset({"kind":"Secret","metadata":{"name":"istio-ingressgateway-certs","namespace":"istio-system"}})
+#@overlay/remove
+---

--- a/config-optional/cert-manager/use-cert-manager-istio-ingress.yml
+++ b/config-optional/cert-manager/use-cert-manager-istio-ingress.yml
@@ -12,8 +12,7 @@ spec:
   secretName: istio-ingressgateway-certs
   dnsNames:
   - #@ "*." + data.values.system_domain
-#@ for/end domain in data.values.app_domains:
-#@overlay/append
+  #@ for/end domain in data.values.app_domains:
   - #@ "*." + domain
   issuerRef:
     name: #@ data.values.istio_cert_issuer_name

--- a/config-optional/cert-manager/values.yml
+++ b/config-optional/cert-manager/values.yml
@@ -1,0 +1,7 @@
+#@data/values
+---
+
+#@overlay/match missing_ok=True
+istio_cert_issuer_name: "letsencrypt-prod"
+#@overlay/match missing_ok=True
+istio_cert_issuer_kind: "ClusterIssuer"

--- a/config-optional/cert-manager/values.yml
+++ b/config-optional/cert-manager/values.yml
@@ -1,6 +1,5 @@
 #@data/values
 ---
-
 #@overlay/match missing_ok=True
 istio_cert_issuer_name: "letsencrypt-prod"
 #@overlay/match missing_ok=True

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -243,4 +243,3 @@ You can delete the cf-for-k8s deployment by running the following command.
    # Assuming that you ran `bin/install.sh...`
    $ kapp delete -a cf
    ```
-

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -125,8 +125,12 @@ Currently, we have tested the following two container registries:
    </br>
 
    > If you do NOT wish to enable Cloud Native Buildpacks feature, then remove the `app_registry` block from your `cf-values.yml`
-1. Run the install script with your "CF Install Values" file.
 
+1. If you want to use a reserved static IP address for your ingress loadbalancer you can set `istio_static_ip` in your `cf-values.yml` file.
+
+1. If you want to use [cert-manager](https://cert-manager.io/docs/) to provide the SSL certs for your istio gateway you can add `-f ./config-optional/cert-manager`. See `./config-optional/values.yml` for values you can override in your `cf-values.yml` file.
+
+1. Run the install script with your "CF Install Values" file
    ```console
    $ ./bin/install-cf.sh /tmp/cf-values.yml
    ```


### PR DESCRIPTION
Building on top of the external-dns support, this PR brings in support for using cert-manager to get a valid certificate from lets encrypt (or even self signed) for the CF api service.