### PR TITLE
Add separate secret for capi cf db encryption key

### DIFF
--- a/config/capi.yml
+++ b/config/capi.yml
@@ -139,3 +139,12 @@ metadata:
 type: Opaque
 stringData:
   password: #@ data.values.capi.cc_username_lookup_client_secret
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: #@ data.values.capi.database_encryption_key_secret_name
+  namespace: #@ data.values.system_namespace
+type: Opaque
+stringData:
+  password: #@ data.values.capi.database.encryption_key

--- a/config/values.yml
+++ b/config/values.yml
@@ -57,6 +57,7 @@ internal_certificate:
 
 capi:
   cf_blobstore_key_secret_name: capi-blobstore-secret-key
+  database_encryption_key_secret_name: capi-database-encryption-key-secret
   blobstore:
     package_directory_key: cc-packages
     droplet_directory_key: cc-droplets
@@ -70,6 +71,7 @@ capi:
   database:
     #! or mysql2, as needed
     adapter: postgres
+    encryption_key: ""
     host: ""
     port: 5432
     user: cloud_controller

--- a/hack/generate-values.sh
+++ b/hack/generate-values.sh
@@ -95,6 +95,8 @@ variables:
   type: password
 - name: capi_db_password
   type: password
+- name: capi_db_encryption_key
+  type: password
 - name: uaa_db_password
   type: password
 - name: uaa_admin_client_secret
@@ -224,6 +226,7 @@ capi:
   kpack_watcher_client_secret: $(bosh interpolate ${VARS_FILE} --path=/kpack_watcher_client_secret)
   database:
     password: $(bosh interpolate ${VARS_FILE} --path=/capi_db_password)
+    encryption_key: $(bosh interpolate ${VARS_FILE} --path=/capi_db_encryption_key)
 
 system_certificate:
   #! This certificates and keys are base64 encoded and should be valid for *.system.cf.example.com

--- a/sample-cf-install-values.yml
+++ b/sample-cf-install-values.yml
@@ -28,6 +28,7 @@ capi:
   cc_username_lookup_client_secret: uaa_cloud_controller_lookup_client_credentials
   database:
     password: ccdb_password
+    encryption_key: ccdb_encryption_key
 
 #! Notes about X.509 certificates:
 #! - the certificates and keys are base64 encoded


### PR DESCRIPTION
[#173930784](https://www.pivotaltracker.com/story/show/173930784)

**Description**
Adds a separate secret for the db encryption key for capi to consume when they're ready to move away from the sensitive plaintext data in the ConfigMap. Note that this reference is not yet consumed. See https://github.com/cloudfoundry/cf-for-k8s/pull/289 for the initial pass where we missed this as a piece of sensitive information configured in plaintext.

**Acceptance Steps**
Deploy cf-for-k8s as normally and validate that the smoke test continues to pass.

_Tag your pair, your PM, and/or team_
cc @Birdrock 
