### PR TITLE
Optionally include metrics-server

### DIFF
--- a/ci/tasks/install-cf-on-kind/task.sh
+++ b/ci/tasks/install-cf-on-kind/task.sh
@@ -21,9 +21,9 @@ export PATH=/tmp/kind/bin:/tmp/kind/go/bin:$PATH
 CF_VALUES=/tmp/cf-install-values.yml
 CF_RENDERED=/tmp/cf-rendered.yml
 cd /tmp/kind/cf-for-k8s
-ytt -f config -f config-optional/remove-ingressgateway-service.yml -f config-optional/remove-resource-requirements.yml -f \$CF_VALUES > \$CF_RENDERED
+ytt -f config -f config-optional/remove-ingressgateway-service.yml -f config-optional/remove-resource-requirements.yml -f config-optional/add-metrics-server-components.yml -f config-optional/patch-metrics-server.yml -f \$CF_VALUES > \$CF_RENDERED
+
 kapp deploy -f \$CF_RENDERED -a cf -y
-kubectl apply -f https://github.com/kubernetes-sigs/metrics-server/releases/download/v0.3.6/components.yaml
 EOT
 chmod +x remote-install-cf.sh
 

--- a/config-optional/add-metrics-server-components-v0.3.6.yml
+++ b/config-optional/add-metrics-server-components-v0.3.6.yml
@@ -1,0 +1,151 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: system:aggregated-metrics-reader
+  labels:
+    rbac.authorization.k8s.io/aggregate-to-view: "true"
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+rules:
+- apiGroups: ["metrics.k8s.io"]
+  resources: ["pods", "nodes"]
+  verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: metrics-server:system:auth-delegator
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:auth-delegator
+subjects:
+- kind: ServiceAccount
+  name: metrics-server
+  namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: metrics-server-auth-reader
+  namespace: kube-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: extension-apiserver-authentication-reader
+subjects:
+- kind: ServiceAccount
+  name: metrics-server
+  namespace: kube-system
+---
+apiVersion: apiregistration.k8s.io/v1beta1
+kind: APIService
+metadata:
+  name: v1beta1.metrics.k8s.io
+spec:
+  service:
+    name: metrics-server
+    namespace: kube-system
+  group: metrics.k8s.io
+  version: v1beta1
+  insecureSkipTLSVerify: true
+  groupPriorityMinimum: 100
+  versionPriority: 100
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: metrics-server
+  namespace: kube-system
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: metrics-server
+  namespace: kube-system
+  labels:
+    k8s-app: metrics-server
+spec:
+  selector:
+    matchLabels:
+      k8s-app: metrics-server
+  template:
+    metadata:
+      name: metrics-server
+      labels:
+        k8s-app: metrics-server
+    spec:
+      serviceAccountName: metrics-server
+      volumes:
+      #! mount in tmp so we can safely use from-scratch images and/or read-only containers
+      - name: tmp-dir
+        emptyDir: {}
+      containers:
+      - name: metrics-server
+        image: oratos/metrics-server:v0.3.6@sha256:a37da13de7b74c373e8698dee7836ce5fdbd102c3c1c8b9953a95e7f20138ab6
+        imagePullPolicy: IfNotPresent
+        args:
+          - --cert-dir=/tmp
+          - --secure-port=4443
+        ports:
+        - name: main-port
+          containerPort: 4443
+          protocol: TCP
+        securityContext:
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true
+          runAsUser: 1000
+        volumeMounts:
+        - name: tmp-dir
+          mountPath: /tmp
+      nodeSelector:
+        kubernetes.io/os: linux
+        kubernetes.io/arch: "amd64"
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: metrics-server
+  namespace: kube-system
+  labels:
+    kubernetes.io/name: "Metrics-server"
+    kubernetes.io/cluster-service: "true"
+spec:
+  selector:
+    k8s-app: metrics-server
+  ports:
+  - port: 443
+    protocol: TCP
+    targetPort: main-port
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: system:metrics-server
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - nodes
+  - nodes/stats
+  - namespaces
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: system:metrics-server
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:metrics-server
+subjects:
+- kind: ServiceAccount
+  name: metrics-server
+  namespace: kube-system

