### PR TITLE
Bump capi-k8s-release

### DIFF
--- a/config/_ytt_lib/github.com/cloudfoundry/capi-k8s-release/templates/api_server_deployment.yml
+++ b/config/_ytt_lib/github.com/cloudfoundry/capi-k8s-release/templates/api_server_deployment.yml
@@ -3,7 +3,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: capi-api-server
+  name: cf-api-server
   namespace: #@ data.values.system_namespace
 spec:
   replicas: 2
@@ -13,7 +13,7 @@ spec:
       maxUnavailable: 1
   selector:
     matchLabels:
-      app.kubernetes.io/name: capi-api-server
+      app.kubernetes.io/name: cf-api-server
   template:
     metadata:
       annotations:
@@ -21,12 +21,12 @@ spec:
         prometheus.io/port: '9102'
         prometheus.io/path: 'metrics'
       labels:
-        app.kubernetes.io/name: capi-api-server
+        app.kubernetes.io/name: cf-api-server
     spec:
       #@ if/end data.values.imagePullSecrets:
       imagePullSecrets: #@ data.values.imagePullSecrets
       containers:
-        - name: capi-api-server
+        - name: cf-api-server
           image: #@ data.values.images.ccng
           imagePullPolicy: Always
           volumeMounts:
@@ -46,7 +46,7 @@ spec:
           #@ if/end data.values.metric_proxy.ca.secret_name:
           - name: metric-proxy-ca
             mountPath: /config/metric_proxy/ca
-        - name: capi-local-worker
+        - name: cf-api-local-worker
           image: #@ data.values.images.ccng
           imagePullPolicy: Always
           command: ["/usr/local/bin/bundle"]

--- a/config/_ytt_lib/github.com/cloudfoundry/capi-k8s-release/templates/capi-kpack-watcher-deployment.yml
+++ b/config/_ytt_lib/github.com/cloudfoundry/capi-k8s-release/templates/capi-kpack-watcher-deployment.yml
@@ -3,11 +3,11 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: capi-kpack-watcher
+  name: cf-api-kpack-watcher
   namespace: #@ data.values.system_namespace
   labels:
-    app.kubernetes.io/name: capi-kpack-watcher
-    app.kubernetes.io/instance: capi-kpack-watcher-0
+    app.kubernetes.io/name: cf-api-kpack-watcher
+    app.kubernetes.io/instance: cf-api-kpack-watcher-0
 spec:
   replicas: 1
   strategy:
@@ -16,15 +16,15 @@ spec:
       maxUnavailable: 1
   selector:
     matchLabels:
-      app.kubernetes.io/name: capi-kpack-watcher
+      app.kubernetes.io/name: cf-api-kpack-watcher
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: capi-kpack-watcher
+        app.kubernetes.io/name: cf-api-kpack-watcher
     spec:
       serviceAccountName: default
       containers:
-        - name: capi-kpack-watcher
+        - name: cf-api-kpack-watcher
           image: #@ data.values.images.capi_kpack_watcher
           env:
           - name: UAA_CLIENT_SECRET

--- a/config/_ytt_lib/github.com/cloudfoundry/capi-k8s-release/templates/clock_deployment.yml
+++ b/config/_ytt_lib/github.com/cloudfoundry/capi-k8s-release/templates/clock_deployment.yml
@@ -3,7 +3,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: capi-clock
+  name: cf-api-clock
   namespace: #@ data.values.system_namespace
 spec:
   replicas: 1
@@ -13,16 +13,16 @@ spec:
       maxUnavailable: 1
   selector:
     matchLabels:
-      app.kubernetes.io/name: capi-clock
+      app.kubernetes.io/name: cf-api-clock
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: capi-clock
+        app.kubernetes.io/name: cf-api-clock
     spec:
       #@ if/end data.values.imagePullSecrets:
       imagePullSecrets: #@ data.values.imagePullSecrets
       containers:
-        - name: capi-clock
+        - name: cf-api-clock
           workingDir: "/cloud_controller_ng"
           command: ["/usr/local/bin/bundle"]
           args: ["exec", "rake", "clock:start"]

--- a/config/_ytt_lib/github.com/cloudfoundry/capi-k8s-release/templates/deployment_updater_deployment.yml
+++ b/config/_ytt_lib/github.com/cloudfoundry/capi-k8s-release/templates/deployment_updater_deployment.yml
@@ -3,7 +3,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: capi-deployment-updater
+  name: cf-api-deployment-updater
   namespace: #@ data.values.system_namespace
 spec:
   replicas: 1
@@ -13,16 +13,16 @@ spec:
       maxUnavailable: 1
   selector:
     matchLabels:
