### PR TITLE
Explicitly define separate system, workloads and internal certs

### DIFF
--- a/config/capi.yml
+++ b/config/capi.yml
@@ -55,9 +55,9 @@ eirini:
 
 apiServer:
   opi:
-    client_cert: #@ data.values.eirini.tls.crt
-    client_key: #@ data.values.eirini.tls.key
-    ca: #@ data.values.system_certificate.ca
+    client_cert: #@ data.values.internal_certificate.crt
+    client_key: #@ data.values.internal_certificate.key
+    ca: #@ data.values.internal_certificate.ca
 
 metric_proxy:
   ca:

--- a/config/eirini.yml
+++ b/config/eirini.yml
@@ -14,9 +14,9 @@ metadata:
   name: eirini-internal-tls-certs
   namespace: #@ data.values.system_namespace
 data:
-  tls.crt: #@ data.values.eirini.tls.crt
-  tls.key: #@ data.values.eirini.tls.key
-  tls.ca: #@ data.values.system_certificate.ca
+  tls.crt: #@ data.values.internal_certificate.crt
+  tls.key: #@ data.values.internal_certificate.key
+  tls.ca: #@ data.values.internal_certificate.ca
 
 #! Allow app traffic from the istio-ingressgateway
 ---

--- a/config/uaa.yml
+++ b/config/uaa.yml
@@ -246,5 +246,5 @@ metadata:
   namespace: #@ data.values.system_namespace
 type: Opaque
 data:
-  uaa.key: #@ data.values.uaa.certificate.key
-  uaa.crt: #@ data.values.uaa.certificate.crt
+  uaa.key: #@ data.values.internal_certificate.key
+  uaa.crt: #@ data.values.internal_certificate.crt

--- a/config/values.yml
+++ b/config/values.yml
@@ -35,7 +35,7 @@ system_certificate:
   #! Base64-encoded certificate for the wildcard
   #! subdomain of the system domain (e.g., CN=*.system.cf.example.com)
   crt: ""
-  #! Base64-encoded private key for the cert above
+  #! Base64-encoded private key for the system certificate
   key: ""
   #! Base64-encoded CA certificate used to sign the system certifcate
   ca: ""
@@ -44,9 +44,18 @@ workloads_certificate:
   #! Base64-encoded certificate for the wildcard
   #! subdomain of the system domain (e.g., CN=*.apps.cf.example.com)
   crt: ""
-  #! Base64-encoded private key for the cert above
+  #! Base64-encoded private key for the workloads certificate
   key: ""
   #! Base64-encoded CA certificate used to sign the workloads certifcate
+  ca: ""
+
+internal_certificate:
+  #! Base64-encoded certificate for the wildcard
+  #! subdomain of the system domain (e.g., CN=*.cf-system.svc.cluster.local)
+  crt: ""
+  #! Base64-encoded private key for the internal certificate
+  key: ""
+  #! Base64-encoded CA certificate used to sign the internal certifcate
   ca: ""
 
 capi:
@@ -81,13 +90,6 @@ uaa:
     password: ""
     name: uaa
 
-  certificate:
-    #! Base64-encoded certificate for the uaa service inside
-    #! the kubernetes cluster (i.e., CN=uaa.cf-system.svc.cluster.local)
-    crt: ""
-    #! Base64-encoded private key for the cert above
-    key: ""
-
   jwt_policy:
     key_id: "default_jwt_policy_key"
     #! Plain text private key
@@ -108,22 +110,6 @@ uaa:
       certificate: ""
 
   login_secret_name: "uaa-login-secret"
-
-doppler:
-  tls:
-    #! Base64-encoded certificate for the doppler service inside
-    #! the kubernetes cluster (i.e., CN=doppler.cf-system.svc.cluster.local)
-    crt: ""
-    #! Base64-encoded private key for the cert above
-    key: ""
-
-eirini:
-  tls:
-    #! Base64-encoded certificate for the eirini service inside
-    #! the kubernetes cluster (i.e., CN=eirini.cf-system.svc.cluster.local)
-    crt: ""
-    #! Base64-encoded private key for the cert above
-    key: ""
 
 log_cache_ca:
   crt: "" #! Base64-encoded ca for the log cache

