### PR TITLE
MAINT: temporarily use kpack from commit d3004be to unblock CAPI

### DIFF
--- a/config/kpack/_ytt_lib/kpack/kpack-rendered.yml
+++ b/config/kpack/_ytt_lib/kpack/kpack-rendered.yml
@@ -87,6 +87,38 @@ spec:
     type: string
     JSONPath: .status.conditions[?(@.type=="Ready")].status
 ---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: build-init-image
+  namespace: kpack
+data:
+  image: "gcr.io/cf-build-service-public/kpack/build-init@sha256:c9fc78e2b527a988a76f68cf6b556beb45d20f9556e8cc2a5095813b38738724"
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: rebase-image
+  namespace: kpack
+data:
+  image: "gcr.io/cf-build-service-public/kpack/rebase@sha256:0ec15508e114229b674b65fcb135ac88ac9e73877b27d4708a7fed0f8cb4311f"
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: lifecycle-image
+  namespace: kpack
+data:
+  image: "gcr.io/cf-build-service-public/kpack/lifecycle@sha256:8b0dea6d3ac03a2d4a2e6728e64ae0d6bf15bf619d4bfbe9ddd70e0fcd7909bc"
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: completion-image
+  namespace: kpack
+data:
+  image: "gcr.io/cf-build-service-public/kpack/completion@sha256:1a1c892059f14061afdac6cc92fb67afc28ed6837ab0011ac13b6933cfa2e2b0"
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -101,12 +133,12 @@ spec:
     metadata:
       labels:
         app: kpack-controller
-        version: 0.0.9-rc.41
+        version: dev
     spec:
       serviceAccountName: controller
       containers:
       - name: controller
-        image: gcr.io/cf-build-service-public/kpack/controller@sha256:6677501fb8073ddc6c61c9fb4bfd1427eb43ce3a06f9fb522ca2aff348ae6c90
+        image: "gcr.io/cf-build-service-public/kpack/controller@sha256:a382af0ae65d504fa3b831e978922592726af20e1d787f3964591d11025dfc35"
         env:
         - name: CONFIG_LOGGING_NAME
           value: config-logging
@@ -119,13 +151,25 @@ spec:
             fieldRef:
               fieldPath: metadata.namespace
         - name: BUILD_INIT_IMAGE
-          value: gcr.io/cf-build-service-public/kpack/build-init@sha256:386452ea690ed497b092977209079c3f310e6fdf94523387e517df97f7f64cb3
+          valueFrom:
+            configMapKeyRef:
+              name: build-init-image
+              key: image
         - name: REBASE_IMAGE
-          value: gcr.io/cf-build-service-public/kpack/rebase@sha256:61f91010e8b77eb6b0d28d69a417a7f597a3fb0d9b2d4e63980be3e64d76721e
+          valueFrom:
+            configMapKeyRef:
+              name: rebase-image
+              key: image
         - name: COMPLETION_IMAGE
-          value: gcr.io/cf-build-service-public/kpack/completion@sha256:de0f72cae50a8db095c6b97a17e7acc79004a5468b1d554b7cd2a9019e9cc807
+          valueFrom:
+            configMapKeyRef:
+              name: completion-image
+              key: image
         - name: LIFECYCLE_IMAGE
-          value: gcr.io/cf-build-service-public/kpack/lifecycle@sha256:8b0dea6d3ac03a2d4a2e6728e64ae0d6bf15bf619d4bfbe9ddd70e0fcd7909bc
+          valueFrom:
+            configMapKeyRef:
+              name: lifecycle-image
+              key: image
 ---
 apiVersion: v1
 kind: ServiceAccount
@@ -455,12 +499,12 @@ spec:
       labels:
         app: kpack-webhook
         role: webhook
-        version: 0.0.9-rc.41
+        version: dev
     spec:
       serviceAccountName: webhook
       containers:
       - name: webhook
-        image: gcr.io/cf-build-service-public/kpack/webhook@sha256:b57ef8d30ad548de39ee7105fe9f783c02ab181c2b80ef68cbd9b7a0bc66ac44
+        image: "gcr.io/cf-build-service-public/kpack/webhook@sha256:c1d08204fd6db33895a5a69b8afdf29ef1558a890a2945ce00a9cac0bd04ac01"
         ports:
         - name: https-webhook
           containerPort: 8443

--- a/vendir.lock.yml
+++ b/vendir.lock.yml
@@ -14,11 +14,6 @@ directories:
   path: config/networking/_ytt_lib/cf-k8s-networking
 - contents:
   - githubRelease:
-      url: https://api.github.com/repos/pivotal/kpack/releases/27343776
-    path: .
-  path: config/kpack/_ytt_lib/kpack
-- contents:
-  - githubRelease:
       url: https://api.github.com/repos/cloudfoundry/cf-k8s-logging/releases/26725288
     path: .
   path: config/logging/_ytt_lib/cf-k8s-logging
@@ -38,6 +33,10 @@ directories:
   - manual: {}
     path: eirini
   path: config/eirini/_ytt_lib
+- contents:
+  - manual: {}
+    path: kpack
+  path: config/kpack/_ytt_lib
 - contents:
   - manual: {}
     path: minio

--- a/vendir.yml
+++ b/vendir.yml
@@ -25,15 +25,6 @@ directories:
     - config/istio-config/**/*
     - config/istio/generated/**/*
     - config/routecontroller/**/*
-- path: config/kpack/_ytt_lib/kpack
-  contents:
-  - path: .
-    githubRelease:
-      slug: pivotal/kpack
-      tag: v0.0.9
-      disableAutoChecksumValidation: true
-    includePaths:
-    - release-*.yaml
 - path: config/logging/_ytt_lib/cf-k8s-logging
   contents:
   - path: .
@@ -62,6 +53,11 @@ directories:
 - path: config/eirini/_ytt_lib
   contents:
   - path: eirini
+    manual: {}
+
+- path: config/kpack/_ytt_lib
+  contents:
+  - path: kpack
     manual: {}
 
 - path: config/minio/_ytt_lib


### PR DESCRIPTION
Additional notes about this change can be found in this Tracker story: [#173992907](https://www.pivotaltracker.com/story/show/173992907)

Co-authored-by: Andrew Costa <acosta@pivotal.io>


---

- Make sure this PR is based off the `develop` branch
- If you're adding/removing/changing any values in `config/values.yml`, please review [this "cf-for-k8s values for contributors" doc](https://docs.google.com/document/d/1Y3jAx48TCGIQdzOFmzqp_R_0WT8Hfjx9oyqs2Tk0Otw/edit#) for up-to-date principles and guidelines for contributing values changes.
- Checkout the [contributing guidelines](https://github.com/cloudfoundry/cf-for-k8s/blob/develop/community/CONTRIBUTING.md)
- Include any links to related PRs, issues, stories, slack discussions, etc... that will help establish context.
- Is there anything else of note that the reviewers should know about this change?

**Acceptance Steps**

CI tests pass


_Tag your pair, your PM, and/or team_

tagging @acosta11 
