### PR TITLE
Correct DaemonSet spec.updateStrategy

### DIFF
--- a/config/_ytt_lib/github.com/cloudfoundry/cf-k8s-networking/config/istio-generated/xxx-generated-istio.yaml
+++ b/config/_ytt_lib/github.com/cloudfoundry/cf-k8s-networking/config/istio-generated/xxx-generated-istio.yaml
@@ -5850,10 +5850,6 @@ spec:
     matchLabels:
       app: istio-ingressgateway
       istio: ingressgateway
-  strategy:
-    rollingUpdate:
-      maxSurge: 100%
-      maxUnavailable: 25%
   template:
     metadata:
       annotations:
@@ -6070,6 +6066,9 @@ spec:
         secret:
           optional: true
           secretName: istio-ingressgateway-ca-certs
+  updateStrategy:
+    rollingUpdate:
+      maxUnavailable: 1
 ---
 apiVersion: networking.istio.io/v1alpha3
 kind: Gateway

--- a/vendir.lock.yml
+++ b/vendir.lock.yml
@@ -6,8 +6,8 @@ directories:
       sha: eacb75b4d562e3fb158eb2147a6768407ab374d4
     path: github.com/GoogleCloudPlatform/metacontroller
   - git:
-      commitTitle: 'chore: add date label to created clusters'
-      sha: bcaeb5c9219b0674a200e561e2a6bb9cf49fda0d
+      commitTitle: 'feat: Change DaemonSet''s maxUnavailable to one...'
+      sha: 9f70c276584718fbc4a72a0ca3460774806a0b15
     path: github.com/cloudfoundry/cf-k8s-networking
   - git:
       commitTitle: Pin versions of capi_kpack_watcher and nginx to a Docker digest

--- a/vendir.yml
+++ b/vendir.yml
@@ -14,7 +14,7 @@ directories:
   - path: github.com/cloudfoundry/cf-k8s-networking
     git:
       url: https://github.com/cloudfoundry/cf-k8s-networking
-      ref: bcaeb5c9219b0674a200e561e2a6bb9cf49fda0d
+      ref: 9f70c276584718fbc4a72a0ca3460774806a0b15
     includePaths:
     - cfroutesync/crds/**/*
     - config/cfroutesync/**/*


### PR DESCRIPTION

> _Please describe the change here._ 

Fixes the issue mentioned in https://github.com/cloudfoundry/cf-for-k8s/issues/102
- DaemonSets don't have a field called "maxSurge"
- `MaxUnavailable` was updated to 1 to match the Gorouter behavior during an upgrade.
- DaemonSets have "updateStrategy" instead of "update"

> Is there anything else of note that the reviewers should know about this change?

Just that it fixes this [issue](https://github.com/cloudfoundry/cf-for-k8s/issues/102)

**Acceptance Steps**

**GIVEN** I have deployed a cloud foundry
**WHEN** I describe the ingress gateway  DaemonSet with `kubectl -n istio-system describe daemonset istio-ingressgateway`
**THEN** I see the spec contains the following [keys](https://github.com/cloudfoundry/cf-for-k8s/blob/203525be553553253daaf8af0809d85a88672e1c/config/_ytt_lib/github.com/cloudfoundry/cf-k8s-networking/config/istio-generated/xxx-generated-istio.yaml#L6069-L6071)

_Tag your pair, your PM, and/or team_
cc: @jrussett 