### PR TITLE
Add quarks secret

### DIFF
--- a/build/quarks-secret/_vendir/LICENSE
+++ b/build/quarks-secret/_vendir/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/build/quarks-secret/_vendir/NOTICE
+++ b/build/quarks-secret/_vendir/NOTICE
@@ -1,0 +1,7 @@
+Copyright (c) 2019-Present CloudFoundry.org Foundation, Inc. All Rights Reserved.
+This project is licensed to you under the Apache License, Version 2.0 (the "License").
+You may not use this project except in compliance with the License.
+
+This project may include a number of subcomponents with separate copyright notices
+and license terms. Your use of these subcomponents is subject to the terms and 
+conditions of the subcomponent's license, as noted in the LICENSE file.

--- a/build/quarks-secret/_vendir/deploy/helm/quarks-secret/.helmignore
+++ b/build/quarks-secret/_vendir/deploy/helm/quarks-secret/.helmignore
@@ -1,0 +1,21 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj

--- a/build/quarks-secret/_vendir/deploy/helm/quarks-secret/Chart.yaml
+++ b/build/quarks-secret/_vendir/deploy/helm/quarks-secret/Chart.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+name: quarks-secret
+version: x.x.x
+appVersion: x.x.x
+description: A Helm chart for quarks-secret, a k8s operator to create secrets
+home: https://github.com/cloudfoundry-incubator/quarks-secret
+icon: https://cloudfoundry-incubator.github.io/quarks-helm/logo.png
+keywords:
+- quarks
+- secret
+- rotation
+sources:
+- https://github.com/cloudfoundry-incubator/quarks-secret
+maintainers:
+- name: project-quarks
+  email: project-quarks@googlegroups.com

