### PR TITLE
Enable tls for external capi database

### DIFF
--- a/config/capi.yml
+++ b/config/capi.yml
@@ -48,6 +48,7 @@ ccdb:
   user: #@ data.values.capi.database.user
   password: #@ data.values.capi.database.password
   database: #@ data.values.capi.database.name
+  ca_cert: #@ data.values.capi.database.ca_cert
 
 eirini:
   serverCerts:

--- a/config/values.yml
+++ b/config/values.yml
@@ -73,6 +73,8 @@ capi:
     #! DB user password in plain text
     password: ""
     name: cloud_controller
+    #! Plain text ca certificate if tls should be used
+    ca_cert: ""
 
 uaa:
   #! client secret for uaa admin client in plain text


### PR DESCRIPTION
Set the ca_cert value introduced in the capi release.