### PR TITLE
Uaa secrets

### DIFF
--- a/config/uaa.yml
+++ b/config/uaa.yml
@@ -74,8 +74,6 @@ scim:
   userids_enabled: true
   user:
     override: true
-  users:
-  - #@ "admin|" + data.values.cf_admin_password + "|admin@admin.tld|first|last|clients.read,cloud_controller.admin,doppler.firehose,network.admin,openid,routing.router_groups.read,routing.router_groups.write,scim.read,scim.write|uaa"
   groups:
     zones.read: Read identity zones
     zones.write: Create and update identity zones
@@ -126,11 +124,9 @@ oauth:
     cloud_controller_username_lookup:
       authorities: scim.userids
       authorized-grant-types: client_credentials
-      secret: #@ data.values.capi.cc_username_lookup_client_secret
     capi_kpack_watcher:
       authorities: cloud_controller.write,cloud_controller.update_build_state
       authorized-grant-types: client_credentials
-      secret: #@ data.values.capi.kpack_watcher_client_secret
   #@overlay/match missing_ok=True
   user:
     authorities:
@@ -256,3 +252,92 @@ metadata:
 type: Opaque
 stringData:
   password: #@ data.values.uaa.encryption_key.passphrase
+
+#@ def uaa_client_credential_data(client_name, credential):
+oauth:
+  #@yaml/text-templated-strings
+  clients:
+    (@= client_name @):
+      secret: #@ credential
+#@ end
+
+#@ def uaa_client_credential(client_name, credential, secret_name):
+apiVersion: v1
+kind: Secret
+metadata:
+  name: #@ secret_name
+  namespace: #@ data.values.system_namespace
+type: Opaque
+stringData:
+  client_credentials.yml: #@ yaml.encode(uaa_client_credential_data(client_name, credential))
+#@ end
+
+#@ def uaa_cf_admin_user_credentials():
+scim:
+  users:
+  - #@ "admin|" + data.values.cf_admin_password + "|admin@admin.tld|first|last|clients.read,cloud_controller.admin,doppler.firehose,network.admin,openid,routing.router_groups.read,routing.router_groups.write,scim.read,scim.write|uaa"
+#@ end
+
+--- #@ uaa_client_credential("cf", "", "uaa-cf-client-secret")
+--- #@ uaa_client_credential("cloud_controller_username_lookup", data.values.capi.cc_username_lookup_client_secret, "uaa-cloud-controller-username-lookup-client-secret")
+--- #@ uaa_client_credential("capi_kpack_watcher", data.values.capi.kpack_watcher_client_secret, "uaa-capi-kpack-watcher-client-secret")
+
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: uaa-cf-admin-user-credentials
+  namespace: #@ data.values.system_namespace
+type: Opaque
+stringData:
+  cf_admin_user_credentials.yml: #@ yaml.encode(uaa_cf_admin_user_credentials())
+
+#@ load("@github.com/cloudfoundry/uaa/k8s:templates/deployment.star",
+#@  "secrets_dir")
+#@overlay/match by=overlay.subset({"kind":"Deployment", "metadata":{"name":"uaa"}})
+---
+spec:
+  template:
+    spec: #! pod spec
+      containers:
+      #@overlay/match by="name"
+      - name: uaa
+        volumeMounts:
+        #@overlay/append
+        - name: cf-admin-user-credentials-file
+          mountPath: #@ "{}/cf_admin_user_credentials.yml".format(secrets_dir)
+          subPath: cf_admin_user_credentials.yml
+          readOnly: true
+        #@overlay/append
+        - name: cc-admin-client-credentials-file
+          mountPath: #@ "{}/cf_client_credentials.yml".format(secrets_dir)
+          subPath: client_credentials.yml
+          readOnly: true
+        #@overlay/append
+        - name: cloud-controller-username-lookup-client-credentials-file
+          mountPath: #@ "{}/cloud_controller_username_lookup_client_credentials.yml".format(secrets_dir)
+          subPath: client_credentials.yml
+          readOnly: true
+        #@overlay/append
+        - name: capi-kpack-watcher-client-credentials-file
+          mountPath: #@ "{}/capi_kpack_watcher_client_credentials.yml".format(secrets_dir)
+          subPath: client_credentials.yml
+          readOnly: true
+      volumes:
+      #@overlay/append
+      - name: cf-admin-user-credentials-file
+        secret:
+          secretName: uaa-cf-admin-user-credentials
+      #@overlay/append
+      - name: cc-admin-client-credentials-file
+        secret:
+          secretName: uaa-cf-client-secret
+      #@overlay/append
+      - name: cloud-controller-username-lookup-client-credentials-file
+        secret:
+          secretName: uaa-cloud-controller-username-lookup-client-secret
+      #@overlay/append
+      - name: capi-kpack-watcher-client-credentials-file
+        secret:
+          secretName: uaa-capi-kpack-watcher-client-secret
+


### PR DESCRIPTION
DO NOT MERGE. Only merge after #295, which we split out into a separate pr make the refactor more digestible. May require another rebase due to changes made in that PR.

[finishes #173295381](https://www.pivotaltracker.com/story/show/173295381)
[finishes #173930701](https://www.pivotaltracker.com/story/show/173930701)
fixes #231 #232 

**Description**
Template client secrets into Secret resources and mount them onto the UAA deployment instead of passing the info through plaintext values on the ConfigMap. This is a security-focused refactor and should not affect functionality.

**Acceptance Steps**
Deploy cf-for-k8s as normally according to the deploy.md docs. Verify that the deployment succeeds and the smoke test continues to pass.


_Tag your pair, your PM, and/or team_
cc @Birdrock 
