### PR TITLE
Update docs for hostname based loadbalancer service

### DIFF
--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -166,6 +166,13 @@ This project is in it's early stages of development and hence there are features
    kubectl get svc -n istio-system istio-ingressgateway -o jsonpath='{.status.loadBalancer.ingress[*].ip}'
    ```
 
+   OR in certain environments, the external ip may be surfaced as a hostname instead. In that case use:
+
+   ```console
+   kubectl get svc -n istio-system istio-ingressgateway -o jsonpath='{.status.loadBalancer.ingress[*].hostname}'
+   ```
+
+
    > If you used a single DNS record for both `system_domain` and `app_domains`, then have it resolve to the Ingress Gateway's external IP
 
       e.g.


### PR DESCRIPTION
Fixes #209.

[#173021567](https://www.pivotaltracker.com/story/show/173021567)

Co-authored-by: Joseph Palermo <jpalermo@pivotal.io>

Updates the docs to reflect an alternate source of external ip information for domain based loadbalancer services. See the warning block on [istio docs](https://istio.io/docs/tasks/traffic-management/ingress/ingress-control/) and the loadbalancer service status api definition in the[ kubernetes api reference](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.11/#loadbalanceringress-v1-core).