### PR TITLE
Update deploy/kind/cluster.yml

### DIFF
--- a/deploy/kind/cluster.yml
+++ b/deploy/kind/cluster.yml
@@ -2,7 +2,6 @@ kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
 nodes:
 - role: control-plane
-  image: kindest/node:v1.15.7
   kubeadmConfigPatches:
   - |
     kind: InitConfiguration


### PR DESCRIPTION
cf-for-k8s now deploys on k8s versions >= 1.16, so we no longer need to pin to k8s 1.15

**Acceptance Steps**
- run the steps to [deploy on kind](https://github.com/cloudfoundry/cf-for-k8s/blob/master/docs/deploy-local.md#steps-to-deploy-on-kind)
- run `kubectl version` and validate that the server version is > 1.16

@cloudfoundry/cf-volume-services 