### PR TITLE
Make CAPI stats scrapable by prometheus

### DIFF
--- a/config/_ytt_lib/github.com/cloudfoundry/capi-k8s-release/templates/api_server_deployment.yml
+++ b/config/_ytt_lib/github.com/cloudfoundry/capi-k8s-release/templates/api_server_deployment.yml
@@ -16,6 +16,10 @@ spec:
       app.kubernetes.io/name: capi-api-server
   template:
     metadata:
+      annotations:
+        prometheus.io/scrape: 'true'
+        prometheus.io/port: '9102'
+        prometheus.io/path: 'metrics'
       labels:
         app.kubernetes.io/name: capi-api-server
     spec:
@@ -75,6 +79,9 @@ spec:
             mountPath: /cloud_controller_ng
           - name: nginx-uploads
             mountPath: /tmp/uploads
+        - name: statsd-exporter
+          image: #@ data.values.images.statsd_exporter
+          imagePullPolicy: Always
       serviceAccountName: cc-api-service-account
       volumes:
       - name: server-sock

--- a/config/_ytt_lib/github.com/cloudfoundry/capi-k8s-release/templates/ccng-config.lib.yml
+++ b/config/_ytt_lib/github.com/cloudfoundry/capi-k8s-release/templates/ccng-config.lib.yml
@@ -293,7 +293,7 @@ default_staging_security_groups: ["public_networks","dns"]
 allowed_cors_domains: []
 
 statsd_host: 127.0.0.1
-statsd_port: 8125
+statsd_port: 9125
 
 security_event_logging:
   enabled: false

--- a/config/_ytt_lib/github.com/cloudfoundry/capi-k8s-release/values.yml
+++ b/config/_ytt_lib/github.com/cloudfoundry/capi-k8s-release/values.yml
@@ -6,6 +6,7 @@ images:
   ccng: cloudfoundry/cloud-controller-ng:33f461df533c7174241b00759bb7622ea37c58c7@sha256:0bc1b2b3e0c2fcfbd76d7c4a311b728a240b928fcd8d2b2b1e057de88a0adacf
   nginx: cloudfoundry/capi:nginx@sha256:51e4e48c457d5cb922cf0f569e145054e557e214afa78fb2b312a39bb2f938b6
   capi_kpack_watcher: cloudfoundry/capi-kpack-watcher:956150dae0a95dcdf3c1f29c23c3bf11db90f7a0@sha256:67125e0d3a4026a23342d80e09aad9284c08ab4f7b3d9a993ae66e403d5d0796
+  statsd_exporter: prom/statsd-exporter:v0.15.0@sha256:e3174186628b401e4a441b78513ba06e957644267332436be0c77dd7af9bdddc
 system_namespace: cf-system
 workloads_namespace: cf-workloads
 staging_namespace: cf-workloads-staging

--- a/vendir.lock.yml
+++ b/vendir.lock.yml
@@ -10,9 +10,8 @@ directories:
       sha: bcaeb5c9219b0674a200e561e2a6bb9cf49fda0d
     path: github.com/cloudfoundry/cf-k8s-networking
   - git:
-      commitTitle: Pin versions of capi_kpack_watcher and nginx to a Docker digest
-        sha...
-      sha: 29980921bca735de3000b32a0defb319ce6522d5
+      commitTitle: Add statsd-exporter container to capi-api-server...
+      sha: 423f8719927f0b6155de26f500f1ffdbd0ef9b86
     path: github.com/cloudfoundry/capi-k8s-release
   - githubRelease:
       url: https://api.github.com/repos/cloudfoundry/cf-k8s-logging/releases/24864777

--- a/vendir.yml
+++ b/vendir.yml
@@ -22,7 +22,7 @@ directories:
   - path: github.com/cloudfoundry/capi-k8s-release
     git:
       url: https://github.com/cloudfoundry/capi-k8s-release
-      ref: 29980921bca735de3000b32a0defb319ce6522d5
+      ref: 423f8719927f0b6155de26f500f1ffdbd0ef9b86
     includePaths:
     - templates/**/*
     - values.yml


### PR DESCRIPTION
Add statsd-exporter container to capi-api-server

This translates the metrics ccng emits via statsd to a
prometheus-scrapable format.

Also annotate the capi-api-server pod with prometheus annotations so
that it will be scraped.
---


**Acceptance Steps**

There should no longer be a bunch of connection refused errors in the `capi-api-server` logs.  When you open a shell onto a `capi-api-server` pod, you should be able to
```
curl localhost:9102/metrics | less
```
And see a bunch of capi metrics

_Tag your pair, your PM, and/or team_

@cloudfoundry/cf-capi @hev @kkburr 
