### PR TITLE
Bump capi-k8s-release: fix cf6 push

### DIFF
--- a/config/_ytt_lib/github.com/cloudfoundry/capi-k8s-release/templates/ccng-config.lib.yml
+++ b/config/_ytt_lib/github.com/cloudfoundry/capi-k8s-release/templates/ccng-config.lib.yml
@@ -383,7 +383,7 @@ max_retained_deployments_per_app: 100
 max_retained_builds_per_app: 100
 max_retained_revisions_per_app: 100
 diego_sync:
-  frequency_in_seconds: 30
+  frequency_in_seconds: 15
 pending_builds:
   frequency_in_seconds: 300
   expiration_in_seconds: 42

--- a/config/_ytt_lib/github.com/cloudfoundry/capi-k8s-release/values.yml
+++ b/config/_ytt_lib/github.com/cloudfoundry/capi-k8s-release/values.yml
@@ -3,7 +3,7 @@
 replicaCount: 1
 
 images:
-  ccng: cloudfoundry/cloud-controller-ng:33f461df533c7174241b00759bb7622ea37c58c7@sha256:0bc1b2b3e0c2fcfbd76d7c4a311b728a240b928fcd8d2b2b1e057de88a0adacf
+  ccng: cloudfoundry/cloud-controller-ng:82dbf8abeb96c0c28c5d75621c8f3c9746666108@sha256:ee68b1b8b0fe53be2e41a8cf13bb01ad49590bfb1d58abff06a19105b79d273c
   nginx: cloudfoundry/capi:nginx@sha256:51e4e48c457d5cb922cf0f569e145054e557e214afa78fb2b312a39bb2f938b6
   capi_kpack_watcher: cloudfoundry/capi-kpack-watcher:956150dae0a95dcdf3c1f29c23c3bf11db90f7a0@sha256:67125e0d3a4026a23342d80e09aad9284c08ab4f7b3d9a993ae66e403d5d0796
   statsd_exporter: prom/statsd-exporter:v0.15.0@sha256:e3174186628b401e4a441b78513ba06e957644267332436be0c77dd7af9bdddc

--- a/vendir.lock.yml
+++ b/vendir.lock.yml
@@ -10,8 +10,8 @@ directories:
       sha: 9f70c276584718fbc4a72a0ca3460774806a0b15
     path: github.com/cloudfoundry/cf-k8s-networking
   - git:
-      commitTitle: Add statsd-exporter container to capi-api-server...
-      sha: 423f8719927f0b6155de26f500f1ffdbd0ef9b86
+      commitTitle: Bump default CCNG docker image reference...
+      sha: e6dc30dce7bb69421075650e2524d4c4e8433217
     path: github.com/cloudfoundry/capi-k8s-release
   - githubRelease:
       url: https://api.github.com/repos/cloudfoundry/cf-k8s-logging/releases/24864777

--- a/vendir.yml
+++ b/vendir.yml
@@ -22,7 +22,7 @@ directories:
   - path: github.com/cloudfoundry/capi-k8s-release
     git:
       url: https://github.com/cloudfoundry/capi-k8s-release
-      ref: 423f8719927f0b6155de26f500f1ffdbd0ef9b86
+      ref: e6dc30dce7bb69421075650e2524d4c4e8433217
     includePaths:
     - templates/**/*
     - values.yml


### PR DESCRIPTION
```
Bump capi-k8s-release:
   e6dc30d Jaskanwal Pawar: Bump default CCNG docker image reference
   e861b64 Jaskanwal Pawar: Increase frequency of diego_sync for cf6+v2 push
   423f871 Chris Selzo: Add statsd-exporter container to capi-api-server
   00ac3ec Chris Selzo: Bump CC source to fix `cf6 push`
   97f0fbe Aakash Shah: Update build script to account for new Dockerfile location
   64c2dab Renee Chu: Copy watcher source code to eventual image
   a8b1df9 Aakash Shah: Update Dockerfile to reflect that watcher source code is within repo's `src/capi
   4cd4f8f Renee Chu: Move watcher Dockerfile to be under watcher directory
   c41f5bf Renee Chu: Create symlink to watcher Dockerfile

Bump cloud_controller_ng:
   82dbf8abe Chris Selzo: Add kpack lifecycle support in process sync
   6a6638497 George Blue: V3 client can create a managed service instance
   87ec71de5 Weyman Fung: line up metadata info in spaces doc according to style
   6ad4645bc Mona Mohebbi: Update docs for space resourse
   064869cc1 Marcela Campo: Add service plan and offering and broker as an included fields resource when
   14b24b756 Reid Mitchell: v3: Add link to apply-manifest endpoint on space resource
   68a90af88 Chris Selzo: Remove `legacy_webish` coercion
   32dc7a824 Reid Mitchell: v3: Make space manifest docs no longer experimental
   7d1baa0c4 Reid Mitchell: Update space manifest docs to match v3 resources
   eb3cd61a9 Sarah Weinstein: v3: Space manifests validates manifest schema version
   3399ff09f Weyman Fung: V3: Deprecate V2's Security Groups in docs
   46aca32b2 Weyman Fung: V3: Security groups → not experimental: docs & /v3
   28ffd7bb8 Mona Mohebbi: V3: Docs: Security Group clarifications
   2b3951d12 Mona Mohebbi: V3: Docs: Update docs to have more specific language
   80766c930 Mona Mohebbi: Docs: V3: Upgrade Guide describes Security Groups changes
   190a762a7 George Blue: V3 client can create a user-provided service instance
   c6dd92a11 Marcela Campo: Add offerings and brokers names/guids to service instance list response
   c4369d856 Jaskanwal Pawar: fix broken dep locator-related test
   ff2e3441d Jaskanwal Pawar: stop caching kpack client
   ba0747567 Marcela Campo: fields for GET service instances list
```

[#171830993](https://www.pivotaltracker.com/story/show/171830993)

**Acceptance Steps**

Using cf6:

```
$ cf6 disable-feature-flag diego_docker
$ cf6 push catnip
```

@jspawar 
