### PR TITLE
Rename system certificate secret to cf-system-cert

### DIFF
--- a/config/external-routing.yml
+++ b/config/external-routing.yml
@@ -6,7 +6,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: istio-ingressgateway-certs
+  name: cf-system-cert
   namespace: istio-system
   annotations:
     kapp.k14s.io/change-rule.istio-ingressgateway: "upsert before upserting istio.io/ingressgateway"

--- a/config/gateway.lib.yml
+++ b/config/gateway.lib.yml
@@ -23,7 +23,7 @@ spec:
       protocol: HTTPS
     tls:
       mode: SIMPLE
-      credentialName: istio-ingressgateway-certs
+      credentialName: cf-system-cert
   #@ non_system_domain_app_domains = [d for d in app_domains if d != system_domain]
   #@ if/end len(non_system_domain_app_domains) > 0:
   - hosts:


### PR DESCRIPTION
This PR renames the system certificate from `istio-ingressgateway-certs` to `cf-system-cert`. This is to support hot reloading of certificates when the secret changes. For some reason Istio doesn't hot reload certificates if the Kubernetes secret name begins with `istio`. The only reference I could find to this in their documentation is in a note [here](https://istio.io/docs/tasks/traffic-management/ingress/secure-ingress/#configure-a-tls-ingress-gateway-for-a-single-host), but it doesn't really explain why. It seems best to change it to a new name that doesn't start with `istio` and as a bonus this will also keep it consistent with the `cf-workloads-cert` secret name.

Related tracker story [#173181160](https://www.pivotaltracker.com/story/show/173181160).

---

**Acceptance Steps**

_please provide a series of instructions (eg kubectl or cf cli commands) for how our Product Manager can verify that your changes were properly integrated_

Given you have a cf-for-k8s environment deployed with the changes
You can

1. Ask the Istio Ingress Gateway for the certificate for a system component.
```
echo | openssl s_client -showcerts -servername api.<DOMAIN> -connect api.<DOMAIN>:443 2> /dev/null
```
2. Rotate your system certificate in `cf-values.yaml`.
  a. Assuming you created your environment with the `./hack/generate-values.sh`, you can open the `/tmp/<DOMAIN>/cf-vars.yaml` and delete the `system_certificate` key and values. Then rerun `./hack/generate-values.sh` again. At this point your `cf-values.yaml` should have a new certificate for the system certificate.

3. Deploy with the updated `cf-values.yaml`.

4. Ask the Istio Ingress Gateway for the certificate again and see the certificate matches the newly generated certificate under `system_certificate.cert` in `/tmp/<DOMAIN>/cf-vars.yaml`.
```
echo | openssl s_client -showcerts -servername api.<DOMAIN> -connect api.<DOMAIN>:443 2> /dev/null
```

_Tag your pair, your PM, and/or team_

> _It's helpful to tag a few other folks on your team or your team alias in case we need to follow up later._

@cloudfoundry/cf-networking 