### PR TITLE
Add documentation for external RDS database

### DIFF
--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -75,7 +75,7 @@ cf-for-k8s can be configured to [use an external database](platform_operators/ex
    TMP_DIR=<your-tmp-dir-path> ; mkdir -p ${TMP_DIR}
    ```
 
-1. Create a "CF Installation Values" file and configure it:
+1. Create a "CF Installation Values" file and configure it<a name="cf-values"></a>:
 
    You can either: a) auto-generate the installation values or b) create the values by yourself.
 

--- a/docs/platform_operators/external-databases.md
+++ b/docs/platform_operators/external-databases.md
@@ -90,7 +90,7 @@ If both, capi and uaa, are configured to use an external database, no internal d
 
 ## Example with external RDS database
 
-In the following section, an external database is created using the bitnami postgresql helm chart. Please note that this setup is **not suitable for production environments**.
+In the following section, we will show how to setup an AWS RDS database and configure it as the datebase to be used for Cloud Controller and UAA. Please note that the values passed for RDS creation are **not suitable for production environments**.
 
 1. Create a RDS database. The following command will create a small database for development. Please adjust the settings to your requirements.
 


### PR DESCRIPTION
We added documentation on how to use an external database (AWS RDS) with cf-for-k8s.

**Acceptance Steps**
When I follow the instructions in the document
Then I'm able to setup my cf-for-k8s with an external database without debugging or further exploration

@kramerul, @loewenstein
