### PR TITLE
Add setting to redirect HTTP requests to HTTPS

### DIFF
--- a/config/networking/external-routing.yml
+++ b/config/networking/external-routing.yml
@@ -37,7 +37,7 @@ metadata:
 
 #! this gateway is used to expose CF services in the cluster, externally
 #@ load("gateway.lib.yml", "gateway")
---- #@ gateway(data.values.system_domain, data.values.app_domains, data.values.system_namespace, data.values.workloads_namespace)
+--- #@ gateway(data.values.system_domain, data.values.app_domains, data.values.system_namespace, data.values.workloads_namespace, data.values.gateway.https_only)
 
 #! This will set overlay a static IP for the istio load balancer.
 #@overlay/match by=overlay.subset({"kind": "Service", "metadata":{"name": "istio-ingressgateway"}})

--- a/config/networking/gateway.lib.yml
+++ b/config/networking/gateway.lib.yml
@@ -1,4 +1,5 @@
-#@ def gateway(system_domain, app_domains, system_namespace, workloads_namespace):
+#@ def gateway(system_domain, app_domains, system_namespace, workloads_namespace, https_only):
+
 apiVersion: networking.istio.io/v1alpha3
 kind: Gateway
 metadata:
@@ -15,6 +16,8 @@ spec:
       name: http
       number: 80
       protocol: HTTP
+    tls:
+      httpsRedirect: #@ https_only
   - hosts:
     - #@ ('' if system_domain in app_domains else '*/') + '*.' + system_domain
     port:

--- a/config/values/00-values.yml
+++ b/config/values/00-values.yml
@@ -29,6 +29,10 @@ workloads_certificate:
   #! Base64-encoded CA certificate used to sign the workloads certifcate
   ca: ""
 
+#! When true, automatically upgrades incoming HTTP connections to HTTPS
+gateway:
+  https_only: true
+
 capi:
   database:
     #! or mysql2, as needed

--- a/sample-cf-install-values.yml
+++ b/sample-cf-install-values.yml
@@ -30,6 +30,10 @@ capi:
     password: ccdb_password
     encryption_key: ccdb_encryption_key
 
+#! When true, automatically upgrades incoming HTTP connections to HTTPS
+gateway:
+  https_only: true
+
 #! Notes about X.509 certificates:
 #! - the certificates and keys are base64 encoded
 #! - all of the certs should have KeyUsage that includes server and client authentication


### PR DESCRIPTION
This change adds a setting to the values file that allows users to tell the platform to redirect HTTP requests to the HTTPS endpoint.

**Acceptance Steps**

Given I have a deployment of cf-k8s with an app,
And I have set `gateway: {https_only: true}`
When I send an http request to that app
Then I can see that I am redirected to https
And I receive a successful response from my application https.

Given I have a deployment of cf-k8s with an app,
And I have set `gateway: {https_only: false}`
When I send an http request to that app
Then I receive a successful response from my application over http.

CC @mike1808 @ndhanushkodi 