### PR TITLE
Update kubeval timeout threshold

### DIFF
--- a/tests/configs/configs_test.go
+++ b/tests/configs/configs_test.go
@@ -129,7 +129,7 @@ var _ = Describe("Configs", func() {
 				fmt.Println(command.Args)
 				session, err := Start(command, ioutil.Discard, GinkgoWriter)
 				Expect(err).NotTo(HaveOccurred())
-				session.Wait(10 * time.Second)
+				session.Wait(30 * time.Second)
 				stdOut := removeExpectedKubevalOutput(session.Out.Contents())
 				Eventually(session).Should(Exit(0),
 					fmt.Sprintf("kubeval failed with (filtered) output: %s\n", stdOut))


### PR DESCRIPTION
Update the timeout threshold on the kubeval unit test. We're seeing timeouts in the CI jobs for updating releases likely due to hardware differences with our dev machines.

See the failures linked in these tracker stories:
https://www.pivotaltracker.com/story/show/173863620
https://www.pivotaltracker.com/story/show/173863619

**Acceptance Steps**
Go into the config tests suite and run Ginkgo. (Or just run all of the unit tests with Ginkgo). The tests should continue to pass and not take any longer aside from the apparent time creep from actual code updates that lead to the timeout issues.

`ginkgo -r` or `ginkgo ./...` in the `tests/` directory 

_Tag your pair, your PM, and/or team_
cc @ericpromislow 