-      app.kubernetes.io/name: capi-deployment-updater
+      app.kubernetes.io/name: cf-api-deployment-updater
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: capi-deployment-updater
+        app.kubernetes.io/name: cf-api-deployment-updater
     spec:
       #@ if/end data.values.imagePullSecrets:
       imagePullSecrets: #@ data.values.imagePullSecrets
       containers:
-        - name: capi-deployment-updater
+        - name: cf-api-deployment-updater
           workingDir: "/cloud_controller_ng"
           command: ["/usr/local/bin/bundle"]
           args: ["exec", "rake", "deployment_updater:start"]

--- a/config/_ytt_lib/github.com/cloudfoundry/capi-k8s-release/templates/service.yml
+++ b/config/_ytt_lib/github.com/cloudfoundry/capi-k8s-release/templates/service.yml
@@ -12,4 +12,4 @@ spec:
       protocol: TCP
       name: http
   selector:
-    app.kubernetes.io/name: capi-api-server
+    app.kubernetes.io/name: cf-api-server

--- a/config/_ytt_lib/github.com/cloudfoundry/capi-k8s-release/templates/worker_deployment.yml
+++ b/config/_ytt_lib/github.com/cloudfoundry/capi-k8s-release/templates/worker_deployment.yml
@@ -3,22 +3,22 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: capi-worker
+  name: cf-api-worker
   namespace: #@ data.values.system_namespace
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app.kubernetes.io/name: capi-worker
+      app.kubernetes.io/name: cf-api-worker
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: capi-worker
+        app.kubernetes.io/name: cf-api-worker
     spec:
       #@ if/end data.values.imagePullSecrets:
       imagePullSecrets: #@ data.values.imagePullSecrets
       containers:
-        - name: capi-worker
+        - name: cf-api-worker
           workingDir: "/cloud_controller_ng"
           command: ["/usr/local/bin/bundle"]
           args: ["exec", "rake", "jobs:generic"]

--- a/config/_ytt_lib/github.com/cloudfoundry/capi-k8s-release/values.yml
+++ b/config/_ytt_lib/github.com/cloudfoundry/capi-k8s-release/values.yml
@@ -3,7 +3,7 @@
 replicaCount: 1
 
 images:
-  ccng: cloudfoundry/cloud-controller-ng:1ebab1cbb5270a3d51c0a098a37cd9e8ca0f721d@sha256:374f967edd7db4d7efc2f38cb849988aa36a8248dd240d56f49484b8159fd800
+  ccng: cloudfoundry/cloud-controller-ng:078281af7f346884fa87aafbff98f444fb1c5b79@sha256:5283da84299d3eab96326fd0ee3d6edd40ec200d2a40f80cb1c92cb5ba070b51
   nginx: cloudfoundry/capi:nginx@sha256:51e4e48c457d5cb922cf0f569e145054e557e214afa78fb2b312a39bb2f938b6
   capi_kpack_watcher: cloudfoundry/capi-kpack-watcher:956150dae0a95dcdf3c1f29c23c3bf11db90f7a0@sha256:67125e0d3a4026a23342d80e09aad9284c08ab4f7b3d9a993ae66e403d5d0796
   statsd_exporter: prom/statsd-exporter:v0.15.0@sha256:e3174186628b401e4a441b78513ba06e957644267332436be0c77dd7af9bdddc
@@ -25,7 +25,7 @@ ccdb:
   database: cloud_controller
 
 blobstore:
-  region: "''"
+  region: ""
   package_directory_key: cc-packages
   droplet_directory_key: cc-droplets
   resource_directory_key: cc-resources

--- a/config/capi.yml
+++ b/config/capi.yml
@@ -89,7 +89,7 @@ kpack:
 apiVersion: networking.istio.io/v1alpha3
 kind: VirtualService
 metadata:
-  name: capi-external-virtual-service
+  name: cf-api-external-virtual-service
   namespace: #@ data.values.system_namespace
 spec:
   hosts:

--- a/config/fix-db-startup-order.yml
+++ b/config/fix-db-startup-order.yml
@@ -16,7 +16,7 @@ metadata:
     #@overlay/match missing_ok=True
     kapp.k14s.io/change-rule.cf-db-postgresql: "upsert after upserting cf-for-k8s.cloudfoundry.org/cf-db-postgresql"
 
-#@overlay/match by=overlay.subset({"kind":"Deployment", "metadata":{"name": "capi-api-server"}})
+#@overlay/match by=overlay.subset({"kind":"Deployment", "metadata":{"name": "cf-api-server"}})
 ---
 metadata:
   #@overlay/match missing_ok=True
@@ -24,7 +24,7 @@ metadata:
     #@overlay/match missing_ok=True
     kapp.k14s.io/change-rule.cf-db-postgresql: "upsert after upserting cf-for-k8s.cloudfoundry.org/cf-db-postgresql"
 