--- a/build/quarks-secret/_vendir/deploy/helm/quarks-secret/README.md
+++ b/build/quarks-secret/_vendir/deploy/helm/quarks-secret/README.md
@@ -1,0 +1,68 @@
+# QUARKS SECRET
+
+## Introduction
+
+This helm chart deploys the quarks-secret operator.
+
+## Installing the Latest Stable Chart
+
+To install the latest stable helm chart, with `quarks-secret` as the release name into the namespace `quarks`:
+
+```bash
+helm repo add quarks https://cloudfoundry-incubator.github.io/quarks-helm/
+helm install quarks-secret quarks/quarks-secret
+```
+
+### Namespaces
+
+The operator runs on every namespace that has the monitoredID label (quarks.cloudfoundry.org/monitored).
+
+```
+helm install relname1 quarks/quarks-secret \
+  --set "global.monitoredID=relname1"
+```
+
+## Installing the Chart From the Developmenet Branch
+
+Download the shared scripts with `bin/tools`, set `PROJECT=quarks-secret` and run `bin/build-image` to create a new docker image. Export `DOCKER_IMAGE_TAG` to override the tag that's being put in the chart.
+
+To install the helm chart directly from the [quarks-secret repository](https://github.com/cloudfoundry-incubator/quarks-secret) (any branch), run `bin/build-helm` first.
+
+## Uninstalling the Chart
+
+To delete the helm chart:
+
+```bash
+$ helm delete quarks-secret --purge
+```
+
+## Configuration
+
+| Parameter                                         | Description                                                                            | Default                                        |
+| ------------------------------------------------- | -------------------------------------------------------------------------------------- | ---------------------------------------------- |
+| `global.contextTimeout`                           | Will set the context timeout in seconds, for future K8S API requests                   | `30`                                           |
+| `global.image.pullPolicy`                         | Kubernetes image pullPolicy                                                            | `IfNotPresent`                                 |
+| `global.monitoredID`                              | Label value of 'quarks.cloudfoundry.org/monitored'. Matching namespaces are watched    | release name                                   |
+| `global.rbac.create`                              | Install required RBAC service account, roles and rolebindings                          | `true`                                         |
+| `serviceAccount.create`                           | If true, create a service account                                                      | `true`                                         |
+| `serviceAccount.name`                             | If not set and `create` is `true`, a name is generated using the fullname of the chart |                                                |
+
+## RBAC
+
+By default, the helm chart will install RBAC ClusterRole and ClusterRoleBinding based on the chart release name, it will also grant the ClusterRole to an specific service account, which have the same name of the chart release.
+
+The RBAC resources are enable by default. To disable use `--set global.rbacEnable=false`.
+
+## Custom Resources
+
+The `quarks-secret` watches for the `QuarksSecret` custom resource.
+
+The `quarks-secret` requires this CRD to be installed in the cluster, in order to work as expected. By default, the `quarks-secret` applies the CRD in your cluster automatically.
+
+To verify if the CRD is installed:
+
+```bash
+$ kubectl get crds
+NAME                                            CREATED AT
+quarkssecrets.quarks.cloudfoundry.org           2019-06-25T07:08:37Z
+```

--- a/build/quarks-secret/_vendir/deploy/helm/quarks-secret/templates/NOTES.txt
+++ b/build/quarks-secret/_vendir/deploy/helm/quarks-secret/templates/NOTES.txt
@@ -1,0 +1,31 @@
+Running the operator will install the following CRD:
+
+- quarkssecrets.quarks.cloudfoundry.org
+
+You can always verify if the CRD´s are installed, by running:
+ $ kubectl get crds
+
+
+
+{{- if and .Release.IsInstall }}
+
+Interacting with the quarks-secret pod
+
+1. Check the quarks-secret pod status
+  kubectl -n {{ .Release.Namespace }} get pods
+
+2. Tail the quarks-secret pod logs
+  export OPERATOR_POD=$(kubectl get pods -l name=quarks-secret --namespace {{ .Release.Namespace }} --output name)
+  kubectl -n {{ .Release.Namespace }} logs $OPERATOR_POD -f
+
+3. Label a namespace so it will be watched for quarks-secret CRDs
+
+  kubectl patch namespace {{ .Release.Namespace }} --type=json -p '[{"op": "add", "path": "/metadata/labels", "value": {"quarks.cloudfoundry.org/monitored": "{{ template "quarks-secret.monitoredID" . }}"}}]'
+
+4. Apply one of the Quarks Secret examples to that namespace
+  kubectl -n {{ .Release.Namespace }} create -f docs/examples/password.yaml
+
+5. See the quarks-secret in action!
+  kubectl -n {{ .Release.Namespace }} get secret --watch
+
+{{- end -}}

--- a/build/quarks-secret/_vendir/deploy/helm/quarks-secret/templates/_helpers.tpl
+++ b/build/quarks-secret/_vendir/deploy/helm/quarks-secret/templates/_helpers.tpl
@@ -1,0 +1,50 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "quarks-secret.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "quarks-secret.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "quarks-secret.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create the name of the quarks-secret service account to use
+*/}}
+{{- define "quarks-secret.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+    {{ default (include "quarks-secret.fullname" .) .Values.serviceAccount.name }}
+{{- else -}}
+    {{ default "default" .Values.serviceAccount.name }}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create the monitored ID, either from release name, or values
+*/}}
+{{- define "quarks-secret.monitoredID" -}}
+{{ default (include "quarks-secret.fullname" .) .Values.global.monitoredID }}
+{{- end -}}

--- a/build/quarks-secret/_vendir/deploy/helm/quarks-secret/templates/cluster-role.yaml
+++ b/build/quarks-secret/_vendir/deploy/helm/quarks-secret/templates/cluster-role.yaml
@@ -35,7 +35,7 @@ rules:
   - create
   - update
 
-
+{{- if .Values.applyCRD }}
 - apiGroups:
   - apiextensions.k8s.io
   resources:
@@ -44,6 +44,7 @@ rules:
   - create
   - get
   - update
+{{- end }}
 
 - apiGroups:
   - ""
