### PR TITLE
Db migration with sidecars

### DIFF
--- a/config/_ytt_lib/github.com/cloudfoundry/capi-k8s-release/LICENSE
+++ b/config/_ytt_lib/github.com/cloudfoundry/capi-k8s-release/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/config/_ytt_lib/github.com/cloudfoundry/capi-k8s-release/templates/api_server_deployment.yml
+++ b/config/_ytt_lib/github.com/cloudfoundry/capi-k8s-release/templates/api_server_deployment.yml
@@ -25,14 +25,6 @@ spec:
     spec:
       #@ if/end data.values.imagePullSecrets:
       imagePullSecrets: #@ data.values.imagePullSecrets
-      initContainers:
-        - name: pre-start
-          image: #@ data.values.images.ccng
-          imagePullPolicy: Always
-          command: ['bundle', 'exec', 'rake', 'db:setup_database']
-          volumeMounts:
-          - name: cloud-controller-ng-yaml
-            mountPath: /config
       containers:
         - name: capi-api-server
           image: #@ data.values.images.ccng

--- a/config/_ytt_lib/github.com/cloudfoundry/capi-k8s-release/templates/ccdb-migrate-job.yaml
+++ b/config/_ytt_lib/github.com/cloudfoundry/capi-k8s-release/templates/ccdb-migrate-job.yaml
@@ -1,0 +1,26 @@
+#@ load("@ytt:data", "data")
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: ccdb-migrate
+  namespace: #@ data.values.system_namespace
+spec:
+  template:
+    metadata:
+      annotations:
+        sidecar.istio.io/inject: "false"
+    spec:
+      containers:
+      - name: run-migrations
+        image: #@ data.values.images.ccng
+        imagePullPolicy: Always
+        command: ['bundle', 'exec', 'rake', 'db:setup_database']
+        volumeMounts:
+        - name: cloud-controller-ng-yaml
+          mountPath: /config
+      restartPolicy: Never
+      volumes:
+      - name: cloud-controller-ng-yaml
+        configMap:
+          name: cloud-controller-ng-yaml

--- a/config/_ytt_lib/github.com/cloudfoundry/capi-k8s-release/templates/ccdb-migrate-job.yaml
+++ b/config/_ytt_lib/github.com/cloudfoundry/capi-k8s-release/templates/ccdb-migrate-job.yaml
@@ -5,6 +5,8 @@ kind: Job
 metadata:
   name: ccdb-migrate
   namespace: #@ data.values.system_namespace
+  annotations:
+    kapp.k14s.io/update-strategy: fallback-on-replace
 spec:
   template:
     spec:

--- a/config/_ytt_lib/github.com/cloudfoundry/capi-k8s-release/templates/ccdb-migrate-job.yaml
+++ b/config/_ytt_lib/github.com/cloudfoundry/capi-k8s-release/templates/ccdb-migrate-job.yaml
@@ -7,15 +7,17 @@ metadata:
   namespace: #@ data.values.system_namespace
 spec:
   template:
-    metadata:
-      annotations:
-        sidecar.istio.io/inject: "false"
     spec:
       containers:
       - name: run-migrations
         image: #@ data.values.images.ccng
         imagePullPolicy: Always
-        command: ['bundle', 'exec', 'rake', 'db:setup_database']
+        command: ["/bin/bash", "-c"]
+        args:
+        - |
+          bundle exec rake db:wait_for_istio && \
+          bundle exec rake db:setup_database && \
+          bundle exec rake db:terminate_istio
         volumeMounts:
         - name: cloud-controller-ng-yaml
           mountPath: /config

--- a/config/_ytt_lib/github.com/cloudfoundry/capi-k8s-release/templates/ccng-config.lib.yml
+++ b/config/_ytt_lib/github.com/cloudfoundry/capi-k8s-release/templates/ccng-config.lib.yml
@@ -10,7 +10,7 @@ readiness_port:
   deployment_updater: 4445
   clock: 4446
 
