### PR TITLE
bump `cfroutesync` image digest

### DIFF
--- a/config/values.yml
+++ b/config/values.yml
@@ -27,7 +27,7 @@ istio_static_ip: ""
 images:
   capi: ""
   nginx: ""
-  cfroutesync: "gcr.io/cf-networking-images/cf-k8s-networking/cfroutesync@sha256:758abd1b6144596cef74ad4805bc7e1a6055142cab5719f0d42d0321a14a190d"
+  cfroutesync: "gcr.io/cf-networking-images/cf-k8s-networking/cfroutesync@sha256:3b2b25614d6da572175a848003e379894b154dd719f2e77a2325b98ad857d416"
 
 system_certificate:
   #! Base64-encoded certificate for the wildcard


### PR DESCRIPTION
> _Please describe the change here._ 

This is a simple bump to the desired `cfroutesync` image to include recent changes such as:
- basing the image off of `cloudfoundry/run:tiny`
- reducing unnecessary requests to the Cloud Controller API (CAPI)


> Is there anything else of note that the reviewers should know about this change?

No

**Acceptance Steps**

_please provide a series of instructions (eg kubectl or cf cli commands) for how our Product Manager can verify that your changes were properly integrated_

**GIVEN** I have deployed a cloud foundry
**WHEN** I describe the cfroutesync deployment with `kubectl -n cf-system describe deployment/cfroutesync`
**THEN** I see the container spec specifies `gcr.io/cf-networking-images/cf-k8s-networking/cfroutesync@sha256:3b2b25614d6da572175a848003e379894b154dd719f2e77a2325b98ad857d416`


_Tag your pair, your PM, and/or team_
cc: @kauana 