@@ -69,6 +70,7 @@ rules:
   - secrets
   verbs:
   - create
+  - delete
   - get
   - list
   - update

--- a/build/quarks-secret/_vendir/deploy/helm/quarks-secret/templates/cluster-role.yaml
+++ b/build/quarks-secret/_vendir/deploy/helm/quarks-secret/templates/cluster-role.yaml
@@ -1,0 +1,103 @@
+{{- if .Values.global.rbac.create }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  name: {{ template "quarks-secret.fullname" . }}
+rules:
+- apiGroups:
+  - certificates.k8s.io
+  resources:
+  - certificatesigningrequests
+  verbs:
+  - approve
+  - create
+  - delete
+  - get
+  - list
+  - update
+  - watch
+
+- apiGroups:
+  - certificates.k8s.io
+  resources:
+  - signers
+  resourceNames:
+  - kubernetes.io/legacy-unknown
+  verbs:
+  - approve
+- apiGroups:
+  - certificates.k8s.io
+  resources:
+  - certificatesigningrequests/approval
+  verbs:
+  - create
+  - update
+
+
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - create
+  - get
+  - update
+
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  verbs:
+  - get
+  - list
+  - watch
+
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - create
+  - get
+  - list
+  - update
+  - watch
+
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+  - update
+
+- apiGroups:
+  - quarks.cloudfoundry.org
+  resources:
+  - quarkssecrets
+  verbs:
+  - delete
+  - get
+  - list
+  - update
+  - watch
+
+- apiGroups:
+  - quarks.cloudfoundry.org
+  resources:
+  - quarkssecrets/status
+  verbs:
+  - update
+{{- end }}

--- a/build/quarks-secret/_vendir/deploy/helm/quarks-secret/templates/crds.yaml
+++ b/build/quarks-secret/_vendir/deploy/helm/quarks-secret/templates/crds.yaml
@@ -1,0 +1,63 @@
+{{- if not .Values.applyCRD }}
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: quarkssecrets.quarks.cloudfoundry.org
+spec:
+  conversion:
+    strategy: None
+  group: quarks.cloudfoundry.org
+  names:
+    kind: QuarksSecret
+    listKind: QuarksSecretList
+    plural: quarkssecrets
+    shortNames:
+    - qsec
+    - qsecs
+    singular: quarkssecret
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        properties:
+          spec:
+            properties:
+              copies:
+                description: A list of namespaced names where to copy generated secrets
+                items:
+                  type: object
+                  x-kubernetes-preserve-unknown-fields: true
+                type: array
+              request:
+                type: object
+                x-kubernetes-preserve-unknown-fields: true
+              secretLabels:
+                type: object
+                x-kubernetes-preserve-unknown-fields: true
+              secretName:
+                description: The name of the generated secret
+                minLength: 1
+                type: string
+              type:
+                description: 'What kind of secret to generate: password, certificate,
+                  ssh, rsa, basic-auth'
+                minLength: 1
+                type: string
+            required:
+            - secretName
+            - type
+            type: object
+          status:
+            properties:
+              generated:
+                type: boolean
+              lastReconcile:
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+{{- end }}

--- a/build/quarks-secret/_vendir/deploy/helm/quarks-secret/templates/operator.yaml
+++ b/build/quarks-secret/_vendir/deploy/helm/quarks-secret/templates/operator.yaml
@@ -1,0 +1,46 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ template "quarks-secret.fullname" . }}
+  namespace: "{{ .Release.Namespace }}"
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      name: quarks-secret
+  template:
+    metadata:
+      labels:
+        name: quarks-secret
+    spec:
+      serviceAccountName: {{ template "quarks-secret.serviceAccountName" . }}
+      containers:
+        - name: quarks-secret
+          image: "{{ .Values.image.org }}/{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          ports:
+          - containerPort: 60000
+            name: metrics
+          command:
+          - quarks-secret
+          imagePullPolicy: {{ .Values.global.image.pullPolicy | quote }}
+          env:
+            - name: APPLY_CRD
+              value: "{{ .Values.applyCRD }}"
+            - name: LOG_LEVEL
+              value: "{{ .Values.logLevel }}"
+            - name: MAX_WORKERS
+              value: "{{ .Values.maxWorkers }}"
+            - name: CTX_TIMEOUT
+              value: "{{ .Values.global.contextTimeout }}"
+            - name: MELTDOWN_DURATION
+              value: "{{ .Values.global.meltdownDuration }}"
+            - name: MELTDOWN_REQUEUE_AFTER
+              value: "{{ .Values.global.meltdownRequeueAfter }}"
+            - name: MONITORED_ID
+              value: {{ template "quarks-secret.monitoredID" . }}
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: OPERATOR_NAME
+              value: "quarks-secret"

