### PR TITLE
[Bug Fix] cf7 push --strategy rolling shows metrics

### DIFF
--- a/config/_ytt_lib/github.com/cloudfoundry/metric-proxy/config/manifests/500-metric-proxy-deployment.yml
+++ b/config/_ytt_lib/github.com/cloudfoundry/metric-proxy/config/manifests/500-metric-proxy-deployment.yml
@@ -33,7 +33,7 @@ spec:
         - name: ADDR
           value: :8080
         - name: APP_SELECTOR
-          value: cloudfoundry.org/app_guid
+          value: cloudfoundry.org/guid
         - name: NAMESPACE
           value: cf-workloads
         - name: QUERY_TIMEOUT

--- a/config/_ytt_lib/github.com/cloudfoundry/metric-proxy/config/values.yml
+++ b/config/_ytt_lib/github.com/cloudfoundry/metric-proxy/config/values.yml
@@ -4,7 +4,7 @@ system_domain: ""
 system_namespace: ""
 
 images:
-  metric_proxy: "oratos/metric-proxy@sha256:fd2f5bad16596919d387c1374ee794e00329af7327f5aafd74d3e546e94180b0"
+  metric_proxy: "oratos/metric-proxy@sha256:0c47312a76f6bb12ee42a8b45f6571d7a87f4c28a34cd76ef9a0f9fe1a9c8ece"
 
 metric_proxy:
   ca:

--- a/vendir.lock.yml
+++ b/vendir.lock.yml
@@ -13,8 +13,8 @@ directories:
       url: https://api.github.com/repos/cloudfoundry/cf-k8s-logging/releases/26057148
     path: github.com/cloudfoundry/cf-k8s-logging/config
   - git:
-      commitTitle: Add quotes to prometheus annotations
-      sha: 8cda308b4681174df273ccb9cf9a7fdebdc7b053
+      commitTitle: Remove reference to cf-for-k8s script that no longer exists...
+      sha: 338ca2d94390bc0758ef7388b6ecfbf43269f99f
     path: github.com/cloudfoundry/metric-proxy
   - git:
       commitTitle: 'Merge pull request #1262 from cloudfoundry/dependabot/go_modules/k8s/k8s.io/api-0.18.1'

--- a/vendir.yml
+++ b/vendir.yml
@@ -30,7 +30,7 @@ directories:
   - path: github.com/cloudfoundry/metric-proxy
     git:
       url: https://github.com/cloudfoundry/metric-proxy
-      ref: 8cda308b4681174df273ccb9cf9a7fdebdc7b053
+      ref: 338ca2d94390bc0758ef7388b6ecfbf43269f99f
     includePaths:
     - config/**/*
   - path: github.com/cloudfoundry/uaa


### PR DESCRIPTION
Fixes: https://github.com/cloudfoundry/cf-for-k8s/issues/177
* update metric-proxy app selector to match on `guid` (process guid sent from capi) rather than `app_guid`

[#172771099]

Signed-off-by: Louie Brann <lbrann@pivotal.io>

**Relevant Links**

* Tracker Story: https://www.pivotaltracker.com/story/show/172771099
* Passing pipeline: https://loggregator.ci.cf-app.com/teams/main/pipelines/metric-proxy/jobs/run-tests-on-cf-for-k8s-pr/builds/16
* Slack conversation: https://cloudfoundry.slack.com/archives/CH9LF6V1P/p1588969711283900

**Acceptance Steps**

1. `cf7 push <your app> --strategy rolling` -->this does not show accurate metrics because of a known kubeapi delay
1. `cf7 app <your app>` --> this will show metrics after the delay (~30 seconds)
1. `cf7 push <your app> --strategy rolling` --> same as above
1. `cf7 app <your app>` --> this should now show accurate metrics (after the delay). 

@hev @louis-brann 