### PR TITLE
Make blob storage configurable for GCP

### DIFF
--- a/config/_ytt_lib/github.com/cloudfoundry/capi-k8s-release/templates/ccng-config.lib.yml
+++ b/config/_ytt_lib/github.com/cloudfoundry/capi-k8s-release/templates/ccng-config.lib.yml
@@ -1,4 +1,7 @@
 #@ load("@ytt:data","data")
+#@ load("@ytt:yaml","yaml")
+#@ load("fog-connection.lib.yml","fog_connection")
+
 #@ def ccng_config():
 ---
 local_route: 0.0.0.0
@@ -172,14 +175,7 @@ default_quota_definition: default
 resource_pool:
   resource_directory_key: #@ data.values.blobstore.resource_directory_key
   blobstore_type: fog
-  fog_connection:
-    provider: AWS
-    endpoint: #@ data.values.blobstore.endpoint
-    aws_access_key_id: #@ data.values.blobstore.access_key_id
-    aws_secret_access_key: #@ data.values.blobstore.secret_access_key
-    aws_signature_version: '2'
-    region: #@ data.values.blobstore.region
-    path_style: true
+  fog_connection: #@ fog_connection()
   minimum_size: 65536
   maximum_size: 536870912
 
@@ -193,14 +189,7 @@ resource_pool:
 packages:
   app_package_directory_key: #@ data.values.blobstore.package_directory_key
   blobstore_type: fog
-  fog_connection:
-    provider: AWS
-    endpoint: #@ data.values.blobstore.endpoint
-    aws_access_key_id: #@ data.values.blobstore.access_key_id
-    aws_secret_access_key: #@ data.values.blobstore.secret_access_key
-    aws_signature_version: '2'
-    region: #@ data.values.blobstore.region
-    path_style: true
+  fog_connection: #@ fog_connection()
   max_valid_packages_stored: 5
   max_package_size: 1073741824
 
@@ -214,14 +203,7 @@ packages:
 droplets:
   droplet_directory_key: #@ data.values.blobstore.droplet_directory_key
   blobstore_type: fog
-  fog_connection:
-    provider: AWS
-    endpoint: #@ data.values.blobstore.endpoint
-    aws_access_key_id: #@ data.values.blobstore.access_key_id
-    aws_secret_access_key: #@ data.values.blobstore.secret_access_key
-    aws_signature_version: '2'
-    region: #@ data.values.blobstore.region
-    path_style: true
+  fog_connection: #@ fog_connection()
 
   cdn:
     uri:
@@ -234,14 +216,7 @@ droplets:
 buildpacks:
   buildpack_directory_key: #@ data.values.blobstore.buildpack_directory_key
   blobstore_type: fog
-  fog_connection:
-    provider: AWS
-    endpoint: #@ data.values.blobstore.endpoint
-    aws_access_key_id: #@ data.values.blobstore.access_key_id
-    aws_secret_access_key: #@ data.values.blobstore.secret_access_key
-    aws_signature_version: '2'
-    region: #@ data.values.blobstore.region
-    path_style: true
+  fog_connection: #@ fog_connection()
 
   cdn:
     uri:

--- a/config/_ytt_lib/github.com/cloudfoundry/capi-k8s-release/templates/fog-connection.lib.yml
+++ b/config/_ytt_lib/github.com/cloudfoundry/capi-k8s-release/templates/fog-connection.lib.yml
@@ -1,0 +1,22 @@
+#@ load("@ytt:data","data")
+#@ load("@ytt:assert","assert")
+
+#@ def fog_connection():
+#@ if data.values.blobstore.provider == "AWS":
+provider: #@ data.values.blobstore.provider
+endpoint: #@ data.values.blobstore.endpoint
+aws_access_key_id: #@ data.values.blobstore.access_key_id
+aws_secret_access_key: #@ data.values.blobstore.secret_access_key
+aws_signature_version: '2'
+region: #@ data.values.blobstore.region if data.values.blobstore.region else ""
+path_style: true
+#@ elif data.values.blobstore.provider == "Google":
+provider: #@ data.values.blobstore.provider
+google_project: #@ data.values.blobstore.google_project
+google_client_email: #@ data.values.blobstore.google_client_email
+google_json_key_string: #@ data.values.blobstore.google_json_key_string
+#@ else:
+  #@ assert.fail("blobstore provider must be AWS or Google.")
+#@ end
+
+#@ end

