### PR TITLE
Change env variable to fix smoke tests

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -68,7 +68,7 @@ In `cf-for-k8s` repo:
     cd tests/smoke
     export SMOKE_TEST_API_ENDPOINT=api.${SYSTEM_DOMAIN}
     export SMOKE_TEST_USERNAME=admin
-    export SMOKE_TEST_APPS_DOMAIN=${SYSTEM_DOMAIN}
+    export SMOKE_TEST_APPS_DOMAIN=apps.${SYSTEM_DOMAIN}
     export SMOKE_TEST_SKIP_SSL=true
     ginkgo -v -r ./
     ```


### PR DESCRIPTION
We were getting the following smoke tests failures. Updating the environment variable fixed the issue. CC @louis-brann 

```
• Failure [194.274 seconds]
Smoke Tests
/home/pivotal/workspace/cf-for-k8s/tests/smoke/smoke_test.go:31
  when running cf push
  /home/pivotal/workspace/cf-for-k8s/tests/smoke/smoke_test.go:32
    creates a routable app pod in Kubernetes from a source-based app [It]
    /home/pivotal/workspace/cf-for-k8s/tests/smoke/smoke_test.go:127

    Timed out after 120.000s.
    Expected
        <int>: 404
    to equal
        <int>: 200

    /home/pivotal/workspace/cf-for-k8s/tests/smoke/smoke_test.go:146


Summarizing 2 Failures:

[Fail] Smoke Tests when running cf push [It] creates a routable app pod in Kubernetes from a docker image-based app
/home/pivotal/workspace/cf-for-k8s/tests/smoke/smoke_test.go:107

[Fail] Smoke Tests when running cf push [It] creates a routable app pod in Kubernetes from a source-based app
/home/pivotal/workspace/cf-for-k8s/tests/smoke/smoke_test.go:146

Ran 2 of 2 Specs in 335.009 seconds
FAIL! -- 0 Passed | 2 Failed | 0 Pending | 0 Skipped
--- FAIL: TestSmoke (335.01s)
FAIL

Ginkgo ran 1 suite in 5m37.987846428s
Test Suite Failed
```