-internal_service_hostname: cloud_controller_ng
+internal_service_hostname: #@ "capi.{}.svc.cluster.local".format(data.values.system_namespace)
 
 pid_filename: /cloud_controller_ng/cloud_controller_ng.pid
 newrelic_enabled: false

--- a/config/_ytt_lib/github.com/cloudfoundry/capi-k8s-release/templates/cf-autodetect-builder.yml
+++ b/config/_ytt_lib/github.com/cloudfoundry/capi-k8s-release/templates/cf-autodetect-builder.yml
@@ -11,4 +11,4 @@ metadata:
   name: cf-autodetect-builder
   namespace: #@ data.values.staging_namespace
 spec:
-  image: cloudfoundry/cnb:0.0.55-bionic
+  image: #@ data.values.images.cf_autodetect_builder

--- a/config/_ytt_lib/github.com/cloudfoundry/capi-k8s-release/values.yml
+++ b/config/_ytt_lib/github.com/cloudfoundry/capi-k8s-release/values.yml
@@ -3,7 +3,7 @@
 replicaCount: 1
 
 images:
-  ccng: cloudfoundry/cloud-controller-ng:c3b2d6dcb6a084d04f3480e4995106474dd481c3@sha256:0afeeb0d2eb10367e06e652c6720e23145dbf7f9af854f8fb403c2385231c8eb
+  ccng: cloudfoundry/cloud-controller-ng:d1cf638f6b7bf5038073c51b8661e68aede859b0@sha256:f5bda8e6e15bf84d6bcc4baf820ffc19cf85c1cff5409c2fd549af9d20a3fccd
   nginx: cloudfoundry/capi:nginx@sha256:51e4e48c457d5cb922cf0f569e145054e557e214afa78fb2b312a39bb2f938b6
   capi_kpack_watcher: cloudfoundry/capi-kpack-watcher:956150dae0a95dcdf3c1f29c23c3bf11db90f7a0@sha256:67125e0d3a4026a23342d80e09aad9284c08ab4f7b3d9a993ae66e403d5d0796
   statsd_exporter: prom/statsd-exporter:v0.15.0@sha256:e3174186628b401e4a441b78513ba06e957644267332436be0c77dd7af9bdddc

--- a/config/_ytt_lib/github.com/cloudfoundry/capi-k8s-release/values.yml
+++ b/config/_ytt_lib/github.com/cloudfoundry/capi-k8s-release/values.yml
@@ -3,10 +3,11 @@
 replicaCount: 1
 
 images:
-  ccng: cloudfoundry/cloud-controller-ng:82dbf8abeb96c0c28c5d75621c8f3c9746666108@sha256:ee68b1b8b0fe53be2e41a8cf13bb01ad49590bfb1d58abff06a19105b79d273c
+  ccng: cloudfoundry/cloud-controller-ng:c3b2d6dcb6a084d04f3480e4995106474dd481c3@sha256:0afeeb0d2eb10367e06e652c6720e23145dbf7f9af854f8fb403c2385231c8eb
   nginx: cloudfoundry/capi:nginx@sha256:51e4e48c457d5cb922cf0f569e145054e557e214afa78fb2b312a39bb2f938b6
   capi_kpack_watcher: cloudfoundry/capi-kpack-watcher:956150dae0a95dcdf3c1f29c23c3bf11db90f7a0@sha256:67125e0d3a4026a23342d80e09aad9284c08ab4f7b3d9a993ae66e403d5d0796
   statsd_exporter: prom/statsd-exporter:v0.15.0@sha256:e3174186628b401e4a441b78513ba06e957644267332436be0c77dd7af9bdddc
+  cf_autodetect_builder: cloudfoundry/cnb:0.0.94-bionic@sha256:5b03a853e636b78c44e475bbc514e2b7b140cc41cca8ab907e9753431ae8c0b0
 system_namespace: cf-system
 workloads_namespace: cf-workloads
 staging_namespace: cf-workloads-staging

