### PR TITLE
bump networking images

### DIFF
--- a/config/_ytt_lib/github.com/cloudfoundry/cf-k8s-networking/config/values.yaml
+++ b/config/_ytt_lib/github.com/cloudfoundry/cf-k8s-networking/config/values.yaml
@@ -7,7 +7,7 @@ systemNamespace: cf-system
 workloadsNamespace: cf-workloads
 
 cfroutesync:
-  image: gcr.io/cf-networking-images/cf-k8s-networking/cfroutesync@sha256:0459226037166b15d4a80f0c4a0be9a16d1cffb76c7dd9c7ad2efbe763e23c61
+  image: gcr.io/cf-networking-images/cf-k8s-networking/cfroutesync@sha256:87704f76960a66e5f11a73ad1a853f5e06203d29d00ef4dc3f61ad81feee1898
 
   ccCA: 'base64_encoded_cloud_controller_ca'
   ccBaseURL: 'https://api.example.com'
@@ -17,7 +17,7 @@ cfroutesync:
   clientSecret: 'base64_encoded_uaaClientSecret'
 
 routecontroller:
-  image: gcr.io/cf-networking-images/cf-k8s-networking/routecontroller@sha256:e097d844f30ad4516b646ee3dc32614d9e76ba764c7ac280c3d1094163a35692
+  image: gcr.io/cf-networking-images/cf-k8s-networking/routecontroller@sha256:717940947ac6b90ccf17a202b5e8eec58388c211dfa26495503471442f5a7202
 
 service:
   externalPort: 80

--- a/vendir.lock.yml
+++ b/vendir.lock.yml
@@ -2,8 +2,8 @@ apiVersion: vendir.k14s.io/v1alpha1
 directories:
 - contents:
   - git:
-      commitTitle: Update routecontroller image digest to sha256:e097d844f30ad4516b646ee3dc32614d9e76ba764c7ac280c3d1094163a35692
-      sha: 2df0c84177c4421ae3e1662b7b1340451d984e4f
+      commitTitle: Add tasks to label routecontroller and cfroutesync images...
+      sha: 1b5e17f00a6c1500eb988187cba1ce171ff58f34
     path: github.com/cloudfoundry/cf-k8s-networking
   - git:
       commitTitle: Bump CCNG docker image manually...

--- a/vendir.yml
+++ b/vendir.yml
@@ -8,7 +8,7 @@ directories:
   - path: github.com/cloudfoundry/cf-k8s-networking
     git:
       url: https://github.com/cloudfoundry/cf-k8s-networking
-      ref: 2df0c84177c4421ae3e1662b7b1340451d984e4f
+      ref: 1b5e17f00a6c1500eb988187cba1ce171ff58f34
     includePaths:
     - config/*
     - cfroutesync/crds/**/*


### PR DESCRIPTION
The new images include a label describing the repository and commit SHA that the image is built from

[#172922921](https://www.pivotaltracker.com/story/show/172922921)

---


**Acceptance Steps**
**When** I run `docker inspect <IMAGE>`, replacing `<IMAGE>` with the cfroutesync image that's deployed as part of cf-for-k8s.

**Then** I can see a label called "io.pivotal.metadata" with information describing the dependencies packaged into the image, including the github repository and commit SHA used to build the image


Note: The "io.pivotal.metadata" label is temporary and due to the tooling we're using at the moment. We plan to update this label to be more vendor agnostic as soon as we can get the tooling changes and a standardized label for cf-for-k8s.

_Tag your pair, your PM, and/or team_
@jenspinney @keshav-pivotal 

cc @evanfarrar

