### PR TITLE
smoke-test: Increase timeout of cf-push to 10 min

### DIFF
--- a/tests/smoke/smoke_test.go
+++ b/tests/smoke/smoke_test.go
@@ -90,7 +90,7 @@ var _ = Describe("Smoke Tests", func() {
 
 			By("pushing an app and checking that the CF CLI command succeeds")
 			cfPush := cf.Cf("push", appName, "-p", "assets/test-node-app", "--no-route")
-			Eventually(cfPush).Should(Exit(0))
+			Eventually(cfPush, 10*time.Minute).Should(Exit(0))
 			mapRoute(appName)
 
 			By("querying the app")


### PR DESCRIPTION
Especially the first `cf push` sometimes takes longer than 5 minutes, which is the current timeout.
