### PR TITLE
rename kpack-watcher-client-secret to cf-api-controllers-client-secret

### DIFF
--- a/config/capi/_ytt_lib/capi-k8s-release/templates/controllers_deployment.yml
+++ b/config/capi/_ytt_lib/capi-k8s-release/templates/controllers_deployment.yml
@@ -3,11 +3,11 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: cf-api-kpack-watcher
+  name: cf-api-controllers
   namespace: #@ data.values.system_namespace
   labels:
-    app.kubernetes.io/name: cf-api-kpack-watcher
-    app.kubernetes.io/instance: cf-api-kpack-watcher-0
+    app.kubernetes.io/name: cf-api-controllers
+    app.kubernetes.io/instance: cf-api-controllers-0
 spec:
   replicas: 1
   strategy:
@@ -16,23 +16,23 @@ spec:
       maxUnavailable: 1
   selector:
     matchLabels:
-      app.kubernetes.io/name: cf-api-kpack-watcher
+      app.kubernetes.io/name: cf-api-controllers
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: cf-api-kpack-watcher
+        app.kubernetes.io/name: cf-api-controllers
     spec:
-      serviceAccountName: cf-api-kpack-watcher-service-account
+      serviceAccountName: cf-api-controllers-service-account
       containers:
       - name: manager
-        image: #@ data.values.images.capi_kpack_watcher
+        image: #@ data.values.images.cf_api_controllers
         env:
         - name: UAA_CLIENT_SECRET
-          value: #@ data.values.uaa.clients.capi_kpack_watcher.secret
+          value: #@ data.values.uaa.clients.cf_api_controllers.secret
         - name: UAA_ENDPOINT
           value: #@ "http://uaa.{}.svc.cluster.local:8080".format(data.values.system_namespace)
         - name: UAA_CLIENT_NAME
-          value: capi_kpack_watcher
+          value: cf_api_controllers
         - name: CF_API_HOST
           value: #@ "http://capi.{}.svc.cluster.local".format(data.values.system_namespace)
         - name: STAGING_NAMESPACE
@@ -49,7 +49,7 @@ spec:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: kpack-watcher
+  name: cf-api-controllers
 rules:
 - apiGroups: ["build.pivotal.io"]
   resources: ["images", "builds", "builds/status", "images/status"]
@@ -58,12 +58,12 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: kpack-watcher-binding
+  name: controllers-binding
 subjects:
 - kind: ServiceAccount
   namespace: #@ data.values.system_namespace
-  name: cf-api-kpack-watcher-service-account
+  name: cf-api-controllers-service-account
 roleRef:
   kind: ClusterRole
-  name: kpack-watcher
+  name: cf-api-controllers
   apiGroup: rbac.authorization.k8s.io

--- a/config/capi/_ytt_lib/capi-k8s-release/templates/service-accounts.yml
+++ b/config/capi/_ytt_lib/capi-k8s-release/templates/service-accounts.yml
@@ -127,13 +127,11 @@ roleRef:
   kind: ClusterRole
   name: "cf:kpack-builds-admin"
   apiGroup: rbac.authorization.k8s.io
-
-#! kpack watcher service account
 ---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: cf-api-kpack-watcher-service-account
+  name: cf-api-controllers-service-account
   namespace: #@ data.values.system_namespace
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -165,11 +163,11 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: cf-api-kpack-watcher-service-account-kpack-builds-reader
+  name: cf-api-controllers-service-account-kpack-builds-reader
   namespace: #@ data.values.staging_namespace
 subjects:
 - kind: ServiceAccount
-  name: cf-api-kpack-watcher-service-account
+  name: cf-api-controllers-service-account
   namespace: #@ data.values.system_namespace
 roleRef:
   kind: ClusterRole
@@ -179,11 +177,11 @@ roleRef:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: cf-api-kpack-watcher-service-account-service-accounts-secrets-fetcher
+  name: cf-api-controllers-service-account-service-accounts-secrets-fetcher
   namespace: #@ data.values.staging_namespace
 subjects:
 - kind: ServiceAccount
-  name: cf-api-kpack-watcher-service-account
+  name: cf-api-controllers-service-account
   namespace: #@ data.values.system_namespace
 roleRef:
   kind: ClusterRole

--- a/config/capi/_ytt_lib/capi-k8s-release/values/_default.yml
+++ b/config/capi/_ytt_lib/capi-k8s-release/values/_default.yml
@@ -103,7 +103,7 @@ system_domain: cf-system.svc.cluster.local
 system_namespace: cf-system
 uaa:
   clients:
