### PR TITLE
bump to UAA from 74.16 > 74.17

### DIFF
--- a/config/_ytt_lib/github.com/cloudfoundry/uaa/k8s/templates/deployment.star
+++ b/config/_ytt_lib/github.com/cloudfoundry/uaa/k8s/templates/deployment.star
@@ -1,11 +1,3 @@
-def spring_profiles(database_scheme):
-  if database_scheme in ["postgresql","mysql"]:
-    return database_scheme
-  else:
-    return "default,hsqldb"
-  end
-end
-
 config_dir = "/etc/config"
 
 java_opts_list = [

--- a/config/_ytt_lib/github.com/cloudfoundry/uaa/k8s/templates/deployment.yml
+++ b/config/_ytt_lib/github.com/cloudfoundry/uaa/k8s/templates/deployment.yml
@@ -1,5 +1,5 @@
 #@ load("@ytt:data", "data")
-#@ load("deployment.star", "java_opts", "spring_profiles", "config_dir")
+#@ load("deployment.star", "java_opts", "config_dir")
 
 #@ secrets_dir = "/etc/secrets"
 ---
@@ -35,7 +35,7 @@ spec:
         - name: JAVA_OPTS
           value: #@ java_opts()
         - name: spring_profiles
-          value: #@ spring_profiles(data.values.database.scheme)
+          value: #@ data.values.database.scheme or "hsqldb"
         - name: CLOUDFOUNDRY_CONFIG_PATH
           value: #@ config_dir
         - name: SECRETS_DIR
@@ -50,6 +50,10 @@ spec:
         - name: database-credentials-file
           mountPath: #@ "{}/database_credentials.yml".format(secrets_dir)
           subPath: database_credentials.yml
+          readOnly: true
+        - name: admin-client-credentials-file
+          mountPath: #@ "{}/admin_client_credentials.yml".format(secrets_dir)
+          subPath: admin_client_credentials.yml
           readOnly: true
         livenessProbe:
           httpGet:
@@ -74,3 +78,6 @@ spec:
         secret:
           optional: true
           secretName: uaa-database-credentials
+      - name: admin-client-credentials-file
+        secret:
+          secretName: uaa-admin-client-credentials

--- a/config/_ytt_lib/github.com/cloudfoundry/uaa/k8s/templates/secrets/admin_client_credentials.yml
+++ b/config/_ytt_lib/github.com/cloudfoundry/uaa/k8s/templates/secrets/admin_client_credentials.yml
@@ -1,0 +1,19 @@
+#@ load("@ytt:data", "data")
+#@ load("@ytt:yaml", "yaml")
+#@ load("@ytt:assert", "assert")
+
+#@ def admin_client_credentials():
+oauth:
+  clients:
+    admin:
+      secret: #@ data.values.admin.client_secret or assert.fail("admin.client_secret is required")
+#@ end
+
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: uaa-admin-client-credentials
+type: Opaque
+stringData:
+  admin_client_credentials.yml: #@ yaml.encode(admin_client_credentials())

--- a/config/_ytt_lib/github.com/cloudfoundry/uaa/k8s/templates/uaa.lib.yml
+++ b/config/_ytt_lib/github.com/cloudfoundry/uaa/k8s/templates/uaa.lib.yml
@@ -8,8 +8,8 @@ issuer:
 encryption:
   active_key_label: CHANGE-THIS-KEY
   encryption_keys:
-  - label: CHANGE-THIS-KEY
-    passphrase: CHANGEME
+    - label: CHANGE-THIS-KEY
+      passphrase: CHANGEME
 
 login:
   serviceProviderKey: |
@@ -72,4 +72,13 @@ smtp:
   port: #@ data.values.smtp.port
   starttls: #@ data.values.smtp.starttls
   from_address: #@ data.values.smtp.from_address
+
+oauth:
+  client:
+    override: true
+  clients:
+    admin:
+      authorized-grant-types: client_credentials
+      authorities: "clients.read,clients.write,clients.secret,uaa.admin,scim.read,scim.write,password.write"
+
 #@ end

--- a/config/_ytt_lib/github.com/cloudfoundry/uaa/k8s/templates/values/_values.yml
+++ b/config/_ytt_lib/github.com/cloudfoundry/uaa/k8s/templates/values/_values.yml
@@ -38,3 +38,6 @@ smtp:
   password: ~
   starttls: ~
   from_address: ~
+
+admin:
+  client_secret: ~

--- a/config/_ytt_lib/github.com/cloudfoundry/uaa/k8s/templates/values/image.yml
+++ b/config/_ytt_lib/github.com/cloudfoundry/uaa/k8s/templates/values/image.yml
@@ -1,3 +1,3 @@
 #@data/values
 ---
-image: "cfidentity/uaa@sha256:e3e6fb18edac235b22e8adb56467ab73a917d8a8f1a92c7b904e1ee0fd282d64"
+image: "cfidentity/uaa@sha256:9f1e7e399c96309935145624d1824b2c2bf93656fd9c4dcf1c593b55f98aa6a8"

--- a/config/uaa.yml
+++ b/config/uaa.yml
@@ -16,6 +16,9 @@
 #@ end
 
 #@ def uaa_values():
+admin:
+  client_secret: #@ data.values.uaa.admin_client_secret
+
 database:
   scheme: #@ data.values.uaa.database.adapter
   address: #@ uaa_db_host()
@@ -79,22 +82,9 @@ scim:
 
 #@overlay/match missing_ok=True
 oauth:
-  user:
-    authorities:
-      - openid
-      - scim.me
-      - cloud_controller.read
-      - cloud_controller.write
-      - cloud_controller_service_permissions.read
-      - password.write
-      - scim.userids
-      - uaa.user
-      - approvals.me
-      - oauth.approvals
-      - profile
-      - roles
-      - user_attributes
-      - uaa.offline_token
+  client:
+    override: true
+  #@overlay/match-child-defaults missing_ok=True
   clients:
     cf:
       id: cf
@@ -111,7 +101,6 @@ oauth:
       autoapprove:
       - openid
       id: admin
-      secret: #@ data.values.uaa.admin_client_secret
     #! TODO: each client should use different secrets!
     cf-k8s-networking:
       authorities: uaa.resource,cloud_controller.admin_read_only

--- a/vendir.lock.yml
+++ b/vendir.lock.yml
@@ -21,8 +21,8 @@ directories:
       sha: 614dbcd1a80512fb707f936067d8c498e3471682
     path: github.com/cloudfoundry/metric-proxy
   - git:
-      commitTitle: 'Merge pull request #1248 from cloudfoundry/dependabot/gradle/versions.springBootVersion-2.2.6.RELEASE'
-      sha: 20d4f7bb7c20b4987e8a9f6e2f6136b9d93c7b32
+      commitTitle: 'Merge pull request #1262 from cloudfoundry/dependabot/go_modules/k8s/k8s.io/api-0.18.1'
+      sha: 211c15994f39fde797a66c2dfd7e15dcad65924c
     path: github.com/cloudfoundry/uaa
   - githubRelease:
       url: https://api.github.com/repos/pivotal/kpack/releases/25016868

--- a/vendir.yml
+++ b/vendir.yml
@@ -42,7 +42,7 @@ directories:
   - path: github.com/cloudfoundry/uaa
     git:
       url: https://github.com/cloudfoundry/uaa
-      ref: 211c15994f39fde797a66c2dfd7e15dcad65924c # v74.17.0
+      ref: v74.17.0
     includePaths:
     - k8s/templates/**/*
     - k8s/values/default-values.yml

--- a/vendir.yml
+++ b/vendir.yml
@@ -45,7 +45,6 @@ directories:
       ref: v74.17.0
     includePaths:
     - k8s/templates/**/*
-    - k8s/values/default-values.yml
   - path: github.com/pivotal/kpack
     githubRelease:
       slug: pivotal/kpack

--- a/vendir.yml
+++ b/vendir.yml
@@ -42,7 +42,7 @@ directories:
   - path: github.com/cloudfoundry/uaa
     git:
       url: https://github.com/cloudfoundry/uaa
-      ref: 20d4f7bb7c20b4987e8a9f6e2f6136b9d93c7b32 # v74.16.0
+      ref: 211c15994f39fde797a66c2dfd7e15dcad65924c # v74.17.0
     includePaths:
     - k8s/templates/**/*
     - k8s/values/default-values.yml


### PR DESCRIPTION
I'm creating this PR to make it easy to share the changes we needed to make with the UAA team. (And to show the general process for bumping a component in cf-for-k8s.)

The [first commit](https://github.com/cloudfoundry/cf-for-k8s/commit/8cb3a6d3f9ecb32857b3a260d4efda4ec811de22) shows step 1: bumping the commit/release in `vendir.yml`
The [2nd commit](https://github.com/cloudfoundry/cf-for-k8s/commit/0e9c444a7bc99b4490adf551e4d89a18d3bd1f95) shows the changes that came in from running `vendir sync`
The [3rd commit](https://github.com/cloudfoundry/cf-for-k8s/commit/2c0019d49b2875a4e663dd9b0c407e409a091c73) shows the changes we needed to make to `config/uaa.yml` 

---


- Make sure this PR is based off the `develop` branch
- Checkout the [contributing guidelines](https://github.com/cloudfoundry/cf-for-k8s/blob/develop/docs/contributing.md)
- Include any links to related PRs, issues, stories, slack discussions, etc... that will help establish context.
- Is there anything else of note that the reviewers should know about this change?

I've shared with UAA folks on slack [here](https://cloudfoundry.slack.com/archives/C0FAEKGUQ/p1587582140098900?thread_ts=1587582140.098800&cid=C0FAEKGUQ)