### PR TITLE
Ignore tmp

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 **/*.tfstate
 **/*.tfstate.backup
 **/.terraform/
+/tmp


### PR DESCRIPTION
Currently the docs ask you to create files in `/tmp/...` but it is also common for people to assume they can use a local `tmp/` inside the project. This PR adds `tmp` to the gitignore.