### PR TITLE
Update deploy/kind/cluster.yml

### DIFF
--- a/deploy/kind/cluster.yml
+++ b/deploy/kind/cluster.yml
@@ -2,7 +2,6 @@ kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
 nodes:
 - role: control-plane
-  image: kindest/node:v1.15.7
   kubeadmConfigPatches:
   - |
     kind: InitConfiguration


### PR DESCRIPTION
cf-for-k8s now deploys on k8s versions >= 1.16, so we no longer need to pin to k8s 1.15



> Thanks for contributing to cf-for-k8s!
>
> We've designed this PR template to speed up the PR review and merge process - please use it.

> _Please describe the change here._ 

---


- Make sure this PR is based off the `develop` branch
- Checkout the [contributing guidelines](https://github.com/cloudfoundry/cf-for-k8s/blob/develop/docs/contributing.md)
- Include any links to related PRs, issues, stories, slack discussions, etc... that will help establish context.
- Is there anything else of note that the reviewers should know about this change?

**Acceptance Steps**

_please provide a series of instructions (eg kubectl or cf cli commands) for how our Product Manager can verify that your changes were properly integrated_


_Tag your pair, your PM, and/or team_

> _It's helpful to tag a few other folks on your team or your team alias in case we need to follow up later._
