### PR TITLE
Explicitly copy/paste default scopes for user

### DIFF
--- a/config/uaa.yml
+++ b/config/uaa.yml
@@ -132,6 +132,24 @@ oauth:
       authorities: cloud_controller.write,cloud_controller.update_build_state
       authorized-grant-types: client_credentials
       secret: #@ data.values.uaa.admin_client_secret
+  #@overlay/match missing_ok=True
+  user:
+    authorities:
+      - openid
+      - scim.me
+      - cloud_controller.read
+      - cloud_controller.write
+      - cloud_controller_service_permissions.read
+      - password.write
+      - uaa.user
+      - approvals.me
+      - oauth.approvals
+      - notification_preferences.read
+      - notification_preferences.write
+      - profile
+      - roles
+      - user_attributes
+      - uaa.offline_token
 
 issuer:
   uri: #@ "https://uaa." + data.values.system_domain


### PR DESCRIPTION
* Allows for downstream overlays to safely append to the list of default scopes granted to a newly created UAA user, instead of being holding downstream overlays responsible for owning the default list.

---

**Acceptance Steps**

1. Deploy old cf-for-k8s
1. Using uaac, collect the list of scopes granted to a newly created user (`uaac user get <>`).
1. Deploy new cf-for-k8s
1. Using uaac, observe the list of scopes granted to a newly created user has not changed.
