### PR TITLE
Add additional namespaces to istio mesh

### DIFF
--- a/config/kpack.yml
+++ b/config/kpack.yml
@@ -16,3 +16,17 @@ spec:
   peers:
   - mtls:
       mode: PERMISSIVE
+---
+#! apiServer fails to validate certs provided by istio endpoints.
+#! traffic from apiServer to kpack-webhook is TLS even without istio
+apiVersion: "authentication.istio.io/v1alpha1"
+kind: "Policy"
+metadata:
+  name: "kpack-webhook-allow-plaintext"
+  namespace: "kpack"
+spec:
+  targets:
+  - name: kpack-webhook
+  peers:
+  - mtls:
+      mode: PERMISSIVE

--- a/config/networking.yml
+++ b/config/networking.yml
@@ -41,12 +41,12 @@ metadata:
 #@ kind_stateful_set = overlay.subset({"kind":"StatefulSet"})
 #@ kind_daemon_set = overlay.subset({"kind":"DaemonSet"})
 #@ kind_job = overlay.subset({"kind":"Job"})
-#@ is_pod = overlay.or_op(kind_deployment, kind_replica_set, kind_stateful_set, kind_daemon_set, kind_job)
+#@ contains_pod = overlay.or_op(kind_deployment, kind_replica_set, kind_stateful_set, kind_daemon_set, kind_job)
 
 #@ namespaced = lambda idx,old,new: "namespace" in old["metadata"]
 #@ not_inside_istio_ns = overlay.not_op(overlay.subset({"metadata":{"namespace":"istio-system"}}))
 
-#@overlay/match by=overlay.and_op(is_pod, namespaced, not_inside_istio_ns), expects="1+"
+#@overlay/match by=overlay.and_op(contains_pod, namespaced, not_inside_istio_ns), expects="1+"
 ---
 metadata:
   #@overlay/match missing_ok=True

--- a/config/networking.yml
+++ b/config/networking.yml
@@ -36,23 +36,9 @@ metadata:
     #@overlay/match missing_ok=True
     cf-for-k8s.cloudfoundry.org/istio-system-ns: ""
 
-#@ cf_namespaces = [data.values.system_namespace, data.values.workloads_namespace , "cf-db", "cf-blobstore", "metacontroller"]
-
-#! Enable istio sidecar injection on cf namespaces
-#@ for namespace in cf_namespaces:
-#@overlay/match by=overlay.subset({"metadata":{"namespace": namespace}}), expects="1+"
----
-metadata:
-  #@overlay/match missing_ok=True
-  annotations:
-    #@overlay/match missing_ok=True
-    kapp.k14s.io/change-rule.istio-sidecar-injector: "upsert after upserting cf-for-k8s.cloudfoundry.org/istio-sidecar-injector"
-#@ end
-
 #! Because the istio sidecar injector is a mutatingwebhook on pod create, we need to guarantee its creation before we start creating pods
 #! in cf namespaces.
 
-#@ for namespace in cf_namespaces:
 #@overlay/match by=overlay.subset({"kind": "MutatingWebhookConfiguration", "metadata":{"name": "istio-sidecar-injector"}})
 ---
 metadata:
@@ -61,11 +47,17 @@ metadata:
     #@overlay/match missing_ok=True
     kapp.k14s.io/change-group: cf-for-k8s.cloudfoundry.org/istio-sidecar-injector
 
-#@overlay/match by=overlay.subset({"kind":"Namespace", "metadata":{"name": namespace}})
+
+#@ ns_matcher = overlay.subset({"kind": "Namespace"})
+#@ not_istio_system = overlay.not_op(overlay.subset({"metadata":{"name": "istio-system"}}))
+#@overlay/match by=overlay.and_op(ns_matcher, not_istio_system), expects="1+"
 ---
 metadata:
+  #@overlay/match missing_ok=True
+  annotations:
+    #@overlay/match missing_ok=True
+    kapp.k14s.io/change-rule.istio-sidecar-injector: "upsert after upserting cf-for-k8s.cloudfoundry.org/istio-sidecar-injector"
   #@overlay/match missing_ok=True
   labels:
     #@overlay/match missing_ok=True
     istio-injection: enabled
-#@ end

--- a/config/networking.yml
+++ b/config/networking.yml
@@ -36,6 +36,24 @@ metadata:
     #@overlay/match missing_ok=True
     cf-for-k8s.cloudfoundry.org/istio-system-ns: ""
 
+#@ kind_deployment = overlay.subset({"kind":"Deployment"})
+#@ kind_replica_set = overlay.subset({"kind":"ReplicaSet"})
+#@ kind_stateful_set = overlay.subset({"kind":"StatefulSet"})
+#@ kind_daemon_set = overlay.subset({"kind":"DaemonSet"})
+#@ kind_job = overlay.subset({"kind":"Job"})
+#@ is_pod = overlay.or_op(kind_deployment, kind_replica_set, kind_stateful_set, kind_daemon_set, kind_job)
+
+#@ namespaced = lambda idx,old,new: "namespace" in old["metadata"]
+#@ not_inside_istio_ns = overlay.not_op(overlay.subset({"metadata":{"namespace":"istio-system"}}))
+
+#@overlay/match by=overlay.and_op(is_pod, namespaced, not_inside_istio_ns), expects="1+"
+---
+metadata:
+  #@overlay/match missing_ok=True
+  annotations:
+    #@overlay/match missing_ok=True
+    kapp.k14s.io/change-rule.istio-sidecar-injector: "upsert after upserting cf-for-k8s.cloudfoundry.org/istio-sidecar-injector"
+
 #! Because the istio sidecar injector is a mutatingwebhook on pod create, we need to guarantee its creation before we start creating pods
 #! in cf namespaces.
 
@@ -47,16 +65,12 @@ metadata:
     #@overlay/match missing_ok=True
     kapp.k14s.io/change-group: cf-for-k8s.cloudfoundry.org/istio-sidecar-injector
 
+#@ is_ns = overlay.subset({"kind":"Namespace"})
+#@ not_istio_ns = overlay.not_op(overlay.subset({"metadata":{"name":"istio-system"}}))
 
-#@ ns_matcher = overlay.subset({"kind": "Namespace"})
-#@ not_istio_system = overlay.not_op(overlay.subset({"metadata":{"name": "istio-system"}}))
-#@overlay/match by=overlay.and_op(ns_matcher, not_istio_system), expects="1+"
+#@overlay/match by=overlay.and_op(is_ns, not_istio_ns), expects="1+"
 ---
 metadata:
-  #@overlay/match missing_ok=True
-  annotations:
-    #@overlay/match missing_ok=True
-    kapp.k14s.io/change-rule.istio-sidecar-injector: "upsert after upserting cf-for-k8s.cloudfoundry.org/istio-sidecar-injector"
   #@overlay/match missing_ok=True
   labels:
     #@overlay/match missing_ok=True


### PR DESCRIPTION
- new namespaces except istio-system have istio injection enabled by
default
- Add exception for kpack-webhook since istio strict TLS does not work
for communication between apiServer and webhooks

[#172880857](https://www.pivotaltracker.com/story/show/172880857)
Co-authored-by: Joseph Palermo <jpalermo@pivotal.io>
Co-authored-by: Lisa Burns <lcho@pivotal.io>