--- a/config/postgres.yml
+++ b/config/postgres.yml
@@ -87,17 +87,3 @@ data:
     psql -U postgres -d (@= uaadb.name @) -c "CREATE EXTENSION citext"
 
 --- #@ template.replace(overlay.apply(library.get("postgres").eval(), add_cf_db_namespace()))
---- #! explanation: the capi-db's sidecar needs to accept plain text connections from capi's init container.
-    #! see https://github.com/cloudfoundry/capi-k8s-release/issues/12
-apiVersion: "authentication.istio.io/v1alpha1"
-kind: "Policy"
-metadata:
-  name: "cf-db-allow-plaintext"
-  namespace: "cf-db"
-spec:
-  targets:
-  - name: cf-db-postgresql
-  - name: cf-db-postgresql-headless
-  peers:
-  - mtls:
-      mode: PERMISSIVE

--- a/vendir.lock.yml
+++ b/vendir.lock.yml
@@ -10,8 +10,8 @@ directories:
       sha: 9f70c276584718fbc4a72a0ca3460774806a0b15
     path: github.com/cloudfoundry/cf-k8s-networking
   - git:
-      commitTitle: Merge branch 'db-migration-with-sidecars'
-      sha: 86f091d878861e88ad20aabe38e8439cd89c7641
+      commitTitle: Add Job update strategy "fallback-on-replace" per Dmitiry's suggestion...
+      sha: 4d461bdb050464d93a0252b519210b4f42322c8f
     path: github.com/cloudfoundry/capi-k8s-release
   - githubRelease:
       url: https://api.github.com/repos/cloudfoundry/cf-k8s-logging/releases/24864777

--- a/vendir.lock.yml
+++ b/vendir.lock.yml
@@ -10,8 +10,8 @@ directories:
       sha: 9f70c276584718fbc4a72a0ca3460774806a0b15
     path: github.com/cloudfoundry/cf-k8s-networking
   - git:
-      commitTitle: Bump default CCNG docker image reference...
-      sha: e6dc30dce7bb69421075650e2524d4c4e8433217
+      commitTitle: Merge branch 'db-migration-with-sidecars'
+      sha: 86f091d878861e88ad20aabe38e8439cd89c7641
     path: github.com/cloudfoundry/capi-k8s-release
   - githubRelease:
       url: https://api.github.com/repos/cloudfoundry/cf-k8s-logging/releases/24864777

--- a/vendir.yml
+++ b/vendir.yml
@@ -22,7 +22,7 @@ directories:
   - path: github.com/cloudfoundry/capi-k8s-release
     git:
       url: https://github.com/cloudfoundry/capi-k8s-release
-      ref: e6dc30dce7bb69421075650e2524d4c4e8433217
+      ref: 86f091d878861e88ad20aabe38e8439cd89c7641
     includePaths:
     - templates/**/*
     - values.yml

--- a/vendir.yml
+++ b/vendir.yml
@@ -22,7 +22,7 @@ directories:
   - path: github.com/cloudfoundry/capi-k8s-release
     git:
       url: https://github.com/cloudfoundry/capi-k8s-release
-      ref: 86f091d878861e88ad20aabe38e8439cd89c7641
+      ref: 4d461bdb050464d93a0252b519210b4f42322c8f
     includePaths:
     - templates/**/*
     - values.yml


### PR DESCRIPTION

> _Please describe the change here._ 

- CC's DB migration logic should now support strict mTLS with the DB's
sidecars
- Create one kpack image per app not build 
- Merge pull request #30 from evanfarrar/add-license -- adds apache license
- Fix internal_hostname for CC API
- Revert "Opi docker custom port" (cloudfoundry/revert-1558-opi-docker-custom-port)
- bump ccng to include the above changes

Tracker Stories:
https://www.pivotaltracker.com/story/show/171388449
https://www.pivotaltracker.com/story/show/171851581
https://www.pivotaltracker.com/story/show/172212215
https://www.pivotaltracker.com/story/show/172246299
https://www.pivotaltracker.com/story/show/172322578

---


cc: @reneighbor @jspawar @selzoc @aashah @sethboyles 