--- a/hack/generate-values.sh
+++ b/hack/generate-values.sh
@@ -111,11 +111,22 @@ variables:
     ca: default_ca
     common_name: "*.${DOMAIN}"
     alternative_names:
-    - "*.${DOMAIN}"
     - "*.login.${DOMAIN}"
     - "*.uaa.${DOMAIN}"
-    - "*.apps.${DOMAIN}"
-    - "*.cf-system.svc.cluster.local"
+    extended_key_usage:
+    - server_auth
+- name: workloads_certificate
+  type: certificate
+  options:
+    ca: default_ca
+    common_name: "*.apps.${DOMAIN}"
+    extended_key_usage:
+    - server_auth
+- name: internal_certificate
+  type: certificate
+  options:
+    ca: default_ca
+    common_name: "*.cf-system.svc.cluster.local"
     extended_key_usage:
     - client_auth
     - server_auth
@@ -214,14 +225,21 @@ capi:
 
 system_certificate:
   #! This certificates and keys are base64 encoded and should be valid for *.system.cf.example.com
-  crt: &crt $(bosh interpolate ${VARS_FILE} --path=/system_certificate/certificate | base64 | tr -d '\n')
-  key: &key $(bosh interpolate ${VARS_FILE} --path=/system_certificate/private_key | base64 | tr -d '\n')
+  crt: $(bosh interpolate ${VARS_FILE} --path=/system_certificate/certificate | base64 | tr -d '\n')
+  key: $(bosh interpolate ${VARS_FILE} --path=/system_certificate/private_key | base64 | tr -d '\n')
   ca: $(bosh interpolate ${VARS_FILE} --path=/system_certificate/ca | base64 | tr -d '\n')
 
 workloads_certificate:
-  crt: *crt
-  key: *key
-  ca: $(bosh interpolate ${VARS_FILE} --path=/system_certificate/ca | base64 | tr -d '\n')
+  #! This certificates and keys are base64 encoded and should be valid for *.apps.cf.example.com
+  crt: $(bosh interpolate ${VARS_FILE} --path=/workloads_certificate/certificate | base64 | tr -d '\n')
+  key: $(bosh interpolate ${VARS_FILE} --path=/workloads_certificate/private_key | base64 | tr -d '\n')
+  ca: $(bosh interpolate ${VARS_FILE} --path=/workloads_certificate/ca | base64 | tr -d '\n')
+
+internal_certificate:
+  #! This certificates and keys are base64 encoded and should be valid for *.cf-system.svc.cluster.local
+  crt: $(bosh interpolate ${VARS_FILE} --path=/internal_certificate/certificate | base64 | tr -d '\n')
+  key: $(bosh interpolate ${VARS_FILE} --path=/internal_certificate/private_key | base64 | tr -d '\n')
+  ca: $(bosh interpolate ${VARS_FILE} --path=/internal_certificate/ca | base64 | tr -d '\n')
 
 log_cache_ca:
   crt: $(bosh interpolate ${VARS_FILE} --path=/log_cache_ca/certificate | base64 | tr -d '\n')
@@ -255,9 +273,6 @@ uaa:
   database:
     password: $(bosh interpolate ${VARS_FILE} --path=/uaa_db_password)
   admin_client_secret: $(bosh interpolate ${VARS_FILE} --path=/uaa_admin_client_secret)
-  certificate:
-    crt: *crt
-    key: *key
   jwt_policy:
     signing_key: |
 $(bosh interpolate "${VARS_FILE}" --path=/uaa_jwt_policy_signing_key/private_key | sed -e 's#^#      #')
