### PR TITLE
Use separate secret values for uaa client secrets

### DIFF
--- a/config/capi.yml
+++ b/config/capi.yml
@@ -69,9 +69,9 @@ uaa:
     secretName: uaa-certs
   clients:
     cloud_controller_username_lookup:
-      secret: #@ data.values.uaa.admin_client_secret
+      secret: #@ data.values.capi.cc_username_lookup_client_secret
     capi_kpack_watcher:
-      secret: #@ data.values.uaa.admin_client_secret
+      secret: #@ data.values.capi.kpack_watcher_client_secret
 
 kpack:
   registry:
@@ -129,7 +129,7 @@ metadata:
   namespace: #@ data.values.system_namespace
 type: Opaque
 stringData:
-  password: #@ data.values.uaa.admin_client_secret
+  password: #@ data.values.capi.kpack_watcher_client_secret
 ---
 apiVersion: v1
 kind: Secret
@@ -138,4 +138,4 @@ metadata:
   namespace: #@ data.values.system_namespace
 type: Opaque
 stringData:
-  password: #@ data.values.uaa.admin_client_secret
+  password: #@ data.values.capi.cc_username_lookup_client_secret

--- a/config/uaa.yml
+++ b/config/uaa.yml
@@ -123,19 +123,14 @@ oauth:
       autoapprove:
       - openid
       id: admin
-    #! TODO: each client should use different secrets!
-    cf-k8s-networking:
-      authorities: uaa.resource,cloud_controller.admin_read_only
-      authorized-grant-types: client_credentials
-      secret: #@ data.values.uaa.admin_client_secret
     cloud_controller_username_lookup:
       authorities: scim.userids
       authorized-grant-types: client_credentials
-      secret: #@ data.values.uaa.admin_client_secret
+      secret: #@ data.values.capi.cc_username_lookup_client_secret
     capi_kpack_watcher:
       authorities: cloud_controller.write,cloud_controller.update_build_state
       authorized-grant-types: client_credentials
-      secret: #@ data.values.uaa.admin_client_secret
+      secret: #@ data.values.capi.kpack_watcher_client_secret
   #@overlay/match missing_ok=True
   user:
     authorities:

--- a/config/values.yml
+++ b/config/values.yml
@@ -65,6 +65,8 @@ capi:
     region: "''"
     endpoint: "http://cf-blobstore-minio.cf-blobstore.svc.cluster.local:9000"
   database_password_secret_name: capi-database-password
+  kpack_watcher_client_secret: ""
+  cc_username_lookup_client_secret: ""
   database:
     #! or mysql2, as needed
     adapter: postgres

--- a/hack/generate-values.sh
+++ b/hack/generate-values.sh
@@ -101,6 +101,10 @@ variables:
   type: password
 - name: uaa_encryption_key_passphrase
   type: password
+- name: cc_username_lookup_client_secret
+  type: password
+- name: kpack_watcher_client_secret
+  type: password
 - name: default_ca
   type: certificate
   options:
@@ -216,6 +220,8 @@ cf_db:
   admin_password: $(bosh interpolate ${VARS_FILE} --path=/db_admin_password)
 
 capi:
+  cc_username_lookup_client_secret: $(bosh interpolate ${VARS_FILE} --path=/cc_username_lookup_client_secret)
+  kpack_watcher_client_secret: $(bosh interpolate ${VARS_FILE} --path=/kpack_watcher_client_secret)
   database:
     password: $(bosh interpolate ${VARS_FILE} --path=/capi_db_password)
 

--- a/sample-cf-install-values.yml
+++ b/sample-cf-install-values.yml
@@ -24,6 +24,8 @@ cf_db:
 
 #! The db password shared between CAPI and the database.
 capi:
+  kpack_watcher_client_secret: uaa_capi_kpack_watcher_client_credentials
+  cc_username_lookup_client_secret: uaa_cloud_controller_lookup_client_credentials
   database:
     password: ccdb_password
 


### PR DESCRIPTION
[finishes #173295725](https://www.pivotaltracker.com/story/show/173295725)
fixes #233

Co-authored-by: Dave Walter <dwalter@pivotal.io>
Co-authored-by: Andrew Wittrock <awittrock@pivotal.io>

**Description**
Use separate secret values for each of the clients we create in UAA.

**Acceptance Steps**

Run the hack/generate-values.sh script to generate the new additional secret values. Then follow the standard ytt and kapp deploy flow described in the deploy.md doc.

When your cf-for-k8s has deployed successfully, check that smoke tests continue to run and that the configMaps no longer have duplicate secret content.


_Tag your pair, your PM, and/or team_
cc @Birdrock 

> _It's helpful to tag a few other folks on your team or your team alias in case we need to follow up later._
