### PR TITLE
Update deploy docs with updated kapp requirements

### DIFF
--- a/config/0-min-kapp-version.yml
+++ b/config/0-min-kapp-version.yml
@@ -1,0 +1,5 @@
+---
+apiVersion: kapp.k14s.io/v1alpha1
+kind: Config
+
+minimumRequiredVersion: 0.24.0

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -21,7 +21,7 @@
 You need the following CLIs on your system to be able to run the script:
 
 - [`cf cli`](https://docs.cloudfoundry.org/cf-cli/install-go-cli.html) (v6.50+)
-- [`kapp`](https://k14s.io/#install) (v0.21.0+)
+- [`kapp`](https://k14s.io/#install) (v0.24.0+)
 - [`ytt`](https://k14s.io/#install) (v0.26.0+)
 - [`kubectl`](https://kubernetes.io/docs/tasks/tools/install-kubectl/)
 


### PR DESCRIPTION
> Thanks for contributing to cf-for-k8s!
>
> We've designed this PR template to speed up the PR review and merge process - please use it.

Kapp versions `0.24.0+` are required to deploy `cf-for-k8s` as of some recent changes, so just want to update that prerequisite

---

**Acceptance Steps**

Confirm that using at least `kapp` version `0.24.0` you can deploy with the existing deployment instructions

_Tag your pair, your PM, and/or team_

Stemming from this conversation: https://cloudfoundry.slack.com/archives/CH9LF6V1P/p1588698073226400
