### PR TITLE
Apply ssl for system domain workloads

### DIFF
--- a/config/gateway.lib.yml
+++ b/config/gateway.lib.yml
@@ -16,7 +16,7 @@ spec:
       number: 80
       protocol: HTTP
   - hosts:
-    - #@ ('' if system_domain in app_domains else system_namespace + '/') + '*.' + system_domain
+    - #@ ('' if system_domain in app_domains else '*/') + '*.' + system_domain
     port:
       name: https-system
       number: 443

--- a/config/gateway_test.star
+++ b/config/gateway_test.star
@@ -20,9 +20,9 @@ def test_gateway_when_app_domain_does_not_equal_system_domain():
   # We expect two https-based entries in the servers list: one for the system domain, and a different one for the app domain
   assert_equals(2, len(https_servers))
 
-  # We expect the host field of both servers to be restricted by namespace
+  # We expect the workloads namespace to be defined separate from the system domain, so that it uses the workloads certificate
   assert_equals(1, len(https_servers[0]["hosts"]))
-  assert_equals("sys-namespace/*.sys-domain.com", https_servers[0]["hosts"][0])
+  assert_equals("*/*.sys-domain.com", https_servers[0]["hosts"][0])
   assert_equals(1, len(https_servers[1]["hosts"]))
   assert_equals("work-namespace/*.app-domain.com", https_servers[1]["hosts"][0])
 end


### PR DESCRIPTION
* Full wildcard was recommended by the Networking team in #238
* Allows SSL traffic to apps deployed to the system domain
* Apps deployed to the workloads namespace will continue to use the
workloads certificate.
* Copy of #242

---



**Acceptance Steps**

I listed out acceptance in #238.


_Tag your pair, your PM, and/or team_

@weymanf