-    capi_kpack_watcher:
+    cf_api_controllers:
       secret: supers3cret
     cloud_controller_username_lookup:
       secret: supers3cret
@@ -111,7 +111,7 @@ uaa:
     secretName: null
 workloads_namespace: cf-workloads
 images:
-  capi_kpack_watcher:
+  cf_api_controllers:
   ccng:
   cf_autodetect_builder:
   nginx:

--- a/config/capi/_ytt_lib/capi-k8s-release/values/images.yml
+++ b/config/capi/_ytt_lib/capi-k8s-release/values/images.yml
@@ -1,7 +1,7 @@
 #@data/values
 ---
 images:
-  capi_kpack_watcher: cloudfoundry/capi-kpack-watcher@sha256:954144ec4062df8913db4d1b3c1cc0330753bafcfd57f11e564b8f34e48a7265
+  cf_api_controllers: cloudfoundry/capi-kpack-watcher@sha256:954144ec4062df8913db4d1b3c1cc0330753bafcfd57f11e564b8f34e48a7265
   ccng: cloudfoundry/cloud-controller-ng@sha256:fe904a2810a6330586a23d4e0e2c607aa95f17ed62d17cc29244ef7f6e9f33b5
   cf_autodetect_builder: cloudfoundry/cnb:0.0.94-bionic@sha256:5b03a853e636b78c44e475bbc514e2b7b140cc41cca8ab907e9753431ae8c0b0
   nginx: cloudfoundry/capi-nginx@sha256:980f50e190cbff72d23300bc422da23faa888271c2d07ac3abaa65af55a5316a

--- a/config/capi/capi.yml
+++ b/config/capi/capi.yml
@@ -70,8 +70,8 @@ uaa:
   clients:
     cloud_controller_username_lookup:
       secret: #@ data.values.capi.cc_username_lookup_client_secret
-    capi_kpack_watcher:
-      secret: #@ data.values.capi.kpack_watcher_client_secret
+    cf_api_controllers:
+      secret: #@ data.values.capi.cf_api_controllers_client_secret
 
 kpack:
   registry:
@@ -125,11 +125,11 @@ stringData:
 apiVersion: v1
 kind: Secret
 metadata:
-  name: #@ data.values.capi.kpack_watcher_secret_name
+  name: #@ data.values.capi.cf_api_controllers_secret_name
   namespace: #@ data.values.system_namespace
 type: Opaque
 stringData:
-  password: #@ data.values.capi.kpack_watcher_client_secret
+  password: #@ data.values.capi.cf_api_controllers_client_secret
 ---
 apiVersion: v1
 kind: Secret

--- a/config/uaa/uaa.yml
+++ b/config/uaa/uaa.yml
@@ -124,7 +124,7 @@ oauth:
     cloud_controller_username_lookup:
       authorities: scim.userids
       authorized-grant-types: client_credentials
-    capi_kpack_watcher:
+    cf_api_controllers:
       authorities: cloud_controller.write,cloud_controller.update_build_state
       authorized-grant-types: client_credentials
   #@overlay/match missing_ok=True
@@ -280,7 +280,7 @@ scim:
 
 --- #@ uaa_client_credential("cf", "", "uaa-cf-client-secret")
 --- #@ uaa_client_credential("cloud_controller_username_lookup", data.values.capi.cc_username_lookup_client_secret, "uaa-cloud-controller-username-lookup-client-secret")
---- #@ uaa_client_credential("capi_kpack_watcher", data.values.capi.kpack_watcher_client_secret, "uaa-capi-kpack-watcher-client-secret")
+--- #@ uaa_client_credential("cf_api_controllers", data.values.capi.cf_api_controllers_client_secret, "uaa-cf-api-controllers-client-secret")
 
 ---
 apiVersion: v1
@@ -319,8 +319,8 @@ spec:
           subPath: client_credentials.yml
           readOnly: true
         #@overlay/append
-        - name: capi-kpack-watcher-client-credentials-file
-          mountPath: #@ "{}/capi_kpack_watcher_client_credentials.yml".format(secrets_dir)
+        - name: cf-api-controllers-client-credentials-file
+          mountPath: #@ "{}/cf_api_controllers_client_credentials.yml".format(secrets_dir)
           subPath: client_credentials.yml
           readOnly: true
       volumes:
