### PR TITLE
Refactor DNS update utility.

### DIFF
--- a/hack/update-gcp-dns.sh
+++ b/hack/update-gcp-dns.sh
@@ -68,13 +68,14 @@ else
   gcloud dns record-sets transaction add --name "*.${DNS_DOMAIN}" --type=A --zone="${DNS_ZONE_NAME}" --ttl=5 "${LB_IP}" --verbosity=debug 
   gcloud dns record-sets transaction execute --zone="${DNS_ZONE_NAME}" --verbosity=debug 
 
-  while true; do
+  SUCCESS_COUNT=0
+  while [[ ${SUCCESS_COUNT} < 3 ]]; do
     DNS_QUERY=$(nslookup *.${DNS_DOMAIN} | awk '/^Address: / { print $2 }')
     if [[ "${LB_IP}" == "${DNS_QUERY}" ]]; then
-      echo "*.${DNS_DOMAIN} successfully updated. Exiting."
-      exit 0
+      SUCCESS_COUNT=$((SUCCESS_COUNT+1))
     fi
     sleep 5
   done
-
+  echo "*.${DNS_DOMAIN} -> ${LB_IP} successfully updated. Exiting."
+  exit 0
 fi


### PR DESCRIPTION
> _Please describe the change here._

A refactor of the DNS update script for GCP, fixing some logic:
 - Don't attempt to to update if the LB address is already correct in DNS.
 - Don't attempt to delete a record if it doesn't exist already.
 - Add some functions to make things a little more readable.
---

- Make sure this PR is based off the `develop` branch
  Yes.

- Checkout the [contributing guidelines](https://github.com/cloudfoundry/cf-for-k8s/blob/develop/docs/contributing.md)
- Include any links to related PRs, issues, stories, slack discussions, etc... that will help establish context.
- Is there anything else of note that the reviewers should know about this change?

  Just tryinig to make this script a bit more readable/functional.

**Acceptance Steps**

_please provide a series of instructions (eg kubectl or cf cli commands) for how our Product Manager can verify that your changes were properly integrated_

# Things I have tested

DNS record already exists and is correct:
```console
  $ bash update-gcp-dns.sh tas4k8s.joecool.cc tas4k8s
  *.tas4k8s.joecool.cc -> 35.225.66.113. No update needed.
```
DNS record already exists and is not correct. Update needed:
```console
$ bash update-gcp-dns.sh tas4k8s.joecool.cc tas4k8s
Transaction started [transaction.yaml].
DEBUG: Running [gcloud.dns.record-sets.transaction.remove] with arguments: [--name: "*.tas4k8s.joecool.cc", --ttl: "5", --type: "A", --verbosity: "debug", --zone: "tas4k8s", DATA:1: "[u'35.225.66.116']"]
Record removal appended to transaction at [transaction.yaml].
INFO: Display format: "default"
DEBUG: SDK update checks are disabled.
DEBUG: Running [gcloud.dns.record-sets.transaction.add] with arguments: [--name: "*.tas4k8s.joecool.cc", --ttl: "5", --type: "A", --verbosity: "debug", --zone: "tas4k8s", DATA:1: "[u'35.225.66.113']"]
Record addition appended to transaction at [transaction.yaml].
INFO: Display format: "default"
DEBUG: SDK update checks are disabled.
DEBUG: Running [gcloud.dns.record-sets.transaction.execute] with arguments: [--verbosity: "debug", --zone: "tas4k8s"]
Executed transaction [transaction.yaml] for managed-zone [tas4k8s].
Created [https://dns.googleapis.com/dns/v1/projects/cso-pcfs-americas-jmcdonald2/managedZones/tas4k8s/changes/15].
INFO: Display format: "table(id, startTime, status)"
ID  START_TIME                STATUS
15  2020-04-01T18:41:44.384Z  pending
DEBUG: SDK update checks are disabled.
*.tas4k8s.joecool.cc successfully updated. Exiting.
```


DNS record does not exist and needs to be created:

```console
$ bash update-gcp-dns.sh tas4k8s.joecool.cc tas4k8s
Transaction started [transaction.yaml].
DEBUG: Running [gcloud.dns.record-sets.transaction.add] with arguments: [--name: "*.tas4k8s.joecool.cc", --ttl: "5", --type: "A", --verbosity: "debug", --zone: "tas4k8s", DATA:1: "[u'35.225.66.113']"]
Record addition appended to transaction at [transaction.yaml].
INFO: Display format: "default"
DEBUG: SDK update checks are disabled.
DEBUG: Running [gcloud.dns.record-sets.transaction.execute] with arguments: [--verbosity: "debug", --zone: "tas4k8s"]
Executed transaction [transaction.yaml] for managed-zone [tas4k8s].
Created [https://dns.googleapis.com/dns/v1/projects/cso-pcfs-americas-jmcdonald2/managedZones/tas4k8s/changes/17].
INFO: Display format: "table(id, startTime, status)"
ID  START_TIME                STATUS
17  2020-04-01T18:43:27.887Z  pending
DEBUG: SDK update checks are disabled.
*.tas4k8s.joecool.cc successfully updated. Exiting.
```

_Tag your pair, your PM, and/or team_

> _It's helpful to tag a few other folks on your team or your team alias in case we need to follow up later._