### PR TITLE
Pin cfroutesync image digest in cf-k8s-networking

### DIFF
--- a/config/_ytt_lib/github.com/cloudfoundry/cf-k8s-networking/config/values.yaml
+++ b/config/_ytt_lib/github.com/cloudfoundry/cf-k8s-networking/config/values.yaml
@@ -7,7 +7,7 @@ systemNamespace: cf-system
 workloadsNamespace: cf-workloads
 
 cfroutesync:
-  image: gcr.io/cf-networking-images/cf-k8s-networking/cfroutesync:latest
+  image: gcr.io/cf-networking-images/cf-k8s-networking/cfroutesync@sha256:ce8f2571251afe12810a37628865233e389ade3c086757e50ed9c1b309bbfad3
 
   ccCA: 'base64_encoded_cloud_controller_ca'
   ccBaseURL: 'https://api.example.com'
@@ -15,6 +15,9 @@ cfroutesync:
   uaaBaseURL: 'https://uaa.example.com'
   clientName: 'uaaClientName'
   clientSecret: 'base64_encoded_uaaClientSecret'
+
+routecontroller:
+  image: gcr.io/cf-networking-images/cf-k8s-networking/routecontroller@sha256:d53b02ed6b1303ee57c64fa8a688e12a2f2f4c1554917262c26d03543a76a136
 
 service:
   externalPort: 80

--- a/config/values.yml
+++ b/config/values.yml
@@ -27,7 +27,7 @@ istio_static_ip: ""
 images:
   capi: ""
   nginx: ""
-  cfroutesync: "gcr.io/cf-networking-images/cf-k8s-networking/cfroutesync@sha256:3b2b25614d6da572175a848003e379894b154dd719f2e77a2325b98ad857d416"
+  cfroutesync: ""
 
 system_certificate:
   #! Base64-encoded certificate for the wildcard

--- a/vendir.lock.yml
+++ b/vendir.lock.yml
@@ -6,8 +6,8 @@ directories:
       sha: eacb75b4d562e3fb158eb2147a6768407ab374d4
     path: github.com/GoogleCloudPlatform/metacontroller
   - git:
-      commitTitle: 'feat: Change DaemonSet''s maxUnavailable to one...'
-      sha: 9f70c276584718fbc4a72a0ca3460774806a0b15
+      commitTitle: Remove hub from istio-values...
+      sha: c31566adbe6f3c3f110aee35e91d314965f99315
     path: github.com/cloudfoundry/cf-k8s-networking
   - git:
       commitTitle: Add Job update strategy "fallback-on-replace" per Dmitiry's suggestion...

--- a/vendir.yml
+++ b/vendir.yml
@@ -14,8 +14,9 @@ directories:
   - path: github.com/cloudfoundry/cf-k8s-networking
     git:
       url: https://github.com/cloudfoundry/cf-k8s-networking
-      ref: 9f70c276584718fbc4a72a0ca3460774806a0b15
+      ref: c31566adbe6f3c3f110aee35e91d314965f99315
     includePaths:
+    - config/*
     - cfroutesync/crds/**/*
     - config/cfroutesync/**/*
     - config/istio-generated/**/*


### PR DESCRIPTION
[#172087151](https://www.pivotaltracker.com/story/show/172087151)

Related to [this issue](https://github.com/cloudfoundry/cf-k8s-networking/issues/36), we now pin the cfroutesync image digest in cf-k8s-networking, so we can remove the override for the image url in cf-for-k8s values. 

**Acceptance Steps**
**GIVEN** I have deployed a cloud foundry
**WHEN** I describe the cfroutesync deployment with kubectl -n cf-system describe deployment/cfroutesync
**THEN** I see the container spec specifies `gcr.io/cf-networking-images/cf-k8s-networking/cfroutesync@sha256:c54be4b33f6a8a7a6dc24ee74cff468b3484411b64182d866a5be52cd67425a4`


_Tag your pair, your PM, and/or team_

@christianang 

> _It's helpful to tag a few other folks on your team or your team alias in case we need to follow up later._