--- a/config-optional/add-metrics-server-components.yml
+++ b/config-optional/add-metrics-server-components.yml
@@ -1,3 +1,4 @@
+#! https://github.com/kubernetes-sigs/metrics-server/releases/download/v0.3.6/components.yaml
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/config-optional/patch-metrics-server.yml
+++ b/config-optional/patch-metrics-server.yml
@@ -1,0 +1,21 @@
+#@ load("@ytt:overlay", "overlay")
+
+#! Patch metrics-server to work in Kind
+#! https://github.com/kubernetes-sigs/kind/issues/398#issuecomment-621143252
+#! https://github.com/kubernetes-sigs/metrics-server/issues/131#issuecomment-618671827
+
+#@overlay/match by=overlay.subset({"kind":"Deployment","metadata":{"name":"metrics-server", "namespace":"kube-system"}})
+---
+spec:
+  template:
+    spec:
+      containers:
+        #@overlay/match by="name"
+        - name: metrics-server
+          #@overlay/replace
+          args:
+            - --cert-dir=/tmp
+            - --secure-port=4443
+            - --kubelet-insecure-tls
+            - --kubelet-preferred-address-types=InternalIP
+

--- a/deploy/kind-on-gcp/install-and-test.sh
+++ b/deploy/kind-on-gcp/install-and-test.sh
@@ -29,8 +29,7 @@ kind delete cluster
 kind create cluster --config=deploy/kind/cluster.yml
 CF_VALUES=/tmp/cf-values.yml
 CF_RENDERED=/tmp/cf-rendered.yml
-ytt -f config -f config-optional/remove-ingressgateway-service.yml -f config-optional/remove-resource-requirements.yml -f $CF_VALUES > $CF_RENDERED
+ytt -f config -f config-optional/remove-ingressgateway-service.yml -f config-optional/remove-resource-requirements.yml -f config-optional/add-metrics-server-components.yml -f config-optional/patch-metrics-server.yml -f $CF_VALUES > $CF_RENDERED
 kapp deploy -f $CF_RENDERED -a cf -y
-kubectl apply -f https://github.com/kubernetes-sigs/metrics-server/releases/download/v0.3.6/components.yaml
 retry 7 cf api api.vcap.me --skip-ssl-validation
 SMOKE_TEST_API_ENDPOINT="https://api.vcap.me" SMOKE_TEST_APPS_DOMAIN=vcap.me SMOKE_TEST_USERNAME=admin SMOKE_TEST_PASSWORD=$(grep cf_admin_pass $CF_VALUES | cut -d" " -f2) SMOKE_TEST_SKIP_SSL=true ./hack/run-smoke-tests.sh

