### PR TITLE
Do not install cf-db if external databases are used for capi and uaa

### DIFF
--- a/config/capi.yml
+++ b/config/capi.yml
@@ -8,10 +8,8 @@
 #@ def capi_host():
 #@   if len(data.values.capi.database.host) > 0:
 #@     return data.values.capi.database.host
-#@   elif data.values.cf_db.enabled == True:
-#@     return "cf-db-postgresql.cf-db.svc.cluster.local"
 #@   else:
-#@     assert.fail("When cf_db.enabled is false, expected a capi.database.host to be provided, but was not.")
+#@     return "cf-db-postgresql.cf-db.svc.cluster.local"
 #@   end
 #@ end
 

--- a/config/fix-db-startup-order.yml
+++ b/config/fix-db-startup-order.yml
@@ -1,5 +1,8 @@
 #@ load("@ytt:overlay", "overlay")
+#@ load("@ytt:data", "data")
+#@ load("postgres.star", "cfdb_enabled")
 
+#@ if cfdb_enabled():
 #@overlay/match by=overlay.subset({"kind": "StatefulSet", "metadata":{"name": "cf-db-postgresql"}})
 ---
 metadata:
@@ -39,3 +42,4 @@ metadata:
   annotations:
     #@overlay/match missing_ok=True
     kapp.k14s.io/change-rule.cf-db-postgresql: "upsert after upserting cf-for-k8s.cloudfoundry.org/cf-db-postgresql"
+#@ end

--- a/config/postgres.star
+++ b/config/postgres.star
@@ -1,0 +1,5 @@
+load("@ytt:data", "data")
+
+def cfdb_enabled():
+  return len(data.values.uaa.database.host) == 0 or len(data.values.capi.database.host) == 0
+end

--- a/config/postgres.yml
+++ b/config/postgres.yml
@@ -4,6 +4,7 @@
 #@ load("@ytt:library", "library")
 #@ load("@ytt:overlay", "overlay")
 #@ load("@ytt:template", "template")
+#@ load("postgres.star", "cfdb_enabled")
 
 #@ def add_cf_db_namespace():
 #@overlay/match by=overlay.all, expects="1+"
@@ -13,6 +14,7 @@ metadata:
   namespace: cf-db
 #@ end
 
+#@ if cfdb_enabled():
 ---
 apiVersion: v1
 kind: Namespace
@@ -79,3 +81,4 @@ data:
     psql -U postgres -d (@= uaadb.name @) -c "CREATE EXTENSION citext"
 
 --- #@ template.replace(overlay.apply(library.get("postgres").eval(), add_cf_db_namespace()))
+#@ end

--- a/config/uaa.yml
+++ b/config/uaa.yml
@@ -8,10 +8,8 @@
 #@ def uaa_db_host():
 #@   if len(data.values.uaa.database.host) > 0:
 #@     return data.values.uaa.database.host
-#@   elif data.values.cf_db.enabled == True:
-#@     return "cf-db-postgresql.cf-db.svc.cluster.local"
 #@   else:
-#@     assert.fail("When cf_db.enabled is false, expected a uaa.database.host to be provided, but was not.")
+#@     return "cf-db-postgresql.cf-db.svc.cluster.local"
 #@   end
 #@ end
 

--- a/config/values.yml
+++ b/config/values.yml
@@ -20,7 +20,6 @@ cf_blobstore:
 #! control optional deployment of a database for CF
 cf_db:
   admin_password: ""
-  enabled: true
 
 #! reserved static ip for istio LoadBalancer
 istio_static_ip: ""


### PR DESCRIPTION
> Thanks for contributing to cf-for-k8s!
>
> We've designed this PR template to speed up the PR review and merge process - please use it.

> _Please describe the change here._ 

If external databases are used for capi and uaa, there is no need to install an internal one. Only if at least one is not using `hostname` to specify a database host, we install an internal one and use its hostname.

- Make sure this PR is based off the `develop` branch
- Checkout the [contributing guidelines](https://github.com/cloudfoundry/cf-for-k8s/blob/develop/docs/contributing.md)
- Include any links to related PRs, issues, stories, slack discussions, etc... that will help establish context.

For documentation on external databases, see
https://github.com/cloudfoundry/cf-for-k8s/pull/143

- Is there anything else of note that the reviewers should know about this change?

**Acceptance Steps**

_please provide a series of instructions (eg kubectl or cf cli commands) for how our Product Manager can verify that your changes were properly integrated_

1. If you use an external database for capi **AND** uaa (by providing a hostname), then we should see no internal database and kapp deploy and smoketests should pass

2. If you just use defaults (use an internal database for either capi, uaa or both), then we should see the internal database and kapp deploy and smoketests should pass.

_Tag your pair, your PM, and/or team_

> _It's helpful to tag a few other folks on your team or your team alias in case we need to follow up later._