@@ -337,7 +337,7 @@ spec:
         secret:
           secretName: uaa-cloud-controller-username-lookup-client-secret
       #@overlay/append
-      - name: capi-kpack-watcher-client-credentials-file
+      - name: cf-api-controllers-client-credentials-file
         secret:
-          secretName: uaa-capi-kpack-watcher-client-secret
+          secretName: uaa-cf-api-controllers-client-secret
 

--- a/config/values.yml
+++ b/config/values.yml
@@ -66,7 +66,7 @@ capi:
     region: "''"
     endpoint: "http://cf-blobstore-minio.cf-blobstore.svc.cluster.local:9000"
   database_password_secret_name: capi-database-password
-  kpack_watcher_client_secret: ""
+  cf_api_controllers_client_secret: ""
   cc_username_lookup_client_secret: ""
   database:
     #! or mysql2, as needed
@@ -80,7 +80,7 @@ capi:
     name: cloud_controller
     #! Plain text ca certificate if tls should be used
     ca_cert: ""
-  kpack_watcher_secret_name: kpack-watcher-client-secret
+  cf_api_controllers_secret_name: cf-api-controllers-client-secret
   cloud_controller_username_lookup_secret_name: cloud-controller-username-lookup-client-secret
 
 uaa:

--- a/hack/generate-values.sh
+++ b/hack/generate-values.sh
@@ -105,7 +105,7 @@ variables:
   type: password
 - name: cc_username_lookup_client_secret
   type: password
-- name: kpack_watcher_client_secret
+- name: cf_api_controllers_client_secret
   type: password
 - name: default_ca
   type: certificate
@@ -223,7 +223,7 @@ cf_db:
 
 capi:
   cc_username_lookup_client_secret: $(bosh interpolate ${VARS_FILE} --path=/cc_username_lookup_client_secret)
-  kpack_watcher_client_secret: $(bosh interpolate ${VARS_FILE} --path=/kpack_watcher_client_secret)
+  cf_api_controllers_client_secret: $(bosh interpolate ${VARS_FILE} --path=/cf_api_controllers_client_secret)
   database:
     password: $(bosh interpolate ${VARS_FILE} --path=/capi_db_password)
     encryption_key: $(bosh interpolate ${VARS_FILE} --path=/capi_db_encryption_key)

--- a/vendir.lock.yml
+++ b/vendir.lock.yml
@@ -2,8 +2,8 @@ apiVersion: vendir.k14s.io/v1alpha1
 directories:
 - contents:
   - git:
-      commitTitle: images.yml updated by CI...
-      sha: bb40b9d67db1c3d150791d773752d1d788cdef91
+      commitTitle: rename kpack_watcher_client_secret => cf_api_controllers_client_secret...
+      sha: 664572184e1b34a1230c713bb908b10a397ad98d
     path: .
   path: config/capi/_ytt_lib/capi-k8s-release
 - contents:

--- a/vendir.yml
+++ b/vendir.yml
@@ -8,7 +8,7 @@ directories:
   - path: .
     git:
       url: https://github.com/cloudfoundry/capi-k8s-release
-      ref: bb40b9d67db1c3d150791d773752d1d788cdef91
+      ref: rename-kpack-watcher-to-controllers
     includePaths:
     - templates/**/*
     - values/**/*


### PR DESCRIPTION
We'd like to rename the capi-kpack-watcher deployment to "cf-api-controllers" to match some new source code organization we've done in capi-k8s-release. In cf-for-k8s, the main thing that still bears that name is the client secret. 

This PR does change one left-hand-side key in `values.yml`, and also updates hack/generate-values to match.

- we are doing this rename in accordance with https://github.com/cloudfoundry/capi-k8s-release/blob/rename-kpack-watcher-to-controllers/decisions/0003-cf-api-controller-repo.md


**PLZ NOTE:**

This PR uses a branch of capi-k8s-release that has the full rename. When this is merged, we'll need to merge that branch or else automated bumps of capi-k8s-release will cause cf-for-k8s pipeline breakage. Can we rely on cf-for-k8s autobump automation magic to change the vendir back to aiming at capi-k8s-release/ci-passed after everything's merged?

That branch is here: https://github.com/cloudfoundry/capi-k8s-release/pull/59 and is referenced in this PR's vendir.yml. 

**Acceptance Steps**

look in the k8s api and see that there is no longer a kpack_watcher_secret, and the uaa config has no mention of it.

@ericpromislow 