--- a/docs/deploy-local.md
+++ b/docs/deploy-local.md
@@ -22,7 +22,6 @@ In addition to the Kubernetes version requirement in [Deploying CF for K8s](depl
 
 - have a minimum of 6 CPU, 6GB memory if using 1 node
   - commonly configured via Docker Desktop > Preferences > Resources
-- have a running metrics-server (this is an important consideration for **Kind** or **kubeadm** clusters. You can see one way to install it in the [Kind deploy instructions](#steps-to-deploy-on-kind))
 
 ## Considerations
 
@@ -48,19 +47,18 @@ In addition to the Kubernetes version requirement in [Deploying CF for K8s](depl
 
 1. Follow the instructions in [Deploying CF for K8s](deploy.md).
 
-   - Include the [remove-resource-requirements.yml](../config-optional/remove-resource-requirements.yml) and
-     [remove-ingressgateway-service.yml](../config-optional/remove-ingressgateway-service.yml)
+   - Include the [remove-resource-requirements.yml](../config-optional/remove-resource-requirements.yml),
+     [remove-ingressgateway-service.yml](../config-optional/remove-ingressgateway-service.yml),
+     [add-metrics-server-components-v0.3.6.yml](../config-optional/add-metrics-server-components-v0.3.6.yml) and
+     [patch-metrics-server.yml](../config-optional/patch-metrics-server.yml)
      overlay files in the set of templates to be deployed. This can be achieved by
      using the following commands:
 
      ```console
      TMP_DIR=<your-tmp-dir-path> ; mkdir -p ${TMP_DIR}
-     ytt -f config -f config-optional/remove-resource-requirements.yml -f config-optional/remove-ingressgateway-service.yml -f <cf_install_values_path> > ${TMP_DIR}/cf-for-k8s-rendered.yml
+     ytt -f config -f config-optional/remove-resource-requirements.yml -f config-optional/remove-ingressgateway-service.yml -f config-optional/add-metrics-server-components.yml -f config-optional/patch-metrics-server.yml -f <cf_install_values_path> > ${TMP_DIR}/cf-for-k8s-rendered.yml
      kapp deploy -a cf -f ${TMP_DIR}/cf-for-k8s-rendered.yml -y
      ```
-
-1. Make sure you've installed a metrics-server.
-   - this may be as simple as running something like `kubectl apply -f https://github.com/kubernetes-sigs/metrics-server/releases/download/v0.3.6/components.yaml`
 
 1. Once the `kapp deploy` succeeds, you should be able to run `cf api api.vcap.me --skip-ssl-validation`, etc
 
@@ -70,6 +68,12 @@ In addition to the Kubernetes version requirement in [Deploying CF for K8s](depl
 
    ```console
    minikube start --cpus=4 --memory=8g --kubernetes-version=1.16.8 --driver=docker
+   ```
+
+1. Enable metrics-server.
+
+   ```console
+   minikube addons enable metrics-server
    ```
 
 1. Obtain minikube IP.

--- a/docs/deploy-local.md
+++ b/docs/deploy-local.md
@@ -49,7 +49,7 @@ In addition to the Kubernetes version requirement in [Deploying CF for K8s](depl
 
    - Include the [remove-resource-requirements.yml](../config-optional/remove-resource-requirements.yml),
      [remove-ingressgateway-service.yml](../config-optional/remove-ingressgateway-service.yml),
-     [add-metrics-server-components-v0.3.6.yml](../config-optional/add-metrics-server-components-v0.3.6.yml) and
+     [add-metrics-server-components.yml](../config-optional/add-metrics-server-components.yml) and
      [patch-metrics-server.yml](../config-optional/patch-metrics-server.yml)
      overlay files in the set of templates to be deployed. This can be achieved by
      using the following commands:

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -38,12 +38,7 @@ To deploy cf-for-k8s as is, the cluster should:
 - have a minimum of 4 CPU, 15GB memory per node
 - support `LoadBalancer` services
 - support `metrics-server`
-  - Most IaaSes come with `metrics-server`, but if yours does not come with it or if you're using `kind`, then you may want to run something like 
-  
-  ```console
-    kubectl apply -f https://github.com/kubernetes-sigs/metrics-server/releases/download/v0.3.6/components.yaml
-  ```
-
+  - Most IaaSes come with `metrics-server`, but if yours does not come with it or if you're using `kind`, you will need to include `config-optional/add-metrics-server-components-v0.3.6.yml` when you render the K8s template.
 - defines a default StorageClass
   - requires [additional config on vSphere](https://vmware.github.io/vsphere-storage-for-kubernetes/documentation/storageclass.html), for example
 
@@ -143,9 +138,9 @@ This project is in it's early stages of development and hence there are features
       ```console
       ytt -f config -f ${TMP_DIR}/cf-values.yml > ${TMP_DIR}/cf-for-k8s-rendered.yml
       ```
-      > cf-for-k8s uses [ytt](https://github.com/k14s/ytt) to create and maintain reusable YAML templates. You can visit the ytt [playground](https://get-ytt.io/) to learn more about it's templating features. 
+      > cf-for-k8s uses [ytt](https://github.com/k14s/ytt) to create and maintain reusable YAML templates. You can visit the ytt [playground](https://get-ytt.io/) to learn more about it's templating features.
       > In the above command, `ytt` can take a folder e.g. `config` or file via `-f`. See all options by running `ytt help`.
-    
+
       ii. Install using `kapp` and pass the above K8s configuration file
       ```console
       kapp deploy -a cf -f ${TMP_DIR}/cf-for-k8s-rendered.yml -y
@@ -153,7 +148,7 @@ This project is in it's early stages of development and hence there are features
       > cf-for-k8s uses [kapp](https://github.com/k14s/kapp) to manage it's lifecycle. `kapp` will first show you a list of resources it plans to install on the cluster and then will attempt to install those resources. `kapp` will not exit untill all resources are installed and their status is running. See all options by running `kapp help`.
 
    Once you run the command, it should take about 10 minutes depending on your cluster bandwidth, size. `kapp` will provide updates on pending resource creations in the cluster and will wait until all resources are created and running. Here is a sample snippet from `kapp` output:
-   
+
    ```console
    4:08:19PM: ---- waiting on 1 changes [0/1 done] ----
    4:08:19PM: ok: reconcile serviceaccount/cc-kpack-registry-service-account (v1) namespace: cf-workloads-staging

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -38,7 +38,7 @@ To deploy cf-for-k8s as is, the cluster should:
 - have a minimum of 4 CPU, 15GB memory per node
 - support `LoadBalancer` services
 - support `metrics-server`
-  - Most IaaSes come with `metrics-server`, but if yours does not come with it or if you're using `kind`, you will need to include `config-optional/add-metrics-server-components-v0.3.6.yml` when you render the K8s template.
+  - Most IaaSes come with `metrics-server`, but if yours does not come with it or if you're using `kind`, you will need to include `config-optional/add-metrics-server-components.yml` when you render the K8s template.
 - defines a default StorageClass
   - requires [additional config on vSphere](https://vmware.github.io/vsphere-storage-for-kubernetes/documentation/storageclass.html), for example
 

--- a/hack/generate-values.sh
+++ b/hack/generate-values.sh
@@ -19,6 +19,7 @@ flags:
 
   -s, --silence-hack-warning
       (optional) Omit hack script warning message.
+
 EOF
   exit 1
 }
@@ -61,7 +62,7 @@ while [[ $# -gt 0 ]]; do
 done
 
 if [[ -z ${SILENCE_HACK_WARNING:=} ]]; then
-  echo "WARNING: The hack scripts are intended for development of cf-for-k8s. 
+  echo "WARNING: The hack scripts are intended for development of cf-for-k8s.
   They are not officially supported product bits.  Their interface and behavior
   may change at any time without notice." 1>&2
 fi

--- a/tests/configs/configs_test.go
+++ b/tests/configs/configs_test.go
@@ -101,18 +101,9 @@ var _ = Describe("Configs", func() {
 
 			configDirectory := filepath.Join(filepath.Dir(filepath.Dir(currentDirectory)), "config-optional")
 
-			configs := []string{}
-			filepath.Walk(configDirectory, func(path string, info os.FileInfo, err error) error {
-
-				basename := info.Name()
-
-				if strings.Contains(basename, "patch-metrics-server") || strings.Contains(basename, "add-metrics-server-components") {
-					configs = append(configs, path)
-					return nil
-				}
-
-				return nil
-			})
+			configPath := filepath.Join(configDirectory, "patch-metrics-server.yml")
+			requiredConfigPath := filepath.Join(configDirectory, "add-metrics-server-components.yml")
+			configs := []string{configPath, requiredConfigPath}
 
 			for _, config := range configs {
 				fmt.Printf("Test file %s\n", config)

--- a/tests/configs/go.sum
+++ b/tests/configs/go.sum
@@ -23,6 +23,7 @@ gopkg.in/fsnotify.v1 v1.4.7 h1:xOHLXZwVvI9hhs+cLKq5+I5onOuwQLhQwiu63xxlHs4=
 gopkg.in/fsnotify.v1 v1.4.7/go.mod h1:Tz8NjZHkW78fSQdbUxIjBTcgA1z1m8ZHf0WmKUhAMys=
 gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 h1:uRGJdciOHaEIrze2W8Q3AKkepLTh2hOroT7a+7czfdQ=
 gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7/go.mod h1:dt/ZhP58zS4L8KSrWDmTeBkI65Dw0HsyUHuEVlX15mw=
+gopkg.in/yaml.v1 v1.0.0-20140924161607-9f9df34309c0 h1:POO/ycCATvegFmVuPpQzZFJ+pGZeX22Ufu6fibxDVjU=
 gopkg.in/yaml.v1 v1.0.0-20140924161607-9f9df34309c0/go.mod h1:WDnlLJ4WF5VGsH/HVa3CI79GS0ol3YnhVnKP89i0kNg=
 gopkg.in/yaml.v2 v2.2.4 h1:/eiJrUcujPVeJ3xlSWaiNi3uSVmDGBK1pDHUHAnao1I=
 gopkg.in/yaml.v2 v2.2.4/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/vendir.lock.yml
+++ b/vendir.lock.yml
@@ -13,8 +13,8 @@ directories:
       url: https://api.github.com/repos/cloudfoundry/cf-k8s-logging/releases/26725288
     path: github.com/cloudfoundry/cf-k8s-logging/config
   - git:
-      commitTitle: Fix annotated image...
-      sha: 63ec659248536d203a399acba04e307e1825c9e2
+      commitTitle: Remove enable_metrics_server value...
+      sha: a987a51e3f1a9cea53784141fde2520feb07e260
     path: github.com/cloudfoundry/metric-proxy
   - git:
       commitTitle: Update UAA image reference in k8s deployment template to 74.21.0

--- a/vendir.yml
+++ b/vendir.yml
@@ -31,7 +31,7 @@ directories:
   - path: github.com/cloudfoundry/metric-proxy
     git:
       url: https://github.com/cloudfoundry/metric-proxy
-      ref: 63ec659248536d203a399acba04e307e1825c9e2
+      ref: a987a51e3f1a9cea53784141fde2520feb07e260
     includePaths:
     - config/**/*
   - path: github.com/cloudfoundry/uaa


### PR DESCRIPTION
This PR allows providing metrics-server on clusters that don't provide it.

`metric_proxy` requires `metrics-server` to function, but not all IaaSes provide the metrics-server, so this change allows operators to include metrics-server on IaaSes that don't already provide it: (e.g. EKS, kind, minikube) using a config-optional file.

---

Relevant stories/issues:
- https://www.pivotaltracker.com/story/show/172821078
- https://www.pivotaltracker.com/story/show/172771099  
- https://www.pivotaltracker.com/story/show/172319933

- https://github.com/cloudfoundry/cf-for-k8s/issues/210#issue-625110008
- https://github.com/cloudfoundry/cf-for-k8s/issues/177 
- https://github.com/cloudfoundry/cf-for-k8s/issues/123 

**Acceptance Steps**

In an IaaS without a metrics-server (e.g. EKS),  include `config-optional/add-metrics-server-components.yml` when rendering the k8s template with `ytt`.

Once this is successfully deployed, there should be a metrics-server in the kube-system namespace, and you should see container metrics when running `cf app`.

Note: If deploying on `kind` or `minikube`, follow the steps in [deploy-local.md](https://github.com/cloudfoundry/cf-for-k8s/blob/metrics-server/docs/deploy-local.md), and you should see the same results: metrics-server running in kube-system and container metrics when running `cf app`.

pair: @heycait @kkburr 
PM: @hev 
team: @cloudfoundry/cf-loggregator 