### PR TITLE
Include Route CRD

### DIFF
--- a/config/_ytt_lib/github.com/cloudfoundry/cf-k8s-networking/config/crd/networking.cloudfoundry.org_routes.yaml
+++ b/config/_ytt_lib/github.com/cloudfoundry/cf-k8s-networking/config/crd/networking.cloudfoundry.org_routes.yaml
@@ -1,0 +1,129 @@
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.2.4
+  creationTimestamp: null
+  name: routes.networking.cloudfoundry.org
+spec:
+  group: networking.cloudfoundry.org
+  names:
+    kind: Route
+    listKind: RouteList
+    plural: routes
+    singular: route
+  scope: Namespaced
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      description: Route is the Schema for the routes API
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: RouteSpec defines the desired state of Route
+          properties:
+            destinations:
+              items:
+                properties:
+                  app:
+                    properties:
+                      guid:
+                        type: string
+                      process:
+                        properties:
+                          type:
+                            type: string
+                        required:
+                        - type
+                        type: object
+                    required:
+                    - guid
+                    - process
+                    type: object
+                  guid:
+                    type: string
+                  port:
+                    type: integer
+                  selector:
+                    properties:
+                      matchLabels:
+                        additionalProperties:
+                          type: string
+                        type: object
+                    required:
+                    - matchLabels
+                    type: object
+                  weight:
+                    type: integer
+                required:
+                - app
+                - guid
+                - port
+                - selector
+                type: object
+              type: array
+            domain:
+              properties:
+                internal:
+                  type: boolean
+                name:
+                  type: string
+              required:
+              - internal
+              - name
+              type: object
+            host:
+              type: string
+            path:
+              type: string
+            url:
+              type: string
+          required:
+          - destinations
+          - domain
+          - host
+          - url
+          type: object
+        status:
+          description: RouteStatus defines the observed state of Route
+          properties:
+            conditions:
+              items:
+                properties:
+                  status:
+                    type: boolean
+                  type:
+                    type: string
+                required:
+                - status
+                - type
+                type: object
+              type: array
+          required:
+          - conditions
+          type: object
+      type: object
+  version: v1alpha1
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/config/_ytt_lib/github.com/cloudfoundry/cf-k8s-networking/config/values.yaml
+++ b/config/_ytt_lib/github.com/cloudfoundry/cf-k8s-networking/config/values.yaml
@@ -7,7 +7,7 @@ systemNamespace: cf-system
 workloadsNamespace: cf-workloads
 
 cfroutesync:
-  image: gcr.io/cf-networking-images/cf-k8s-networking/cfroutesync:latest
+  image: gcr.io/cf-networking-images/cf-k8s-networking/cfroutesync@sha256:ce8f2571251afe12810a37628865233e389ade3c086757e50ed9c1b309bbfad3
 
   ccCA: 'base64_encoded_cloud_controller_ca'
   ccBaseURL: 'https://api.example.com'
@@ -15,6 +15,9 @@ cfroutesync:
   uaaBaseURL: 'https://uaa.example.com'
   clientName: 'uaaClientName'
   clientSecret: 'base64_encoded_uaaClientSecret'
+
+routecontroller:
+  image: gcr.io/cf-networking-images/cf-k8s-networking/routecontroller@sha256:d53b02ed6b1303ee57c64fa8a688e12a2f2f4c1554917262c26d03543a76a136
 
 service:
   externalPort: 80

--- a/config/values.yml
+++ b/config/values.yml
@@ -27,7 +27,7 @@ istio_static_ip: ""
 images:
   capi: ""
   nginx: ""
-  cfroutesync: "gcr.io/cf-networking-images/cf-k8s-networking/cfroutesync@sha256:3b2b25614d6da572175a848003e379894b154dd719f2e77a2325b98ad857d416"
+  cfroutesync: ""
 
 system_certificate:
   #! Base64-encoded certificate for the wildcard

--- a/vendir.lock.yml
+++ b/vendir.lock.yml
@@ -6,8 +6,8 @@ directories:
       sha: eacb75b4d562e3fb158eb2147a6768407ab374d4
     path: github.com/GoogleCloudPlatform/metacontroller
   - git:
-      commitTitle: 'feat: Change DaemonSet''s maxUnavailable to one...'
-      sha: 9f70c276584718fbc4a72a0ca3460774806a0b15
+      commitTitle: Remove hub from istio-values...
+      sha: c31566adbe6f3c3f110aee35e91d314965f99315
     path: github.com/cloudfoundry/cf-k8s-networking
   - git:
       commitTitle: Add Job update strategy "fallback-on-replace" per Dmitiry's suggestion...

--- a/vendir.yml
+++ b/vendir.yml
@@ -14,8 +14,9 @@ directories:
   - path: github.com/cloudfoundry/cf-k8s-networking
     git:
       url: https://github.com/cloudfoundry/cf-k8s-networking
-      ref: 9f70c276584718fbc4a72a0ca3460774806a0b15
+      ref: c31566adbe6f3c3f110aee35e91d314965f99315
     includePaths:
+    - config/*
     - cfroutesync/crds/**/*
     - config/cfroutesync/**/*
     - config/istio-generated/**/*

--- a/vendir.yml
+++ b/vendir.yml
@@ -19,6 +19,7 @@ directories:
     - config/*
     - cfroutesync/crds/**/*
     - config/cfroutesync/**/*
+    - config/crd/**/*
     - config/istio-generated/**/*
   - path: github.com/cloudfoundry/capi-k8s-release
     git:


### PR DESCRIPTION
This PR includes the Route CRD that will be referenced by the Cloud Controller and the future routecontroller component from the cf-k8s-networking team.

---

This PR is a follow-up PR to the bump made as part of #151 . Until that PR is merged, this diff will look messy and misleading. To see what we've added as part of just this PR before that is merged, click on [this link](https://github.com/cloudfoundry/cf-for-k8s/compare/pin-cfroutesync-digest...pr-include-route-crd).

See [this slack thread](https://cloudfoundry.slack.com/archives/CFX13JK7B/p1587675432112300) for more context on why this CRD is needed urgently. Basically, we won't be able to bump capi-k8s-release in cf-for-k8s until this CRD is available in cf-for-k8s. For broader context on the general routecontroller work, see this story: https://www.pivotaltracker.com/story/show/171826991.

This PR does not include any actual functional changes. It adds what is for the moment an unused CRD, but that foundation is needed for the route-controller work the Networking and CAPI teams are doing.

**Acceptance Steps**

`kubectl get crds` should return "routes.networking.cloudfoundry.org" in its list.

Thanks,
Jen & @sethboyles (CF-k8s Networking and CAPI)