-#@overlay/match by=overlay.subset({"kind":"Deployment", "metadata":{"name": "capi-clock"}})
+#@overlay/match by=overlay.subset({"kind":"Deployment", "metadata":{"name": "cf-api-clock"}})
 ---
 metadata:
   #@overlay/match missing_ok=True
@@ -32,7 +32,7 @@ metadata:
     #@overlay/match missing_ok=True
     kapp.k14s.io/change-rule.cf-db-postgresql: "upsert after upserting cf-for-k8s.cloudfoundry.org/cf-db-postgresql"
 
-#@overlay/match by=overlay.subset({"kind":"Deployment", "metadata":{"name": "capi-worker"}})
+#@overlay/match by=overlay.subset({"kind":"Deployment", "metadata":{"name": "cf-api-worker"}})
 ---
 metadata:
   #@overlay/match missing_ok=True

--- a/vendir.lock.yml
+++ b/vendir.lock.yml
@@ -6,8 +6,8 @@ directories:
       sha: 2564ff8398d50f0dc7f29e2ae6e5b4a98f293a4c
     path: github.com/cloudfoundry/cf-k8s-networking
   - git:
-      commitTitle: 'Merge pull request #33 from davewalter/relint-use-internal-loggregator-url-171007126...'
-      sha: 38792a391bb48a42418b800805ac5319505c5b92
+      commitTitle: Switch prefix from "capi-" to "cf-api-"...
+      sha: a698364eebf83a27f8da83210fc6c47c1d83b174
     path: github.com/cloudfoundry/capi-k8s-release
   - githubRelease:
       url: https://api.github.com/repos/cloudfoundry/cf-k8s-logging/releases/26057148

--- a/vendir.yml
+++ b/vendir.yml
@@ -18,7 +18,7 @@ directories:
   - path: github.com/cloudfoundry/capi-k8s-release
     git:
       url: https://github.com/cloudfoundry/capi-k8s-release
-      ref: 38792a391bb48a42418b800805ac5319505c5b92
+      ref: a698364eebf83a27f8da83210fc6c47c1d83b174
     includePaths:
     - templates/**/*
     - values.yml


### PR DESCRIPTION
List of changes:

highlights:
  * change prefix for user-facing CAPI names to "cf-api" (shortened for
  CloudFoundry API) - cloudfoundry/capi-k8s-release#15
  * fix panic in capi-kpack-watcher that is masking deeper issues
  related to "cf push" - cloudfoundry/capi-k8s-release#27 cloudfoundry/capi-k8s-release#39
  * user-defiend env vars are now passed to kpack Build resource -
  (cloudcloudfoundry/cloud_controller_ng#1600)

capi-k8s-release changelog:
  a698364 Aakash Shah: Switch prefix from "capi-" to "cf-api-"
  b4319f2 Aakash Shah: Bump cloud_controller_ng docker image
  7965f22 Aakash Shah: Fix ./scripts/rollout.sh using bin/install-cf
  d7bd988 Aakash Shah: Fix panic when stepsCompleted is empty
  03195bd Renee Chu: Bump capi-k8s-release
  40b6f9b Piyali Banerjee: Fixed default blobstore region to be empty string

cloud_controller_ng changelog:
  078281af7 Aakash Shah: Merge pull request #1600 from akhinos/kpack-env
  b5a5e89df Sarah Weinstein: **V3** client can assign **router groups** to domains
  ae9eb0f32 Belinda Liu: **V3** client can assign **router groups** to domains
  f186ac484 Brian Cunnie: **V3**: `GET /v3/routes` filters by app GUIDs
  4cd6bd2a3 Aakash Shah: Update app_events.exit_description to text
  ccf6ae1e3 Reid Mitchell: Fix v3 🐞: UnknownError when API user specifies big numbers for quota limits
  2bca16c29 Teal Stannard: Remove unnecessary debugging output
  1a37a81b1 Piyali Banerjee: Add tls proxy ports to process stats object
  0c199d477 Aakash Shah: Truncate 'metadata' app.crash event payload
  7395ee8e9 Sarah Weinstein: v3: Surface helpful error when trying to create security group with invalid name
  f961fab98 George Blue: V3 client can update user-provided service instance
  b427112c5 Ulrich Kramer: Filter out VCAP_SERVICES from environment variables
  0b35016a5 Ulrich Kramer: Remove select of variables starting with BP
  3502b17d8 Ulrich Kramer: Add environment variables to kpack image CR

---

**Acceptance Steps**

_please provide a series of instructions (eg kubectl or cf cli commands) for how our Product Manager can verify that your changes were properly integrated_

* Regular installation + smoke should be be just fine

@selzoc @jspawar @ssisil 