--- a/build/quarks-secret/_vendir/deploy/helm/quarks-secret/templates/service-account.yaml
+++ b/build/quarks-secret/_vendir/deploy/helm/quarks-secret/templates/service-account.yaml
@@ -1,0 +1,23 @@
+{{- if or .Values.serviceAccount.create .Values.global.rbac.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ template "quarks-secret.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
+{{- end }}
+
+{{- if .Values.global.rbac.create }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ template "quarks-secret.fullname" . }}
+roleRef:
+  kind: ClusterRole
+  name: {{ template "quarks-secret.fullname" . }}
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+- kind: ServiceAccount
+  name: {{ template "quarks-secret.serviceAccountName" . }}
+  namespace: "{{ .Release.Namespace }}"
+{{- end }}

--- a/build/quarks-secret/_vendir/deploy/helm/quarks-secret/values.yaml
+++ b/build/quarks-secret/_vendir/deploy/helm/quarks-secret/values.yaml
@@ -1,0 +1,55 @@
+## Default values for Quarks Secret Helm Chart.
+## This is a YAML-formatted file.
+## Declare variables to be passed into your templates.
+
+
+# applyCRD is a boolean to control the installation of CRD's.
+applyCRD: true
+
+# fullnameOverride overrides the release name
+fullnameOverride: ""
+
+# image is the docker image of quarks secret.
+image:
+  # repository that provides the operator docker image.
+  repository: quarks-secret
+  # organization that provides the operator docker image.
+  org: cfcontainerization
+  # tag of the operator docker image
+  tag: foobar
+
+# logLevel defines from which level the logs should be printed.
+logLevel: debug
+
+# maxWorkers is the count of workers concurrently running the controller.
+maxWorkers: 1
+
+# nameOverride overrides the chart name part of the release name
+nameOverride: ""
+
+serviceAccount:
+  # create is a boolean to control the creation of service account name.
+  create: true
+  # name of the service account.
+  name:
+
+global:
+  # contextTimeout is the timeout value for each K8's API request in seconds.
+  contextTimeout: 30
+  # MeltdownDuration is the duration (in seconds) of the meltdown period, in which we
+  # postpone further reconciles for the same resource
+  meltdownDuration: 60
+  # MeltdownRequeueAfter is the duration (in seconds) for which we delay the requeuing of the reconcile
+  meltdownRequeueAfter: 30
+  rbac:
+    # create is a boolean to control the installation of rbac resources.
+    create: true
+  image:
+    # pullPolicy defines the policy used for pulling docker images.
+    pullPolicy: IfNotPresent
+  # monitoredID is a string that has to match the content of the 'monitored' label in each monitored namespace.
+  # The monitoredID helper uses the release fullname, unless this is set.
+  monitoredID:
+  rbac:
+    # create is a boolean to control the installation of rbac resources.
+    create: true

--- a/build/quarks-secret/_vendir/deploy/helm/quarks-secret/values.yaml
+++ b/build/quarks-secret/_vendir/deploy/helm/quarks-secret/values.yaml
@@ -3,7 +3,10 @@
 ## Declare variables to be passed into your templates.
 
 
-# applyCRD is a boolean to control the installation of CRD's.
+# applyCRD is a boolean to control the installation of CRDs
+# when this is true, the operator will install the CRDs
+# an rbac rule will be set for the operator to control CRDs
+# when this is false, helm will install the CRDs
 applyCRD: true
 
 # fullnameOverride overrides the release name
@@ -50,6 +53,3 @@ global:
   # monitoredID is a string that has to match the content of the 'monitored' label in each monitored namespace.
   # The monitoredID helper uses the release fullname, unless this is set.
   monitoredID:
-  rbac:
-    # create is a boolean to control the installation of rbac resources.
-    create: true

--- a/build/quarks-secret/build.sh
+++ b/build/quarks-secret/build.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -eu
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
+
+echo "generating QuarksSecret resource definitions..."
+
+helm template cf-quarks-secret --namespace=cf-system "${SCRIPT_DIR}/_vendir/deploy/helm/quarks-secret" \
+  --values="${SCRIPT_DIR}/quarks-values.yaml" |
+  ytt --ignore-unknown-comments -f - |
+  kbld -f - > "${SCRIPT_DIR}/../../config/_ytt_lib/quarks-secret/rendered.yml"

--- a/build/quarks-secret/quarks-values.yaml
+++ b/build/quarks-secret/quarks-values.yaml
@@ -1,0 +1,9 @@
+fullnameOverride: cf-quarks-secret
+
+image:
+  repository: quarks-secret
+  org: us.gcr.io/cf-security-credhub-main
+  tag: latest
+
+global:
+  monitoredID: cf

--- a/build/quarks-secret/quarks-values.yaml
+++ b/build/quarks-secret/quarks-values.yaml
@@ -6,4 +6,4 @@ image:
   tag: latest
 
 global:
-  monitoredID: cf
+  monitoredID: cf-quarks-secret

--- a/build/quarks-secret/quarks-values.yaml
+++ b/build/quarks-secret/quarks-values.yaml
@@ -2,7 +2,7 @@ fullnameOverride: cf-quarks-secret
 
 image:
   repository: quarks-secret
-  org: us.gcr.io/cf-security-credhub-main
+  org: cloudfoundry
   tag: latest
 
 global:

--- a/config/_ytt_lib/quarks-secret/rendered.yml
+++ b/config/_ytt_lib/quarks-secret/rendered.yml
@@ -68,6 +68,7 @@ rules:
   - secrets
   verbs:
   - create
+  - delete
   - get
   - list
   - update
@@ -119,7 +120,7 @@ metadata:
         - Tag: latest
           Type: resolved
           URL: cloudfoundry/quarks-secret:latest
-        URL: index.docker.io/cloudfoundry/quarks-secret@sha256:c53235f79663f48c893250a7000f80d7685c7b583f30066bb9e6041f0aff8dcc
+        URL: index.docker.io/cloudfoundry/quarks-secret@sha256:4636fde42cd678823daea530f465389e3e92740b8fdfe6a6dca45aec838b37cd
   name: cf-quarks-secret
   namespace: cf-system
 spec:
@@ -149,14 +150,14 @@ spec:
         - name: MELTDOWN_REQUEUE_AFTER
           value: "30"
         - name: MONITORED_ID
-          value: cf
+          value: cf-quarks-secret
         - name: POD_NAME
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
         - name: OPERATOR_NAME
           value: quarks-secret
-        image: index.docker.io/cloudfoundry/quarks-secret@sha256:c53235f79663f48c893250a7000f80d7685c7b583f30066bb9e6041f0aff8dcc
+        image: index.docker.io/cloudfoundry/quarks-secret@sha256:4636fde42cd678823daea530f465389e3e92740b8fdfe6a6dca45aec838b37cd
         imagePullPolicy: IfNotPresent
         name: quarks-secret
         ports:

--- a/config/_ytt_lib/quarks-secret/rendered.yml
+++ b/config/_ytt_lib/quarks-secret/rendered.yml
@@ -118,8 +118,8 @@ metadata:
       - Metas:
         - Tag: latest
           Type: resolved
-          URL: us.gcr.io/cf-security-credhub-main/quarks-secret:latest
-        URL: us.gcr.io/cf-security-credhub-main/quarks-secret@sha256:15c623339d4a21b56fc655588dcca88229a37b552d6add89f4d5134753326788
+          URL: cloudfoundry/quarks-secret:latest
+        URL: index.docker.io/cloudfoundry/quarks-secret@sha256:c53235f79663f48c893250a7000f80d7685c7b583f30066bb9e6041f0aff8dcc
   name: cf-quarks-secret
   namespace: cf-system
 spec:
@@ -156,7 +156,7 @@ spec:
               fieldPath: metadata.name
         - name: OPERATOR_NAME
           value: quarks-secret
-        image: us.gcr.io/cf-security-credhub-main/quarks-secret@sha256:15c623339d4a21b56fc655588dcca88229a37b552d6add89f4d5134753326788
+        image: index.docker.io/cloudfoundry/quarks-secret@sha256:c53235f79663f48c893250a7000f80d7685c7b583f30066bb9e6041f0aff8dcc
         imagePullPolicy: IfNotPresent
         name: quarks-secret
         ports:

--- a/config/_ytt_lib/quarks-secret/rendered.yml
+++ b/config/_ytt_lib/quarks-secret/rendered.yml
@@ -1,0 +1,165 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: cf-quarks-secret
+  namespace: cf-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  name: cf-quarks-secret
+rules:
+- apiGroups:
+  - certificates.k8s.io
+  resources:
+  - certificatesigningrequests
+  verbs:
+  - approve
+  - create
+  - delete
+  - get
+  - list
+  - update
+  - watch
+- apiGroups:
+  - certificates.k8s.io
+  resourceNames:
+  - kubernetes.io/legacy-unknown
+  resources:
+  - signers
+  verbs:
+  - approve
+- apiGroups:
+  - certificates.k8s.io
+  resources:
+  - certificatesigningrequests/approval
+  verbs:
+  - create
+  - update
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - create
+  - get
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - create
+  - get
+  - list
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+  - update
+- apiGroups:
+  - quarks.cloudfoundry.org
+  resources:
+  - quarkssecrets
+  verbs:
+  - delete
+  - get
+  - list
+  - update
+  - watch
+- apiGroups:
+  - quarks.cloudfoundry.org
+  resources:
+  - quarkssecrets/status
+  verbs:
+  - update
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: cf-quarks-secret
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cf-quarks-secret
+subjects:
+- kind: ServiceAccount
+  name: cf-quarks-secret
+  namespace: cf-system
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+    kbld.k14s.io/images: |
+      - Metas:
+        - Tag: latest
+          Type: resolved
+          URL: us.gcr.io/cf-security-credhub-main/quarks-secret:latest
+        URL: us.gcr.io/cf-security-credhub-main/quarks-secret@sha256:15c623339d4a21b56fc655588dcca88229a37b552d6add89f4d5134753326788
+  name: cf-quarks-secret
+  namespace: cf-system
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      name: quarks-secret
+  template:
+    metadata:
+      labels:
+        name: quarks-secret
+    spec:
+      containers:
+      - command:
+        - quarks-secret
+        env:
+        - name: APPLY_CRD
+          value: "true"
+        - name: LOG_LEVEL
+          value: debug
+        - name: MAX_WORKERS
+          value: "1"
+        - name: CTX_TIMEOUT
+          value: "30"
+        - name: MELTDOWN_DURATION
+          value: "60"
+        - name: MELTDOWN_REQUEUE_AFTER
+          value: "30"
+        - name: MONITORED_ID
+          value: cf
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: OPERATOR_NAME
+          value: quarks-secret
+        image: us.gcr.io/cf-security-credhub-main/quarks-secret@sha256:15c623339d4a21b56fc655588dcca88229a37b552d6add89f4d5134753326788
+        imagePullPolicy: IfNotPresent
+        name: quarks-secret
+        ports:
+        - containerPort: 60000
+          name: metrics
+      serviceAccountName: cf-quarks-secret

--- a/config/quarks-secret.yml
+++ b/config/quarks-secret.yml
@@ -1,0 +1,4 @@
+#@ load("@ytt:library", "library")
+#@ load("@ytt:template", "template")
+
+--- #@ template.replace(library.get("quarks-secret").eval())

--- a/vendir.lock.yml
+++ b/vendir.lock.yml
@@ -57,8 +57,8 @@ directories:
   path: build/postgres/_vendir
 - contents:
   - git:
-      commitTitle: Stop specifying UID/GID for quarks in Dockerfile...
-      sha: 5a31fccb204770d0cf851080389e6a25555f9e98
+      commitTitle: Add delete secret permission to cluster role (#20)
+      sha: 01d7be017c3cec812a056e364a47dc6ca1d27d90
     path: .
   path: build/quarks-secret/_vendir
 kind: LockConfig

--- a/vendir.lock.yml
+++ b/vendir.lock.yml
@@ -23,6 +23,8 @@ directories:
   - githubRelease:
       url: https://api.github.com/repos/pivotal/kpack/releases/27343776
     path: github.com/pivotal/kpack
+  - manual: {}
+    path: quarks-secret
   path: config/_ytt_lib
 - contents:
   - manual: {}
@@ -53,4 +55,10 @@ directories:
       sha: f9cb0102f1e03d9ee7f09dbb65e9d7cdc25f84fe
     path: .
   path: build/postgres/_vendir
+- contents:
+  - git:
+      commitTitle: Stop specifying UID/GID for quarks in Dockerfile...
+      sha: 5a31fccb204770d0cf851080389e6a25555f9e98
+    path: .
+  path: build/quarks-secret/_vendir
 kind: LockConfig

--- a/vendir.yml
+++ b/vendir.yml
@@ -106,6 +106,6 @@ directories:
   - path: .
     git:
       url: https://github.com/cloudfoundry-incubator/quarks-secret
-      ref: 5a31fccb204770d0cf851080389e6a25555f9e98 # version: TBD
+      ref: 01d7be017c3cec812a056e364a47dc6ca1d27d90 # version: 1.0.692
     includePaths:
     - deploy/helm/quarks-secret/**/*

--- a/vendir.yml
+++ b/vendir.yml
@@ -50,6 +50,9 @@ directories:
 
 # the components in this section below are handled by their corresponding build scripts
 # the manual param tells vendir to not override/touch the contents of these config/_ytt_lib/<eirini|minio|postgres> directories
+  - path: quarks-secret
+    manual: {}
+
 - path: config/eirini/_ytt_lib
   contents:
   - path: eirini
@@ -97,3 +100,12 @@ directories:
       ref: f9cb0102f1e03d9ee7f09dbb65e9d7cdc25f84fe # version: 8.10.6
     includePaths:
     - bitnami/postgresql/**/*
+
+- path: build/quarks-secret/_vendir
+  contents:
+  - path: .
+    git:
+      url: https://github.com/cloudfoundry-incubator/quarks-secret
+      ref: 5a31fccb204770d0cf851080389e6a25555f9e98 # version: TBD
+    includePaths:
+    - deploy/helm/quarks-secret/**/*


### PR DESCRIPTION
Things we have not included in this PR but will follow up later:
- In this PR, the QuarksSecret image is still stored on Credhub team's test repository; once we gain access to the cloudfoundry dockerhub we will make another PR to switch to using cloudfoundry dockerhub.
- We have not figured out how to track updates on QuarksSecret helm chart; we will communicate that once we figured it out (currently, vendir.yml just uses chart on the latest commit as of 7/14/2020 of QuarksSecret).