### PR TITLE
Add validation with kubeval

### DIFF
--- a/ci/dockerfiles/cf-for-k8s-ci/Dockerfile
+++ b/ci/dockerfiles/cf-for-k8s-ci/Dockerfile
@@ -15,6 +15,10 @@ RUN bosh_cli_version=$(curl --silent "https://api.github.com/repos/cloudfoundry/
     curl -LO https://github.com/cloudfoundry/bosh-cli/releases/download/v${bosh_cli_version}/bosh-cli-${bosh_cli_version}-linux-amd64 && \
     chmod +x ./bosh-cli-${bosh_cli_version}-linux-amd64 && \
     mv ./bosh-cli-${bosh_cli_version}-linux-amd64 /usr/local/bin/bosh
+RUN wget https://github.com/instrumenta/kubeval/releases/latest/download/kubeval-linux-amd64.tar.gz && \
+    tar xf kubeval-linux-amd64.tar.gz && \
+    mv kubeval /usr/local/bin
+
 
 # ginkgo
 RUN export GO_TAR=go1.13.8.linux-amd64.tar.gz && \

--- a/config/0-min-kapp-version.yml
+++ b/config/0-min-kapp-version.yml
@@ -1,5 +1,7 @@
 ---
 apiVersion: kapp.k14s.io/v1alpha1
 kind: Config
+metadata:
+  name: kapp-version
 
 minimumRequiredVersion: 0.26.0

--- a/config/kapp-rebase-rules.yml
+++ b/config/kapp-rebase-rules.yml
@@ -2,8 +2,7 @@
 apiVersion: kapp.k14s.io/v1alpha1
 kind: Config
 metadata:
-  name: "test"
-  namespace: "test"
+  name: "kapp-config"
 rebaseRules:
 - path: [metadata, annotations, pv.kubernetes.io/bind-completed]
   type: copy

--- a/config/kapp-rebase-rules.yml
+++ b/config/kapp-rebase-rules.yml
@@ -1,7 +1,9 @@
 ---
 apiVersion: kapp.k14s.io/v1alpha1
 kind: Config
-
+metadata:
+  name: "test"
+  namespace: "test"
 rebaseRules:
 - path: [metadata, annotations, pv.kubernetes.io/bind-completed]
   type: copy

--- a/tests/configs/configs_test.go
+++ b/tests/configs/configs_test.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"time"
 
@@ -15,44 +16,47 @@ import (
 	. "github.com/onsi/gomega/gexec"
 )
 
-var _ = Describe("Optional Configs", func() {
-	Describe("Check optional configs", func() {
-		var (
-			args     []string
-			baseHash [16]byte
-			repoDir  string
+var _ = Describe("Configs", func() {
+	var (
+		args          []string
+		baseHash      [16]byte
+		repoDir       string
+		templatedPath string = "/tmp/cf-for-k8s.yml"
+	)
+	BeforeEach(func() {
+		currentDirectory, err := os.Getwd()
+		repoDir = filepath.Dir(filepath.Dir(currentDirectory))
+
+		command := exec.Command(filepath.Join(repoDir, "hack", "generate-values.sh"),
+			"--cf-domain", "dummy-domain",
 		)
+		valuesFile, err := os.Create("/tmp/dummy-domain-values.yml")
+		Expect(err).NotTo(HaveOccurred())
+		defer valuesFile.Close()
+		command.Stdout = valuesFile
 
-		BeforeEach(func() {
-			currentDirectory, err := os.Getwd()
-			repoDir = filepath.Dir(filepath.Dir(currentDirectory))
+		err = command.Start()
+		Expect(err).NotTo(HaveOccurred())
 
-			command := exec.Command(filepath.Join(repoDir, "hack", "generate-values.sh"),
-				"--cf-domain", "dummy-domain",
-			)
-			outfile, err := os.Create("/tmp/dummy-domain-values.yml")
-			Expect(err).NotTo(HaveOccurred())
-			defer outfile.Close()
-			command.Stdout = outfile
+		print("generating fake values...")
+		command.Wait()
+		print(" [done]\n")
 
-			err = command.Start()
-			Expect(err).NotTo(HaveOccurred())
-
-			print("generating fake values...")
-			command.Wait()
-			print(" [done]\n")
-
-			args = []string{
-				"-f", "../../config",
-				"-f", "/tmp/dummy-domain-values.yml",
-			}
-			command = exec.Command("ytt", args...)
-			session, err := Start(command, ioutil.Discard, GinkgoWriter)
-			Expect(err).NotTo(HaveOccurred())
-			Eventually(session, 10*time.Second).Should(Exit(0),
-				fmt.Sprintf("ytt failed on base with output %s", session.Err.Contents()))
-			baseHash = md5.Sum(session.Out.Contents())
-		})
+		args = []string{
+			"-f", "../../config",
+			"-f", "/tmp/dummy-domain-values.yml",
+		}
+		outfile, err := os.Create(templatedPath)
+		Expect(err).NotTo(HaveOccurred())
+		defer outfile.Close()
+		command = exec.Command("ytt", args...)
+		session, err := Start(command, outfile, GinkgoWriter)
+		Expect(err).NotTo(HaveOccurred())
+		Eventually(session, 10*time.Second).Should(Exit(0),
+			fmt.Sprintf("ytt failed on base with output %s", session.Err.Contents()))
+		baseHash = md5.Sum(session.Out.Contents())
+	})
+	Describe("Check optional configs", func() {
 
 		It("should load each optional config file", func() {
 			currentDirectory, err := os.Getwd()
@@ -85,4 +89,22 @@ var _ = Describe("Optional Configs", func() {
 			Expect(count).To(BeNumerically(">=", 1))
 		})
 	})
+	When("validating with kubeval", func() {
+		It("should pass", func() {
+			command := exec.Command("kubeval", "--strict", "--ignore-missing-schemas", "--skip-kinds", "Config", templatedPath)
+			session, err := Start(command, ioutil.Discard, GinkgoWriter)
+			Expect(err).NotTo(HaveOccurred())
+			session.Wait(10 * time.Second)
+			stdOut := removeExpectedKubevalOutput(session.Out.Contents())
+			Eventually(session).Should(Exit(0),
+				fmt.Sprintf("kubeval failed with output: %s\n", stdOut))
+		})
+	})
 })
+
+func removeExpectedKubevalOutput(output []byte) []byte {
+	reMissingSchema := regexp.MustCompile("(?m)[\r\n]+^.*not validated against a schema$")
+	rePassed := regexp.MustCompile("(?m)[\r\n]+^PASS - .*$")
+	res := reMissingSchema.ReplaceAll(output, []byte(""))
+	return rePassed.ReplaceAll(res, []byte(""))
+}

--- a/tests/configs/configs_test.go
+++ b/tests/configs/configs_test.go
@@ -93,9 +93,9 @@ var _ = Describe("Configs", func() {
 	When("validating with kubeval", func() {
 		It("should pass", func() {
 			for _, v := range getSupportedK8Versions() {
-				By(fmt.Sprintf("checking version '%s'", v))
-				print("kubeval", "--strict", "--ignore-missing-schemas", "--skip-kinds", "Config", "-v", v, templatedPath)
-				command := exec.Command("kubeval", "--strict", "--ignore-missing-schemas", "--skip-kinds", "Config", "-v", v, templatedPath)
+				By(fmt.Sprintf("checking with K8s version '%s'", v))
+				command := exec.Command("kubeval", "--strict", "--ignore-missing-schemas", "-v", v, templatedPath)
+				fmt.Println(command.Args)
 				session, err := Start(command, ioutil.Discard, GinkgoWriter)
 				Expect(err).NotTo(HaveOccurred())
 				session.Wait(10 * time.Second)

--- a/tests/configs/go.mod
+++ b/tests/configs/go.mod
@@ -6,4 +6,5 @@ require (
 	github.com/cloudfoundry-incubator/cf-test-helpers v1.0.0
 	github.com/onsi/ginkgo v1.11.0
 	github.com/onsi/gomega v1.7.1
+	gopkg.in/yaml.v1 v1.0.0-20140924161607-9f9df34309c0
 )

--- a/tests/configs/go.sum
+++ b/tests/configs/go.sum
@@ -23,5 +23,6 @@ gopkg.in/fsnotify.v1 v1.4.7 h1:xOHLXZwVvI9hhs+cLKq5+I5onOuwQLhQwiu63xxlHs4=
 gopkg.in/fsnotify.v1 v1.4.7/go.mod h1:Tz8NjZHkW78fSQdbUxIjBTcgA1z1m8ZHf0WmKUhAMys=
 gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 h1:uRGJdciOHaEIrze2W8Q3AKkepLTh2hOroT7a+7czfdQ=
 gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7/go.mod h1:dt/ZhP58zS4L8KSrWDmTeBkI65Dw0HsyUHuEVlX15mw=
+gopkg.in/yaml.v1 v1.0.0-20140924161607-9f9df34309c0/go.mod h1:WDnlLJ4WF5VGsH/HVa3CI79GS0ol3YnhVnKP89i0kNg=
 gopkg.in/yaml.v2 v2.2.4 h1:/eiJrUcujPVeJ3xlSWaiNi3uSVmDGBK1pDHUHAnao1I=
 gopkg.in/yaml.v2 v2.2.4/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=


### PR DESCRIPTION
Add a `--validate` flag to install-cf.sh so we can validate k8s resources.
Use `--validate` to test PRs.

Solves https://github.com/k14s/kapp/issues/98  

~This is WIP because kapp's `Config` resource does not play well with kubeval.~


**Acceptance Steps**

Introduce an error somewhere in the `config` folder and execute `install-cf.sh --validate` to see if it is caught.