--- a/config/_ytt_lib/github.com/cloudfoundry/capi-k8s-release/values/_default.yml
+++ b/config/_ytt_lib/github.com/cloudfoundry/capi-k8s-release/values/_default.yml
@@ -66,14 +66,18 @@ apiServer:
       -----END RSA PRIVATE KEY-----
 app_domains: []
 blobstore:
+  provider: AWS
   access_key_id: AKIAIOSFODNN7EXAMPLE
   buildpack_directory_key: cc-buildpacks
   droplet_directory_key: cc-droplets
   endpoint: http://capi-blobstore-minio.default:9000
   package_directory_key: cc-packages
-  region: ""
+  region: ~
   resource_directory_key: cc-resources
   secret_access_key: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
+  google_project: project-id
+  google_client_email: client-email
+  google_json_key_string: "{}"
 ccdb:
   adapter: postgres
   database: cloud_controller

--- a/config/capi.yml
+++ b/config/capi.yml
@@ -32,6 +32,7 @@ app_domains:
 - #@ domain
 
 blobstore:
+  provider: #@ data.values.capi.blobstore.provider
   endpoint: #@ data.values.capi.blobstore.endpoint
   region: #@ data.values.capi.blobstore.region
   access_key_id: #@ data.values.cf_blobstore.access_key
@@ -40,7 +41,9 @@ blobstore:
   droplet_directory_key: #@ data.values.capi.blobstore.droplet_directory_key
   resource_directory_key: #@ data.values.capi.blobstore.resource_directory_key
   buildpack_directory_key: #@ data.values.capi.blobstore.buildpack_directory_key
-
+  google_project: #@ data.values.capi.blobstore.google_project
+  google_client_email: #@ data.values.capi.blobstore.google_client_email
+  google_json_key_string: #@ data.values.capi.blobstore.google_json_key_string
 ccdb:
   adapter: #@ data.values.capi.database.adapter
   host: #@ capi_host()

--- a/config/values.yml
+++ b/config/values.yml
@@ -1,5 +1,6 @@
 #@data/values
 ---
+
 system_namespace: cf-system
 workloads_namespace: cf-workloads
 staging_namespace: cf-workloads-staging
@@ -59,12 +60,16 @@ internal_certificate:
 
 capi:
   blobstore:
+    provider: AWS
     package_directory_key: cc-packages
     droplet_directory_key: cc-droplets
     resource_directory_key: cc-resources
     buildpack_directory_key: cc-buildpacks
-    region: "''"
+    region: ~
     endpoint: "http://cf-blobstore-minio.cf-blobstore.svc.cluster.local:9000"
+    google_project: project-id
+    google_client_email: client-email
+    google_json_key_string: "{}"
   database:
     #! or mysql2, as needed
     adapter: postgres


### PR DESCRIPTION
* Moved fog blob storage connectity config to its own library file and allow for Google storage
* Change default region from "''" to ~.  Logic in the fog library will set it to "" if nil. This stops extra templating from adding more and more quote marks around it.

Some of this change probably lives [upstream](https://github.com/cloudfoundry/capi-k8s-release/blob/master/templates/ccng-config.lib.yml#L197-L203) but I figured I'd start here to get the discussion going.

I imagine adding a blob storage option for minio rather than keying of AWS, this would allow us to disable installing minio if GCP or AWS.

Signed-off-by: Paul Czarkowski <username.taken@gmail.com>



> Thanks for contributing to cf-for-k8s!
>
> We've designed this PR template to speed up the PR review and merge process - please use it.

> _Please describe the change here._ 

---


- Make sure this PR is based off the `develop` branch
- Checkout the [contributing guidelines](https://github.com/cloudfoundry/cf-for-k8s/blob/develop/docs/contributing.md)
- Include any links to related PRs, issues, stories, slack discussions, etc... that will help establish context.
- Is there anything else of note that the reviewers should know about this change?

**Acceptance Steps**

_please provide a series of instructions (eg kubectl or cf cli commands) for how our Product Manager can verify that your changes were properly integrated_


_Tag your pair, your PM, and/or team_

> _It's helpful to tag a few other folks on your team or your team alias in case we need to follow up later._
