### PR TITLE
Remove diego docker flag instruction

### DIFF
--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -175,13 +175,6 @@ Currently, we have tested the following two container registries:
    $ cf target -o test-org -s test-space
    ```
 
-1. Enable docker feature:
-   ```console
-   $ cf enable-feature-flag diego_docker
-   ```
-   
-   > This is a temporary requirement to enable cf-push. The team has plans to remove this requirement soon.
-
 1. Deploy a source code based app:
 
    ```console


### PR DESCRIPTION
Remove diego_docker flag instruction since we don't need that anymore.


**Acceptance Steps**

cf push without enabling Diego docker flag works.

_Tag your pair, your PM, and/or team_

> _It's helpful to tag a few other folks on your team or your team alias in case we need to follow up later._
