### PR TITLE
Master is now requiring kapp 0.26+

### DIFF
--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -21,7 +21,7 @@
 You need the following CLIs on your system to be able to run the script:
 
 - [`cf cli`](https://docs.cloudfoundry.org/cf-cli/install-go-cli.html) (v6.50+)
-- [`kapp`](https://k14s.io/#install) (v0.24.0+)
+- [`kapp`](https://k14s.io/#install) (v0.26.0+)
 - [`ytt`](https://k14s.io/#install) (v0.26.0+)
 - [`kubectl`](https://kubernetes.io/docs/tasks/tools/install-kubectl/)
 


### PR DESCRIPTION
Just pulled from master, which told me to upgrade kapp:

`kapp: Error: Validating config: kapp version '0.25.0' does not meet the minimum required version '0.26.0'`

I think it's great that the install will fail immediately if you don't have the right version. It used to give a really weird and hard to troubleshoot error if you didn't have the right versions. 

But I think the readme needs to be updated to reflect the new version requirements.



> Thanks for contributing to cf-for-k8s!
>
> We've designed this PR template to speed up the PR review and merge process - please use it.

> _Please describe the change here._ 

---


- Make sure this PR is based off the `develop` branch
- Checkout the [contributing guidelines](https://github.com/cloudfoundry/cf-for-k8s/blob/develop/docs/contributing.md)
- Include any links to related PRs, issues, stories, slack discussions, etc... that will help establish context.
- Is there anything else of note that the reviewers should know about this change?

**Acceptance Steps**

_please provide a series of instructions (eg kubectl or cf cli commands) for how our Product Manager can verify that your changes were properly integrated_


_Tag your pair, your PM, and/or team_

> _It's helpful to tag a few other folks on your team or your team alias in case we need to follow up later._
