### PR TITLE
Fix: blobsore.region default value to be ""

### DIFF
--- a/config/_ytt_lib/github.com/cloudfoundry/capi-k8s-release/values.yml
+++ b/config/_ytt_lib/github.com/cloudfoundry/capi-k8s-release/values.yml
@@ -25,7 +25,7 @@ ccdb:
   database: cloud_controller
 
 blobstore:
-  region: "''"
+  region: ""
   package_directory_key: cc-packages
   droplet_directory_key: cc-droplets
   resource_directory_key: cc-resources

--- a/config/values.yml
+++ b/config/values.yml
@@ -53,7 +53,7 @@ capi:
     droplet_directory_key: cc-droplets
     resource_directory_key: cc-resources
     buildpack_directory_key: cc-buildpacks
-    region: "''"
+    region: ""
     endpoint: "http://cf-blobstore-minio.cf-blobstore.svc.cluster.local:9000"
   database:
     #! or mysql2, as needed

--- a/vendir.lock.yml
+++ b/vendir.lock.yml
@@ -6,8 +6,8 @@ directories:
       sha: 2564ff8398d50f0dc7f29e2ae6e5b4a98f293a4c
     path: github.com/cloudfoundry/cf-k8s-networking
   - git:
-      commitTitle: 'Merge pull request #33 from davewalter/relint-use-internal-loggregator-url-171007126...'
-      sha: 38792a391bb48a42418b800805ac5319505c5b92
+      commitTitle: Fixed default blobstore region to be empty string...
+      sha: 40b6f9bee0134f992565638eafccdabf07849665
     path: github.com/cloudfoundry/capi-k8s-release
   - githubRelease:
       url: https://api.github.com/repos/cloudfoundry/cf-k8s-logging/releases/26057148

--- a/vendir.yml
+++ b/vendir.yml
@@ -18,7 +18,7 @@ directories:
   - path: github.com/cloudfoundry/capi-k8s-release
     git:
       url: https://github.com/cloudfoundry/capi-k8s-release
-      ref: 38792a391bb48a42418b800805ac5319505c5b92
+      ref: 40b6f9bee0134f992565638eafccdabf07849665
     includePaths:
     - templates/**/*
     - values.yml


### PR DESCRIPTION
Following up on a suggestion by RelInt to update the blobstore.region property in values.yml as discussed here: https://github.com/cloudfoundry/capi-k8s-release/issues/24

Previously, blobstore.region was "''". Now, it's "". 

Authored-by: Piyali Banerjee <pbanerjee@pivotal.io>



> Thanks for contributing to cf-for-k8s!
>
> We've designed this PR template to speed up the PR review and merge process - please use it.

> _Please describe the change here._ 

---


- Make sure this PR is based off the `develop` branch
- Checkout the [contributing guidelines](https://github.com/cloudfoundry/cf-for-k8s/blob/develop/docs/contributing.md)
- Include any links to related PRs, issues, stories, slack discussions, etc... that will help establish context.
- Is there anything else of note that the reviewers should know about this change?

**Acceptance Steps**

_please provide a series of instructions (eg kubectl or cf cli commands) for how our Product Manager can verify that your changes were properly integrated_


_Tag your pair, your PM, and/or team_

> _It's helpful to tag a few other folks on your team or your team alias in case we need to follow up later._
