### PR TITLE
Enable tls for external uaa

### DIFF
--- a/config/uaa.yml
+++ b/config/uaa.yml
@@ -16,10 +16,11 @@
 #@ end
 
 #@ def database_query_params(scheme):
+#@   useSSL=len(data.values.uaa.database.ca_cert) > 0
 #@   if scheme == "postgresql":
-#@     return "?sslmode=disable"
+#@     return "?sslmode=verify-full&sslfactory=org.postgresql.ssl.DefaultJavaSSLFactory" if useSSL else "?sslmode=disable"
 #@   elif scheme == "mysql":
-#@     return "?useSSL=false"
+#@     return "?useSSL=true" if useSSL else "?useSSL=false"
 #@   end
 #@   return ""
 #@ end
@@ -42,6 +43,11 @@ database:
   scheme: #@ data.values.uaa.database.adapter
   username: #@ data.values.uaa.database.user
   password: #@ data.values.uaa.database.password
+
+#@ if/end len(data.values.uaa.database.ca_cert) > 0:
+#@overlay/replace
+ca_certs:
+  -  #@ data.values.uaa.database.ca_cert
 
 namespace: #@ data.values.system_namespace
 

--- a/config/values.yml
+++ b/config/values.yml
@@ -88,6 +88,8 @@ uaa:
     #! DB user password in plain text
     password: ""
     name: uaa
+    #! Plain text ca certificate for tls
+    ca_cert: ""
 
   jwt_policy:
     key_id: "default_jwt_policy_key"


### PR DESCRIPTION
Co-authored-by: Ulrich Kramer <u.kramer@sap.com>



> Thanks for contributing to cf-for-k8s!
>
> We've designed this PR template to speed up the PR review and merge process - please use it.

> _Please describe the change here._ 

If case of using an external database for uaa (e.g. RDS), using tls is important for obvious reasons. By setting the ca cert which is used to verify the certificate of the database server, tls will be enabled. Using an external database without a ca certificate will still unencrypted communication.


- Make sure this PR is based off the `develop` branch
- Checkout the [contributing guidelines](https://github.com/cloudfoundry/cf-for-k8s/blob/develop/docs/contributing.md)
- Include any links to related PRs, issues, stories, slack discussions, etc... that will help establish context.

We have tested it with RDS  (Amazon), with postgres and with mysql.

- Is there anything else of note that the reviewers should know about this change?

**Acceptance Steps**

_please provide a series of instructions (eg kubectl or cf cli commands) for how our Product Manager can verify that your changes were properly integrated_


_Tag your pair, your PM, and/or team_

> _It's helpful to tag a few other folks on your team or your team alias in case we need to follow up later._
