### PR TITLE
bump capi to pick up api readiness check

### DIFF
--- a/config/_ytt_lib/github.com/cloudfoundry/capi-k8s-release/templates/api_server_deployment.yml
+++ b/config/_ytt_lib/github.com/cloudfoundry/capi-k8s-release/templates/api_server_deployment.yml
@@ -61,6 +61,10 @@ spec:
           imagePullPolicy: Always
           ports:
           - containerPort: 80
+          readinessProbe:
+            httpGet:
+              port: 80
+              path: "/healthz"
           volumeMounts:
           - name: nginx
             mountPath: /etc/nginx

--- a/config/_ytt_lib/github.com/cloudfoundry/capi-k8s-release/values/images.yml
+++ b/config/_ytt_lib/github.com/cloudfoundry/capi-k8s-release/values/images.yml
@@ -1,10 +1,10 @@
 #@data/values
 ---
 images:
-  capi_kpack_watcher: cloudfoundry/capi-kpack-watcher@sha256:88e06b9b420a7b9f80a86535f58a2e62ea12f7176886a505b148af0ea07ee4ea
-  ccng: cloudfoundry/cloud-controller-ng@sha256:27569309a80cb2e3105338f43e31a34be944546cb8a2a9b514206f5aba0409aa
+  capi_kpack_watcher: cloudfoundry/capi-kpack-watcher@sha256:ff54aa76f4be872de7742ab263176a41ef10da3817ee1d0cd8986755631247ce
+  ccng: cloudfoundry/cloud-controller-ng@sha256:1a13237463a8e2f47731d5f20ac406b8e9f4f564d18dd799123238c180260d7e
   cf_autodetect_builder: cloudfoundry/cnb:0.0.94-bionic@sha256:5b03a853e636b78c44e475bbc514e2b7b140cc41cca8ab907e9753431ae8c0b0
-  nginx: cloudfoundry/capi-nginx@sha256:98bd1a5240c5d39d64a04af7e847284582329eeb007db324dce19ac260f81c09
+  nginx: cloudfoundry/capi-nginx@sha256:abfa8900163892fae1ebdaffbe3619ef821b769646d51279278bff4334b3d8bc
   statsd_exporter: prom/statsd-exporter:v0.15.0@sha256:e3174186628b401e4a441b78513ba06e957644267332436be0c77dd7af9bdddc
 kbld:
   destination: null

--- a/vendir.lock.yml
+++ b/vendir.lock.yml
@@ -6,8 +6,8 @@ directories:
       sha: 1b5e17f00a6c1500eb988187cba1ce171ff58f34
     path: github.com/cloudfoundry/cf-k8s-networking
   - git:
-      commitTitle: Bump CCNG docker image manually...
-      sha: 3cd77b697476085a8b7c91c586ffba50e260d4fa
+      commitTitle: images.yml updated by CI...
+      sha: 2b8c6b0a9aca6206937e86685edc57afe906848c
     path: github.com/cloudfoundry/capi-k8s-release
   - githubRelease:
       url: https://api.github.com/repos/cloudfoundry/cf-k8s-logging/releases/26725288

--- a/vendir.yml
+++ b/vendir.yml
@@ -18,7 +18,7 @@ directories:
   - path: github.com/cloudfoundry/capi-k8s-release
     git:
       url: https://github.com/cloudfoundry/capi-k8s-release
-      ref: 3cd77b697476085a8b7c91c586ffba50e260d4fa
+      ref: 2b8c6b0a9aca6206937e86685edc57afe906848c
     includePaths:
     - templates/**/*
     - values/**/*


### PR DESCRIPTION
also bumps images to the most recent set that've passed CAPI's CI.

https://cloudfoundry.slack.com/archives/C07C04W4Q/p1590092485340200?thread_ts=1590008371.325800&cid=C07C04W4Q

**Acceptance Steps**

Check that a deployed cf-api-server pod has a readiness check. If you want to confirm that it's working, configure the cf-api-server to listen on a port other than 80 to see the readiness check fail.

at @jamespollard8 's request.

