### PR TITLE
Add optional templates to deploy external-dns for Google Cloud DNS

### DIFF
--- a/config-optional/gcp/add-external-dns.yml
+++ b/config-optional/gcp/add-external-dns.yml
@@ -1,0 +1,86 @@
+#@ load("@ytt:data", "data")
+#@ load("@ytt:base64","base64")
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: external-dns
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: external-dns
+  namespace: external-dns
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: external-dns
+rules:
+- apiGroups: [""]
+  resources: ["services","endpoints","pods"]
+  verbs: ["get","watch","list"]
+- apiGroups: [""]
+  resources: ["nodes"]
+  verbs: ["get", "watch", "list"]
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: external-dns-viewer
+  namespace: external-dns
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: external-dns
+subjects:
+- kind: ServiceAccount
+  name: external-dns
+  namespace: external-dns
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: google-cloud-dns-key
+  namespace: external-dns
+data:
+  key.json: #@ base64.encode(data.values.external_dns.gcp.service_account_key)
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: external-dns
+  namespace: external-dns
+spec:
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: external-dns
+  template:
+    metadata:
+      labels:
+        app: external-dns
+    spec:
+      serviceAccountName: external-dns
+      containers:
+      - name: external-dns
+        image: registry.opensource.zalan.do/teapot/external-dns:latest
+        args:
+        - --source=service
+        - #@ "--domain-filter=" + data.values.external_dns.parent_domain
+        - --provider=google
+        - #@ "--google-project=" + data.values.external_dns.gcp.project_id
+        - --policy=upsert-only #! would prevent ExternalDNS from deleting any records, omit to enable full synchronization
+        - --registry=txt
+        env:
+        - name: GOOGLE_APPLICATION_CREDENTIALS
+          value: /etc/google-cloud-dns/key.json
+        volumeMounts:
+        - name: google-cloud-dns-key
+          mountPath: /etc/google-cloud-dns
+          readOnly: true
+      volumes:
+      - name: google-cloud-dns-key
+        secret:
+          secretName: google-cloud-dns-key

--- a/config/values.yml
+++ b/config/values.yml
@@ -156,3 +156,13 @@ metric_proxy:
     secret_name: "metric-proxy-cert"
     crt: ""
     key: ""
+
+#! [Optional] Used for optional config to set up `external-dns` deployment
+external_dns:
+  #! The domain which is the parent domain of `system_domain`
+  parent_domain: ""
+  gcp:
+    #! Use this to specify the project which contains the desired Google Cloud DNS entries
+    project_id: ""
+    #! The JSON key for a service account which has permission to modify the desired GCP project's Google Cloud DNS entries
+    service_account_key: ""


### PR DESCRIPTION
Added optional templates which deploys the [external-dns](https://github.com/kubernetes-sigs/external-dns) controller which will manage configured Google Cloud DNS entries. Reason being is so users deploying to GKE and also maintaining their DNS with Google Cloud DNS do not have to constantly, manually update DNS records when deploying or be forced to use terraform (with the templates in the `deploy` directory) and maintain terraform state.

Given that this requires adding new values to `config/values.yml`, would also like to open a discussion about how best to add these new, optional values. Is the way it is in the PR currently fine? Would you all prefer something along the lines of #245 with the `cfdb_enabled` function? 

We're a little unclear about how to proceed with this specifically given that it's an optional template (i.e. it's in `config-optional` and not the main `config` directory) whose values are implicitly optional as a result.

Also would love some feedback about us making IaaS-specific directories inside the `config-optional` directory like we did for this PR.

---

**Acceptance Steps**

1. Deploy cf-for-k8s with the following additional ytt templates:
    - `config-optional/use-external-dns-for-wildcard.yml`
    - `config-optional/gcp/add-external-dns.yml`
1. Verify that eventually the `*.<system_domain>` DNS record has been made in the desired Google Cloud DNS project
1. Ensure that cf has deployed successfully (can target the deployment with `cf api` or something which also further indicates DNS has been configured automatically)

Thanks,
Jwal + @matt-royal 
