### PR TITLE
Update minikube instructions

### DIFF
--- a/docs/deploy-local.md
+++ b/docs/deploy-local.md
@@ -34,20 +34,16 @@ In addition to the Kubernetes version requirement in [Deploying CF for K8s](depl
 
 1. Start minikube using the docker driver:
    ```bash
-   $ minikube start --cpus=4 --memory=8g --kubernetes-version=1.15.7 --driver=docker
+   $ minikube start --cpus=4 --memory=8g --kubernetes-version=1.16.8 --driver=docker
    ```
 
-1. Follow the instructions in [Deploying CF for K8s](deploy.md).
-   * Include the [remove-resource-requirements.yml](../config-optional/remove-resource-requirements.yml)
-     overlay file in the set of templates to be deployed. This can be achieved by
-     using the following command instead of running the install-cf.sh script:
-     
-     ```bash
-     $ kapp deploy -a cf -f <(ytt -f config -f <cf_install_values_path> -f config-optional/remove-resource-requirements.yml)
-     ```
-   * Use `vcap.me` as the domain for the installation. This means that you do not have to
-    configure DNS for the domain.
-   
+1. Obtain minikube IP.
+   ```bash
+   $ minikube ip
+   <minikube ip>
+   ```
+   * The domain used for the installation will use this IP with the following format `<minikube ip>.nip.io`.
+
 1. Use minikube tunnel to expose the LoadBalancer service for the ingress
    gateway:
    ```bash
@@ -56,6 +52,22 @@ In addition to the Kubernetes version requirement in [Deploying CF for K8s](depl
    * This should be run in a separate terminal as this will block.
    * The `install-cf.sh` script will not exit successfully until this command is
      run to allow minikube to create the LoadBalancer service.
+
+1. Follow the instructions in [Deploying CF for K8s](deploy.md).
+   * Use `<minikube ip>.nip.io` as the domain for the installation. This means that you do not have to
+     configure DNS for the domain.
+   * Include the [remove-resource-requirements.yml](../config-optional/remove-resource-requirements.yml)
+     overlay file in the set of templates to be deployed. This can be achieved by
+     using the following command instead of running the install-cf.sh script:
+     
+     ```bash
+     $ kapp deploy -a cf -f <(ytt -f config -f <cf_install_values_path> -f config-optional/remove-resource-requirements.yml)
+     ```
+
+1. You will be able to target your CF CLI to point to the new CF instance
+   ```console
+   $ cf api --skip-ssl-validation https://api.<minikube ip>.nip.io
+   ```
 
 1. To access the kubelet's docker engine, run:
    ```bash


### PR DESCRIPTION
The previous minikube instructions didn't work with `vcap.me` as the domain. I've updated the instructions to use [nip.io](https://nip.io/).

---


- Make sure this PR is based off the `develop` branch
- Checkout the [contributing guidelines](https://github.com/cloudfoundry/cf-for-k8s/blob/develop/docs/contributing.md)
- Include any links to related PRs, issues, stories, slack discussions, etc... that will help establish context.
- Is there anything else of note that the reviewers should know about this change?

**Acceptance Steps**

_please provide a series of instructions (eg kubectl or cf cli commands) for how our Product Manager can verify that your changes were properly integrated_


_Tag your pair, your PM, and/or team_

> _It's helpful to tag a few other folks on your team or your team alias in case we need to follow up later._