@@ -269,16 +284,6 @@ $(bosh interpolate "${VARS_FILE}" --path=/uaa_jwt_policy_signing_key/private_key
 $(bosh interpolate "${VARS_FILE}" --path=/uaa_login_service_provider/private_key | sed -e 's#^#        #')
       certificate: |
 $(bosh interpolate "${VARS_FILE}" --path=/uaa_login_service_provider/certificate | sed -e 's#^#        #')
-
-doppler:
-  tls:
-    crt: *crt
-    key: *key
-
-eirini:
-  tls:
-    crt: *crt
-    key: *key
 EOF
 
 if [[ -n "${GCP_SERVICE_ACCOUNT_JSON:=}" ]]; then

--- a/sample-cf-install-values.yml
+++ b/sample-cf-install-values.yml
@@ -32,10 +32,10 @@ capi:
 #! - all of the certs should have KeyUsage that includes server and client authentication
 
 #! certificate, private key, and certificate authority used to identify the CF installation (i.e. the ingress gateway).
-#! - should be valid for *.system.cf.example.com, and *.cf-system.svc.cluster.local
+#! - should be valid for *.system.cf.example.com
 system_certificate:
-  crt: &crt ingress_gateway_certificate
-  key: &key ingress_gateway_private_key
+  crt: ingress_gateway_certificate
+  key: ingress_gateway_private_key
   ca: ingress_gateway_certificate_ca
 
 #! certificate, private key, and certificate authority used to identify the CF installation (i.e. the ingress gateway).
@@ -45,6 +45,13 @@ workloads_certificate:
   crt: workload_certificate
   key: workload_private_key
   ca: workload_certificate_ca
+
+#! certificate, private key, and certificate authority used internally within the CF installation (i.e. cf-system.svc.cluster.local).
+#! - should be valid for *.cf-system.svc.cluster.local
+internal_certificate:
+  crt: &crt internal_certificate
+  key: &key internal_private_key
+  ca: internal_certificate_ca
 
 #! Log Cache CA certificate and private key
 #! - the common name needs to be log-cache-ca
@@ -96,10 +103,6 @@ uaa:
     password: uaadb_password
   #! The secret used for the UAA admin client.
   admin_client_secret: uaaadminclientsecret
-  certificate:
-    #! This certificate should be valid for uaa.cf-system.svc.cluster.local
-    crt: *crt
-    key: *key
   #! JWT policy configuration
   jwt_policy:
     #! This private key should NOT be base64 encoded
@@ -114,22 +117,8 @@ uaa:
       key: login_service_provider_key
       certificate: login_service_provider_certificate
 
-doppler:
-  tls:
-    #! Certificate and private key for doppler to support TLS communication
-    #! - this certificate should be valid for doppler.cf-system.svc.cluster.local
-    crt: *crt
-    key: *key
-
-eirini:
-  tls:
-    #! Certificate and private key for eirini to support TLS communication
-    #! - this certificate should be valid for eirini.cf-system.svc.cluster.local
-    crt: *crt
-    key: *key
-
 #! To push apps from source code, you need to configure the `app_registry` block
-#! Example below is for docker hub. For other registry examples, see below. 
+#! Example below is for docker hub. For other registry examples, see below.
 
 app_registry:
    hostname: https://index.docker.io/v1/


### PR DESCRIPTION
This PR separates the TLS certificate used for system, workloads and internal endpoints into three, distinct, certificates. Hopefully, this will clarify what each certificate is used for, as well as provide validation that each certificate is only being used for its intended purpose since each certificate now only has the required domains associated with it.

---
- Make sure this PR is based off the `develop` branch
- Checkout the [contributing guidelines](https://github.com/cloudfoundry/cf-for-k8s/blob/develop/docs/contributing.md)
- Include any links to related PRs, issues, stories, slack discussions, etc... that will help establish context.
- Is there anything else of note that the reviewers should know about this change?

**Acceptance Steps**

* Deploy with these changes as normal
* Open the API URL for your deployment in your favourite web browser and examine the certificate to confirm that it has the correct domains for system traffic, but not for application or internal traffic
* Push an application
* Open the application URL in your favourite web browser and examine the certificate to confirm that it has the correct domains for application traffic, but not for system or internal traffic
* Retrieve the internal certificate from the `eirini-internal-tls-certs` or `uaa-certs` secret in the system namespace and confirm that it has the correct domains for internal traffic, but not for system or application traffic using the following command:

> openssl x509 -in <cert.pem> -text -noout
