### PR TITLE
Use a Secret to store DB init credentials

### DIFF
--- a/build/postgres/init-db-values.yml
+++ b/build/postgres/init-db-values.yml
@@ -1,3 +1,4 @@
 initdbScripts:
   init.sh: ""
+initdbScriptsSecret: cf-db-credentials
 existingSecret: cf-db-admin-secret

--- a/config/_ytt_lib/postgres/rendered.yml
+++ b/config/_ytt_lib/postgres/rendered.yml
@@ -141,6 +141,8 @@ spec:
         volumeMounts:
         - name: custom-init-scripts
           mountPath: /docker-entrypoint-initdb.d/
+        - name: custom-init-scripts-secret
+          mountPath: /docker-entrypoint-initdb.d/secret
         - name: dshm
           mountPath: /dev/shm
         - name: data
@@ -150,6 +152,9 @@ spec:
       - name: custom-init-scripts
         configMap:
           name: cf-db-postgresql-init-scripts
+      - name: custom-init-scripts-secret
+        secret:
+          secretName: cf-db-credentials
       - name: dshm
         emptyDir:
           medium: Memory

--- a/config/postgres.yml
+++ b/config/postgres.yml
@@ -18,6 +18,7 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: cf-db
+
 ---
 apiVersion: v1
 kind: Secret
@@ -29,6 +30,30 @@ data:
   #@  assert.fail("cf_db.admin_password cannot be empty")
   #@ end
   postgresql-password: #@ base64.encode(data.values.cf_db.admin_password)
+
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: cf-db-credentials
+  namespace: cf-db
+data:
+  #@ if len(data.values.capi.database.user) == 0:
+  #@  assert.fail("capi.database.user cannot be empty")
+  #@ end
+  ccdb-username: #@ base64.encode(data.values.capi.database.user)
+  #@ if len(data.values.capi.database.password) == 0:
+  #@  assert.fail("capi.database.password cannot be empty")
+  #@ end
+  ccdb-password: #@ base64.encode(data.values.capi.database.password)
+  #@ if len(data.values.uaa.database.user) == 0:
+  #@  assert.fail("uaa.database.user cannot be empty")
+  #@ end
+  uaadb-username: #@ base64.encode(data.values.uaa.database.user)
+  #@ if len(data.values.uaa.database.password) == 0:
+  #@  assert.fail("uaa.database.password cannot be empty")
+  #@ end
+  uaadb-password: #@ base64.encode(data.values.uaa.database.password)
 
 #@overlay/match by=overlay.subset({"kind": "StatefulSet", "metadata":{"name":"cf-db-postgresql"}})
 ---
@@ -45,14 +70,19 @@ spec:
 #@yaml/text-templated-strings
 data:
   #@overlay/match missing_ok=True
-  setup_db.sql: |
-    CREATE DATABASE (@= ccdb.name @);
-    CREATE ROLE (@= ccdb.user @) LOGIN PASSWORD '(@= ccdb.password @)';
-    CREATE DATABASE (@= uaadb.name @);
-    CREATE ROLE (@= uaadb.user @) LOGIN PASSWORD '(@= uaadb.password @)';
   init.sh: |
     #!/bin/bash
-    psql -U postgres -f /docker-entrypoint-initdb.d/setup_db.sql
+    CCDB_USERNAME=$(cat /docker-entrypoint-initdb.d/secret/ccdb-username)
+    CCDB_PASSWORD=$(cat /docker-entrypoint-initdb.d/secret/ccdb-password)
+    UAADB_USERNAME=$(cat /docker-entrypoint-initdb.d/secret/uaadb-username)
+    UAADB_PASSWORD=$(cat /docker-entrypoint-initdb.d/secret/uaadb-password)
+    cat > /tmp/setup_db.sql <<EOT
+    CREATE DATABASE (@= ccdb.name @);
+    CREATE ROLE ${CCDB_USERNAME} LOGIN PASSWORD '${CCDB_PASSWORD}';
+    CREATE DATABASE (@= uaadb.name @);
+    CREATE ROLE ${UAADB_USERNAME} LOGIN PASSWORD '${UAADB_PASSWORD}';
+    EOT
+    psql -U postgres -f /tmp/setup_db.sql
     psql -U postgres -d (@= ccdb.name @) -c "CREATE EXTENSION citext"
     psql -U postgres -d (@= uaadb.name @) -c "CREATE EXTENSION citext"
 
@@ -71,4 +101,3 @@ spec:
   peers:
   - mtls:
       mode: PERMISSIVE
-


### PR DESCRIPTION
> Thanks for contributing to cf-for-k8s!
>
> We've designed this PR template to speed up the PR review and merge process - please use it.

Use a Secret to store DB init credentials instead of interpolating them directly into the init.sh ConfigMap.

---


- Make sure this PR is based off the `develop` branch
- Checkout the [contributing guidelines](https://github.com/cloudfoundry/cf-for-k8s/blob/develop/docs/contributing.md)
- Include any links to related PRs, issues, stories, slack discussions, etc... that will help establish context.
- Is there anything else of note that the reviewers should know about this change?

**Acceptance Steps**

_please provide a series of instructions (eg kubectl or cf cli commands) for how our Product Manager can verify that your changes were properly integrated_

1. Deploy cf-for-k8s (with this change)
1. Run `kubectl desc configmap/cf-db-postgresql-init-scripts -n cf-db` and confirm that there aren't any database credentials visible

_Tag your pair, your PM, and/or team_

> _It's helpful to tag a few other folks on your team or your team alias in case we need to follow up later._
