### PR TITLE
Expose Istio Pilot metrics port in NetworkPolicy

### DIFF
--- a/config/_ytt_lib/github.com/cloudfoundry/cf-k8s-networking/config/istio-generated/xxx-generated-istio.yaml
+++ b/config/_ytt_lib/github.com/cloudfoundry/cf-k8s-networking/config/istio-generated/xxx-generated-istio.yaml
@@ -9851,6 +9851,7 @@ spec:
     - port: 15004
     - port: 15010
     - port: 15011
+    - port: 15014
 ---
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy

--- a/config/_ytt_lib/github.com/cloudfoundry/cf-k8s-networking/config/values.yaml
+++ b/config/_ytt_lib/github.com/cloudfoundry/cf-k8s-networking/config/values.yaml
@@ -7,7 +7,7 @@ systemNamespace: cf-system
 workloadsNamespace: cf-workloads
 
 cfroutesync:
-  image: gcr.io/cf-networking-images/cf-k8s-networking/cfroutesync@sha256:de15fb9d960ecd36082550ec7a24dcad12a63f7ca53d110fbb4c9c59eca9b544
+  image: gcr.io/cf-networking-images/cf-k8s-networking/cfroutesync@sha256:0459226037166b15d4a80f0c4a0be9a16d1cffb76c7dd9c7ad2efbe763e23c61
 
   ccCA: 'base64_encoded_cloud_controller_ca'
   ccBaseURL: 'https://api.example.com'
@@ -17,7 +17,7 @@ cfroutesync:
   clientSecret: 'base64_encoded_uaaClientSecret'
 
 routecontroller:
-  image: gcr.io/cf-networking-images/cf-k8s-networking/routecontroller@sha256:f2d76c155a89af005b3fe4c4186f4590b6f70560ef79d15cb0d62d805e4d79c7
+  image: gcr.io/cf-networking-images/cf-k8s-networking/routecontroller@sha256:e097d844f30ad4516b646ee3dc32614d9e76ba764c7ac280c3d1094163a35692
 
 service:
   externalPort: 80

--- a/vendir.lock.yml
+++ b/vendir.lock.yml
@@ -2,8 +2,8 @@ apiVersion: vendir.k14s.io/v1alpha1
 directories:
 - contents:
   - git:
-      commitTitle: Update routecontroller image digest to sha256:f2d76c155a89af005b3fe4c4186f4590b6f70560ef79d15cb0d62d805e4d79c7
-      sha: 2564ff8398d50f0dc7f29e2ae6e5b4a98f293a4c
+      commitTitle: Update routecontroller image digest to sha256:e097d844f30ad4516b646ee3dc32614d9e76ba764c7ac280c3d1094163a35692
+      sha: 2df0c84177c4421ae3e1662b7b1340451d984e4f
     path: github.com/cloudfoundry/cf-k8s-networking
   - git:
       commitTitle: 'Merge pull request #33 from davewalter/relint-use-internal-loggregator-url-171007126...'

--- a/vendir.yml
+++ b/vendir.yml
@@ -8,7 +8,7 @@ directories:
   - path: github.com/cloudfoundry/cf-k8s-networking
     git:
       url: https://github.com/cloudfoundry/cf-k8s-networking
-      ref: 2564ff8398d50f0dc7f29e2ae6e5b4a98f293a4c
+      ref: 2df0c84177c4421ae3e1662b7b1340451d984e4f
     includePaths:
     - config/*
     - cfroutesync/crds/**/*


### PR DESCRIPTION
We were not exposing the port that Istio Pilot uses for its metrics endpoint in our `NetworkPolicy` which resulted in Prometheus being unable to scrape it.

This `cf-k8s-networking` bump includes changes from https://github.com/cloudfoundry/cf-k8s-networking/pull/39 to fix this.

[Tracker story #172313646](https://www.pivotaltracker.com/story/show/172313646)

**Acceptance Steps**

1. Deploy these changes
1. Confirm that the `pilot-network-policy` `NetworkPolicy` is allowing ingress on port `15014`:
  ```
  kubectl get -n istio-system NetworkPolicy/pilot-network-policy -o yaml
  ```
3. If you'd like you can also `kubectl exec` on to a pod that has `curl` and `curl istio-pilot.istio-system:15014/metrics` and marvel at the output.

@jrussett has crafted a premium command for doing this:
```console
kubectl exec -n cf-db pod/cf-db-postgresql-0 -c cf-db-postgresql -- curl "istio-pilot.istio-system:15014/metrics"
```

@keshav-pivotal  @kauana @XanderStrike 
