### PR TITLE
Add additional ci-job to validate external database feature

### DIFF
--- a/ci/pipelines/cf-for-k8s.yml
+++ b/ci/pipelines/cf-for-k8s.yml
@@ -8,6 +8,7 @@ groups:
   - validate-cf-for-k8s-gke
   - validate-cf-for-k8s-oldest
   - validate-cf-for-k8s-newest
+  - validate-cf-for-k8s-gke-external-db
   - promote-master-deliver-stories
 - name: stability-checks-and-slis
   jobs:
@@ -485,6 +486,212 @@ jobs:
     params:
       remove: ready-pool
 
+- name: validate-cf-for-k8s-gke-external-db
+  serial: true
+  public: true
+  plan:
+  - get: cf-for-k8s-develop
+    passed:
+    - test-vendir-sync-on-cf-for-k8s
+    - run-unit-tests
+    trigger: true
+  - get: cf-for-k8s-ci
+
+  - put: ready-pool
+    params: {acquire: true}
+
+  - task: install-postgres
+    input_mapping:
+      pool-lock: ready-pool
+    config:
+      <<: *common-task-config
+      inputs:
+      - name: cf-for-k8s-develop
+      - name: cf-for-k8s-ci
+      - name: pool-lock
+      outputs:
+      - name: db-metadata
+      params:
+        GCP_SERVICE_ACCOUNT_JSON: ((ci_k8s_gcp_service_account_json))
+        GCP_PROJECT_NAME: ((ci_k8s_gcp_project_name))
+        GCP_PROJECT_ZONE: ((ci_k8s_gcp_project_zone))
+      run:
+        path: /bin/bash
+        args:
+        - -ec
+        - |
+          source cf-for-k8s-ci/ci/helpers/gke.sh
+
+          cluster_name="$(cat pool-lock/name)"
+          gcloud_auth "${cluster_name}"
+
+          kubectl create namespace external-db
+          helm repo add bitnami https://charts.bitnami.com/bitnami
+          helm install -n external-db --wait postgresql bitnami/postgresql
+
+          CCDB_USERNAME="capi_user"
+          CCDB_PASSWORD="$(openssl rand -base64 32)"
+          CCDB_NAME="capi_db"
+          UAADB_USERNAME="uaa_user"
+          UAADB_PASSWORD="$(openssl rand -base64 32)"
+          UAADB_NAME="uaa_db"
+
+          cat > /tmp/setup_db.sql <<EOT
+          CREATE DATABASE ${CCDB_NAME};
+          CREATE ROLE ${CCDB_USERNAME} LOGIN PASSWORD '${CCDB_PASSWORD}';
+          CREATE DATABASE ${UAADB_NAME};
+          CREATE ROLE ${UAADB_USERNAME} LOGIN PASSWORD '${UAADB_PASSWORD}';
+          \c ${CCDB_NAME};
+          CREATE EXTENSION citext;
+          \c ${UAADB_NAME};
+          CREATE EXTENSION citext;
+          EOT
+
+          export POSTGRES_PASSWORD=$(kubectl get secret -n external-db postgresql -o jsonpath="{.data.postgresql-password}" | base64 -d)
+          kubectl exec -n external-db statefulset/postgresql-postgresql -i -- psql "postgresql://postgres:$POSTGRES_PASSWORD@localhost:5432/postgres" < /tmp/setup_db.sql
+
+          cat > db-metadata/db-values.yaml <<EOT
+          #@data/values
+          ---
+          capi:
+            database:
+              adapter: postgres
+              host: postgresql.external-db.svc.cluster.local
+              port: 5432
+              user: $CCDB_USERNAME
+              password: $CCDB_PASSWORD
+              name: $CCDB_NAME
+
+          uaa:
+            database:
+              adapter: postgresql
+              host: postgresql.external-db.svc.cluster.local
+              port: 5432
+              user: $UAADB_USERNAME
+              password: $UAADB_PASSWORD
+              name: $UAADB_NAME
+          EOT
+
+  - task: install-cf
+    input_mapping:
+      pool-lock: ready-pool
+    config:
+      <<: *common-task-config
+      inputs:
+      - name: db-metadata
+      - name: cf-for-k8s-develop
+      - name: cf-for-k8s-ci
+      - name: pool-lock
+      outputs:
+      - name: env-metadata
+      params:
+        GCP_SERVICE_ACCOUNT_JSON: ((ci_k8s_gcp_service_account_json))
+        GCP_PROJECT_NAME: ((ci_k8s_gcp_project_name))
+        GCP_PROJECT_ZONE: ((ci_k8s_gcp_project_zone))
+      run:
+        path: /bin/bash
+        args:
+        - -ec
+        - |
+          source cf-for-k8s-ci/ci/helpers/gke.sh
+
+          cluster_name="$(cat pool-lock/name)"
+          gcloud_auth "${cluster_name}"
+
+          DNS_DOMAIN="${cluster_name}.k8s-dev.relint.rocks"
+          cf-for-k8s-develop/hack/confirm-network-policy.sh "${cluster_name}" '((ci_k8s_gcp_project_zone))'
+
+          echo "Generating install values..."
+          cf-for-k8s-develop/hack/generate-values.sh --cf-domain "${DNS_DOMAIN}" > cf-install-values.yml
+          cat <<EOT >> cf-install-values.yml
+          app_registry:
+             hostname: https://index.docker.io/v1/
+             repository_prefix: ((cf_for_k8s_private_dockerhub.username))
+             username: ((cf_for_k8s_private_dockerhub.username))
+             password: ((cf_for_k8s_private_dockerhub.password))
+          istio_static_ip: $(jq -r '.lb_static_ip' pool-lock/metadata)
+          EOT
+
+          echo "Installing CF..."
+          kapp deploy -a cf -f <(ytt -f cf-for-k8s-develop/config -f cf-install-values.yml -f db-metadata/db-values.yaml) -y
+
+          bosh interpolate --path /cf_admin_password cf-install-values.yml > env-metadata/cf-admin-password.txt
+          bosh interpolate --path /default_ca/ca /tmp/${DNS_DOMAIN}/cf-vars.yaml > env-metadata/default_ca.ca
+          echo "${DNS_DOMAIN}" > env-metadata/dns-domain.txt
+
+  - task: run-smoke-test
+    file: cf-for-k8s-ci/ci/tasks/run-smoke-tests/task.yml
+    attempts: 3
+    params:
+      SMOKE_TEST_SKIP_SSL: false
+    input_mapping:
+      cf-for-k8s: cf-for-k8s-develop
+
+  - task: push-test-app
+    file: cf-for-k8s-ci/ci/tasks/push-test-app/task.yml
+    params:
+      APP_NAME: lingering-node-app
+      VERIFY_EXISTING_APP: false
+    input_mapping:
+      cf-for-k8s: cf-for-k8s-develop
+
+  - task: delete-cf
+    input_mapping:
+      pool-lock: ready-pool
+    config:
+      <<: *common-task-config
+      inputs:
+      - name: cf-for-k8s-ci
+      - name: pool-lock
+      params:
+        GCP_SERVICE_ACCOUNT_JSON: ((ci_k8s_gcp_service_account_json))
+        GCP_PROJECT_NAME: ((ci_k8s_gcp_project_name))
+        GCP_PROJECT_ZONE: ((ci_k8s_gcp_project_zone))
+      run:
+        path: /bin/bash
+        args:
+        - -ec
+        - |
+          source cf-for-k8s-ci/ci/helpers/gke.sh
+
+          cluster_name="$(cat pool-lock/name)"
+          gcloud_auth "${cluster_name}"
+
+          kapp delete -a cf --yes
+
+  - task: delete-postgres
+    input_mapping:
+      pool-lock: ready-pool
+    config:
+      <<: *common-task-config
+      inputs:
+      - name: cf-for-k8s-ci
+      - name: pool-lock
+      params:
+        GCP_SERVICE_ACCOUNT_JSON: ((ci_k8s_gcp_service_account_json))
+        GCP_PROJECT_NAME: ((ci_k8s_gcp_project_name))
+        GCP_PROJECT_ZONE: ((ci_k8s_gcp_project_zone))
+      run:
+        path: /bin/bash
+        args:
+        - -ec
+        - |
+          source cf-for-k8s-ci/ci/helpers/gke.sh
+
+          cluster_name="$(cat pool-lock/name)"
+          gcloud_auth "${cluster_name}"
+
+          helm uninstall -n external-db postgresql
+          kubectl delete namespace external-db
+
+  - put: destroy-pool
+    params:
+      add: ready-pool
+
+  - put: ready-pool
+    params:
+      remove: ready-pool
+
 - name: validate-cf-for-k8s-oldest
   plan:
   - in_parallel:
@@ -654,6 +861,7 @@ jobs:
       - validate-cf-for-k8s-newest
       - validate-cf-for-k8s-oldest
       - validate-cf-for-k8s-gke
+      - validate-cf-for-k8s-gke-external-db
     trigger: true
   - put: cf-for-k8s-master-push
     params:


### PR DESCRIPTION
This uses the bitnami postgresql helm-chart to install a database into the same cluster, otherwise it is a duplicate of the existing job "validate-cf-for-k8s-gke".

First step to implement proposal #168

