### PR TITLE
Change env variable to fix smoke tests

### DIFF
--- a/ci/pipelines/cf-for-k8s.yml
+++ b/ci/pipelines/cf-for-k8s.yml
@@ -5,9 +5,10 @@ groups:
   - unit-test-config-optional-files
   - branch-freshness
   - test-vendir-sync-on-cf-for-k8s
-  - validate-cf-for-k8s
+  - validate-cf-for-k8s-gke
   - validate-cf-for-k8s-oldest
   - validate-cf-for-k8s-newest
+  - promote-master-deliver-stories
   - release-validation-pool-manual
 - name: stability-checks-and-slis
   jobs:
@@ -342,13 +343,14 @@ jobs:
       VENDIR_GITHUB_API_TOKEN: ((github_status_bot_vendir_github_read_token))
       REPO_DIR: cf-for-k8s-repo
 
-- name: validate-cf-for-k8s
+- name: validate-cf-for-k8s-gke
   serial: true
   public: true
   plan:
   - get: cf-for-k8s-develop
     passed:
     - test-vendir-sync-on-cf-for-k8s
+    - unit-test-config-optional-files
     trigger: true
   - put: validation-pool
     params: {acquire: true}
@@ -448,15 +450,6 @@ jobs:
 
           kapp delete -a cf --yes
 
-  - put: cf-for-k8s-master-push
-    params:
-      repository: cf-for-k8s-develop
-
-  - put: deliver-tracker-stories
-    params:
-      repos:
-      - cf-for-k8s-develop
-
   - put: validation-pool
     params: {release: validation-pool}
 
@@ -466,6 +459,7 @@ jobs:
     - get: cf-for-k8s-develop
       passed:
       - test-vendir-sync-on-cf-for-k8s
+      - unit-test-config-optional-files
       trigger: true
     - get: cf-for-k8s-develop-ci
     - get: cf-for-k8s-kind-gcp-terraform-templates
@@ -556,6 +550,7 @@ jobs:
     - get: cf-for-k8s-develop
       passed:
       - test-vendir-sync-on-cf-for-k8s
+      - unit-test-config-optional-files
       trigger: true
     - get: cf-for-k8s-develop-ci
     - get: cf-for-k8s-kind-gcp-terraform-templates
@@ -639,6 +634,24 @@ jobs:
         var_files: [tf-vars/input.tfvars]
       get_params:
         action: destroy
+
+- name: promote-master-deliver-stories
+  serial: true
+  public: true
+  plan:
+  - get: cf-for-k8s-develop
+    passed:
+      - validate-cf-for-k8s-newest
+      - validate-cf-for-k8s-oldest
+      - validate-cf-for-k8s-gke
+    trigger: true
+  - put: cf-for-k8s-master-push
+    params:
+      repository: cf-for-k8s-develop
+  - put: deliver-tracker-stories
+    params:
+      repos:
+        - cf-for-k8s-develop
 
 - name: release-validation-pool-manual
   public: true

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -68,7 +68,7 @@ In `cf-for-k8s` repo:
     cd tests/smoke
     export SMOKE_TEST_API_ENDPOINT=api.${SYSTEM_DOMAIN}
     export SMOKE_TEST_USERNAME=admin
-    export SMOKE_TEST_APPS_DOMAIN=${SYSTEM_DOMAIN}
+    export SMOKE_TEST_APPS_DOMAIN=apps.${SYSTEM_DOMAIN}
     export SMOKE_TEST_SKIP_SSL=true
     ginkgo -v -r ./
     ```


### PR DESCRIPTION
We were getting the following smoke tests failures. Updating the environment variable fixed the issue. CC @louis-brann 

```
• Failure [194.274 seconds]
Smoke Tests
/home/pivotal/workspace/cf-for-k8s/tests/smoke/smoke_test.go:31
  when running cf push
  /home/pivotal/workspace/cf-for-k8s/tests/smoke/smoke_test.go:32
    creates a routable app pod in Kubernetes from a source-based app [It]
    /home/pivotal/workspace/cf-for-k8s/tests/smoke/smoke_test.go:127

    Timed out after 120.000s.
    Expected
        <int>: 404
    to equal
        <int>: 200

    /home/pivotal/workspace/cf-for-k8s/tests/smoke/smoke_test.go:146


Summarizing 2 Failures:

[Fail] Smoke Tests when running cf push [It] creates a routable app pod in Kubernetes from a docker image-based app
/home/pivotal/workspace/cf-for-k8s/tests/smoke/smoke_test.go:107

[Fail] Smoke Tests when running cf push [It] creates a routable app pod in Kubernetes from a source-based app
/home/pivotal/workspace/cf-for-k8s/tests/smoke/smoke_test.go:146

Ran 2 of 2 Specs in 335.009 seconds
FAIL! -- 0 Passed | 2 Failed | 0 Pending | 0 Skipped
--- FAIL: TestSmoke (335.01s)
FAIL

Ginkgo ran 1 suite in 5m37.987846428s
Test Suite Failed
```