### PR TITLE
Add external db check on pr to ci pipeline (second try)

### DIFF
--- a/ci/pipelines/cf-for-k8s.yml
+++ b/ci/pipelines/cf-for-k8s.yml
@@ -486,76 +486,13 @@ jobs:
     params: {acquire: true}
 
   - task: install-postgres
+    params:
+      GCP_PROJECT_NAME: ((ci_k8s_gcp_project_name))
+      GCP_PROJECT_ZONE: ((ci_k8s_gcp_project_zone))
+      GCP_SERVICE_ACCOUNT_JSON: ((ci_k8s_gcp_service_account_json))
+    file: cf-for-k8s-ci/ci/tasks/install-postgres/task.yml
     input_mapping:
       pool-lock: ready-pool
-    config:
-      <<: *common-task-config
-      inputs:
-      - name: cf-for-k8s-develop
-      - name: cf-for-k8s-ci
-      - name: pool-lock
-      outputs:
-      - name: db-metadata
-      params:
-        GCP_SERVICE_ACCOUNT_JSON: ((ci_k8s_gcp_service_account_json))
-        GCP_PROJECT_NAME: ((ci_k8s_gcp_project_name))
-        GCP_PROJECT_ZONE: ((ci_k8s_gcp_project_zone))
-      run:
-        path: /bin/bash
-        args:
-        - -ec
-        - |
-          source cf-for-k8s-ci/ci/helpers/gke.sh
-
-          cluster_name="$(cat pool-lock/name)"
-          gcloud_auth "${cluster_name}"
-
-          kubectl create namespace external-db
-          helm repo add bitnami https://charts.bitnami.com/bitnami
-          helm install -n external-db --wait postgresql bitnami/postgresql
-
-          CCDB_USERNAME="capi_user"
-          CCDB_PASSWORD="$(openssl rand -base64 32)"
-          CCDB_NAME="capi_db"
-          UAADB_USERNAME="uaa_user"
-          UAADB_PASSWORD="$(openssl rand -base64 32)"
-          UAADB_NAME="uaa_db"
-
-          cat > /tmp/setup_db.sql <<EOT
-          CREATE DATABASE ${CCDB_NAME};
-          CREATE ROLE ${CCDB_USERNAME} LOGIN PASSWORD '${CCDB_PASSWORD}';
-          CREATE DATABASE ${UAADB_NAME};
-          CREATE ROLE ${UAADB_USERNAME} LOGIN PASSWORD '${UAADB_PASSWORD}';
-          \c ${CCDB_NAME};
-          CREATE EXTENSION citext;
-          \c ${UAADB_NAME};
-          CREATE EXTENSION citext;
-          EOT
-
-          export POSTGRES_PASSWORD=$(kubectl get secret -n external-db postgresql -o jsonpath="{.data.postgresql-password}" | base64 -d)
-          kubectl exec -n external-db statefulset/postgresql-postgresql -i -- psql "postgresql://postgres:$POSTGRES_PASSWORD@localhost:5432/postgres" < /tmp/setup_db.sql
-
-          cat > db-metadata/db-values.yaml <<EOT
-          #@data/values
-          ---
-          capi:
-            database:
-              adapter: postgres
-              host: postgresql.external-db.svc.cluster.local
-              port: 5432
-              user: $CCDB_USERNAME
-              password: $CCDB_PASSWORD
-              name: $CCDB_NAME
-
-          uaa:
-            database:
-              adapter: postgresql
-              host: postgresql.external-db.svc.cluster.local
-              port: 5432
-              user: $UAADB_USERNAME
-              password: $UAADB_PASSWORD
-              name: $UAADB_NAME
-          EOT
 
   - task: install-cf
     input_mapping:
@@ -1468,81 +1405,11 @@ jobs:
       var_files: [tf-vars/input.tfvars]
 
   - task: install-postgres
-    config:
-      image_resource:
-        source:
-          repository: relintdockerhubpushbot/cf-for-k8s-ci
-        type: docker-image
-      inputs:
-      - name: cf-for-k8s-develop
-      - name: cf-for-k8s-ci
-      - name: terraform
-      - name: tf-vars
-      outputs:
-      - name: db-metadata
-      params:
-        GCP_PROJECT_NAME: ((ci_k8s_gcp_project_name))
-        GCP_PROJECT_ZONE: ((ci_k8s_gcp_project_zone))
-        GCP_SERVICE_ACCOUNT_JSON: ((ci_k8s_gcp_service_account_json))
-      platform: linux
-      run:
-        args:
-        - -ec
-        - |
-          source cf-for-k8s-ci/ci/helpers/gke.sh
-
-          cluster_name="$(cat tf-vars/env-name.txt)"
-          gcloud_auth "${cluster_name}"
-
-          kubectl create namespace external-db
-          helm repo add bitnami https://charts.bitnami.com/bitnami
-          helm install -n external-db --wait postgresql bitnami/postgresql
-
-          CCDB_USERNAME="capi_user"
-          CCDB_PASSWORD="$(openssl rand -base64 32)"
-          CCDB_NAME="capi_db"
-          UAADB_USERNAME="uaa_user"
-          UAADB_PASSWORD="$(openssl rand -base64 32)"
-          UAADB_NAME="uaa_db"
-
-          cat > /tmp/setup_db.sql <<EOT
-          CREATE DATABASE ${CCDB_NAME};
-          CREATE ROLE ${CCDB_USERNAME} LOGIN PASSWORD '${CCDB_PASSWORD}';
-          CREATE DATABASE ${UAADB_NAME};
-          CREATE ROLE ${UAADB_USERNAME} LOGIN PASSWORD '${UAADB_PASSWORD}';
-          \c ${CCDB_NAME};
-          CREATE EXTENSION citext;
-          \c ${UAADB_NAME};
-          CREATE EXTENSION citext;
-          EOT
-
-          export POSTGRES_PASSWORD=$(kubectl get secret -n external-db postgresql -o jsonpath="{.data.postgresql-password}" | base64 -d)
-          kubectl exec -n external-db statefulset/postgresql-postgresql -i -- psql "postgresql://postgres:$POSTGRES_PASSWORD@localhost:5432/postgres" < /tmp/setup_db.sql
-
-          cat > db-metadata/db-values.yaml <<EOT
-          #@data/values
-          ---
-          capi:
-            database:
-              adapter: postgres
-              host: postgresql.external-db.svc.cluster.local
-              port: 5432
-              user: $CCDB_USERNAME
-              password: $CCDB_PASSWORD
-              name: $CCDB_NAME
-
-          uaa:
-            database:
-              adapter: postgresql
-              host: postgresql.external-db.svc.cluster.local
-              port: 5432
-              user: $UAADB_USERNAME
-              password: $UAADB_PASSWORD
-              name: $UAADB_NAME
-          EOT
-        path: /bin/bash
-    input_mapping:
-      pool-lock: ready-pool
+    params:
+      GCP_PROJECT_NAME: ((ci_k8s_gcp_project_name))
+      GCP_PROJECT_ZONE: ((ci_k8s_gcp_project_zone))
+      GCP_SERVICE_ACCOUNT_JSON: ((ci_k8s_gcp_service_account_json))
+    file: cf-for-k8s-ci/ci/tasks/install-postgres/task.yml
   - do:
     - task: install-cf-develop
       params:

--- a/ci/pipelines/cf-for-k8s.yml
+++ b/ci/pipelines/cf-for-k8s.yml
@@ -1428,7 +1428,6 @@ jobs:
         cf-for-k8s: cf-for-k8s-develop
 
   - task: push-test-app
-    attempts: 3
     file: cf-for-k8s-ci/ci/tasks/push-test-app/task.yml
     params:
       APP_NAME: jp-node-app

--- a/ci/pipelines/cf-for-k8s.yml
+++ b/ci/pipelines/cf-for-k8s.yml
@@ -1388,7 +1388,7 @@ jobs:
         - -ec
         - |
           echo "pr-validation" > tf-vars/env-name.txt
-          cat <<EOT > tf-vars/input.tfvars
+          cat > tf-vars/input.tfvars <<EOT
           project = "((ci_k8s_gcp_project_name))"
           region = "((ci_k8s_gcp_project_region))"
           zone = "((ci_k8s_gcp_project_zone))"
@@ -1437,7 +1437,6 @@ jobs:
 
   - task: upgrade-to-pr
     file: cf-for-k8s-ci/ci/tasks/install-cf-on-gke/task.yml
-    on_failure: *on_failure_uptime_pr_comment
     input_mapping:
       cf-for-k8s: cf-for-k8s-pr-all-branches-and-forks
     params:
@@ -1456,14 +1455,12 @@ jobs:
 
   - in_parallel:
     - task: run-smoke-tests
-      on_failure: *on_failure_uptime_pr_comment
       file: cf-for-k8s-ci/ci/tasks/run-smoke-tests/task.yml
       params:
         SMOKE_TEST_SKIP_SSL: false
       input_mapping:
         cf-for-k8s: cf-for-k8s-pr-all-branches-and-forks
     - task: verify-existing-app
-      on_failure: *on_failure_uptime_pr_comment
       file: cf-for-k8s-ci/ci/tasks/push-test-app/task.yml
       params:
         APP_NAME: jp-node-app
@@ -1471,6 +1468,20 @@ jobs:
       input_mapping:
         cf-for-k8s: cf-for-k8s-pr-all-branches-and-forks
 
+  on_failure:
+    do:
+    - task: write-pr-check-failure-comment
+      file: runtime-ci/tasks/write-pr-check-failure-comment/task.yml
+      input_mapping:
+        pull-request: cf-for-k8s-pr-all-branches-and-forks
+
+    - put: cf-for-k8s-pr-all-branches-and-forks
+      params:
+        path: cf-for-k8s-pr-all-branches-and-forks
+        status: failure
+        context: upgrade-check-uptime
+        comment_file: pull-request-comment/comment
+  
   on_success:
     put: cf-for-k8s-pr-all-branches-and-forks
     params:

--- a/ci/pipelines/cf-for-k8s.yml
+++ b/ci/pipelines/cf-for-k8s.yml
@@ -26,6 +26,7 @@ groups:
   - pass-prs-to-cf-for-k8s-develop
   - run-unit-tests-on-pr
   - validate-pr-on-gke
+  - validate-pr-on-gke-external-db
   - validate-pr-on-newest-k8s-kind
   - validate-pr-on-oldest-k8s-kind
   - test-vendir-sync-on-cf-for-k8s-pr
@@ -1413,6 +1414,235 @@ jobs:
       - put: ready-pool
         params:
           remove: ready-pool
+
+- name: validate-pr-on-gke-external-db
+  serial: true
+  public: true
+  plan:
+  - in_parallel:
+    - get: cf-for-k8s-pr-all-branches-and-forks
+      params:
+        integration_tool: rebase
+      trigger: true
+      version: every
+      passed:
+      - run-unit-tests-on-pr
+      - test-vendir-sync-on-cf-for-k8s-pr
+    - get: cf-for-k8s-ci
+    - get: cf-for-k8s-develop
+    - get: cf-for-k8s-gke-terraform-templates
+    - get: runtime-ci
+
+  - put: cf-for-k8s-pr-all-branches-and-forks
+    params:
+      path: cf-for-k8s-pr-all-branches-and-forks
+      status: pending
+      context: upgrade-check-uptime
+  - task: create-tf-vars-file
+    config:
+      <<: *common-task-config
+      outputs:
+      - name: tf-vars
+      params:
+        SERVICE_ACCOUNT_JSON: ((dev_cluster_pool_admin_service_account_json))
+      run:
+        path: /bin/bash
+        args:
+        - -ec
+        - |
+          echo "pr-validation" > tf-vars/env-name.txt
+          cat <<EOT > tf-vars/input.tfvars
+          project = "((ci_k8s_gcp_project_name))"
+          region = "((ci_k8s_gcp_project_region))"
+          zone = "((ci_k8s_gcp_project_zone))"
+          service_account_key = "$(echo ${SERVICE_ACCOUNT_JSON} | jq -c '.' | sed -e 's#"#\\"#g' -e 's#\\n#\\\\n#g')"
+          env_name = "$(cat tf-vars/env-name.txt)"
+          env_dns_domain = "$(cat tf-vars/env-name.txt).((ci_k8s_root_domain))"
+          dns_zone_name = "((ci_k8s_dns_zone_name))"
+          EOT
+  - put: terraform
+    params:
+      terraform_source: cf-for-k8s-gke-terraform-templates/deploy/gke/terraform
+      env_name_file: tf-vars/env-name.txt
+      delete_on_failure: true
+      var_files: [tf-vars/input.tfvars]
+
+  - task: install-postgres
+    config:
+      image_resource:
+        source:
+          repository: relintdockerhubpushbot/cf-for-k8s-ci
+        type: docker-image
+      inputs:
+      - name: cf-for-k8s-develop
+      - name: cf-for-k8s-ci
+      - name: terraform
+      - name: tf-vars
+      outputs:
+      - name: db-metadata
+      params:
+        GCP_PROJECT_NAME: ((ci_k8s_gcp_project_name))
+        GCP_PROJECT_ZONE: ((ci_k8s_gcp_project_zone))
+        GCP_SERVICE_ACCOUNT_JSON: ((ci_k8s_gcp_service_account_json))
+      platform: linux
+      run:
+        args:
+        - -ec
+        - |
+          source cf-for-k8s-ci/ci/helpers/gke.sh
+
+          cluster_name="$(cat tf-vars/env-name.txt)"
+          gcloud_auth "${cluster_name}"
+
+          kubectl create namespace external-db
+          helm repo add bitnami https://charts.bitnami.com/bitnami
+          helm install -n external-db --wait postgresql bitnami/postgresql
+
+          CCDB_USERNAME="capi_user"
+          CCDB_PASSWORD="$(openssl rand -base64 32)"
+          CCDB_NAME="capi_db"
+          UAADB_USERNAME="uaa_user"
+          UAADB_PASSWORD="$(openssl rand -base64 32)"
+          UAADB_NAME="uaa_db"
+
+          cat > /tmp/setup_db.sql <<EOT
+          CREATE DATABASE ${CCDB_NAME};
+          CREATE ROLE ${CCDB_USERNAME} LOGIN PASSWORD '${CCDB_PASSWORD}';
+          CREATE DATABASE ${UAADB_NAME};
+          CREATE ROLE ${UAADB_USERNAME} LOGIN PASSWORD '${UAADB_PASSWORD}';
+          \c ${CCDB_NAME};
+          CREATE EXTENSION citext;
+          \c ${UAADB_NAME};
+          CREATE EXTENSION citext;
+          EOT
+
+          export POSTGRES_PASSWORD=$(kubectl get secret -n external-db postgresql -o jsonpath="{.data.postgresql-password}" | base64 -d)
+          kubectl exec -n external-db statefulset/postgresql-postgresql -i -- psql "postgresql://postgres:$POSTGRES_PASSWORD@localhost:5432/postgres" < /tmp/setup_db.sql
+
+          cat > db-metadata/db-values.yaml <<EOT
+          #@data/values
+          ---
+          capi:
+            database:
+              adapter: postgres
+              host: postgresql.external-db.svc.cluster.local
+              port: 5432
+              user: $CCDB_USERNAME
+              password: $CCDB_PASSWORD
+              name: $CCDB_NAME
+
+          uaa:
+            database:
+              adapter: postgresql
+              host: postgresql.external-db.svc.cluster.local
+              port: 5432
+              user: $UAADB_USERNAME
+              password: $UAADB_PASSWORD
+              name: $UAADB_NAME
+          EOT
+        path: /bin/bash
+    input_mapping:
+      pool-lock: ready-pool
+  - do:
+    - task: install-cf-develop
+      params:
+        GCP_SERVICE_ACCOUNT_JSON: ((ci_k8s_gcp_service_account_json))
+        GCP_PROJECT_NAME: ((ci_k8s_gcp_project_name))
+        GCP_PROJECT_ZONE: ((ci_k8s_gcp_project_zone))
+        DOMAIN: cf-for-k8s.relint.rocks
+        USE_EXTERNAL_APP_REGISTRY: true
+        APP_REGISTRY_HOSTNAME: https://index.docker.io/v1/
+        APP_REGISTRY_REPOSITORY_PREFIX: ((cf_for_k8s_private_dockerhub.username))
+        APP_REGISTRY_USERNAME: ((cf_for_k8s_private_dockerhub.username))
+        APP_REGISTRY_PASSWORD: ((cf_for_k8s_private_dockerhub.password))
+        USE_EXTERNAL_DB: "true"
+      file: cf-for-k8s-ci/ci/tasks/install-cf-on-gke/task.yml
+      input_mapping:
+        cf-for-k8s: cf-for-k8s-develop
+
+  - task: push-test-app
+    attempts: 3
+    file: cf-for-k8s-ci/ci/tasks/push-test-app/task.yml
+    params:
+      APP_NAME: jp-node-app
+      VERIFY_EXISTING_APP: false
+    input_mapping:
+      cf-for-k8s: cf-for-k8s-develop
+
+  - task: upgrade-to-pr
+    file: cf-for-k8s-ci/ci/tasks/install-cf-on-gke/task.yml
+    on_failure: *on_failure_uptime_pr_comment
+    input_mapping:
+      cf-for-k8s: cf-for-k8s-pr-all-branches-and-forks
+    params:
+      GCP_SERVICE_ACCOUNT_JSON: ((ci_k8s_gcp_service_account_json))
+      GCP_PROJECT_NAME: ((ci_k8s_gcp_project_name))
+      GCP_PROJECT_ZONE: ((ci_k8s_gcp_project_zone))
+      UPGRADE: true
+      UPTIMER: true
+      DOMAIN: cf-for-k8s.relint.rocks
+      USE_EXTERNAL_APP_REGISTRY: true
+      APP_REGISTRY_HOSTNAME: https://index.docker.io/v1/
+      APP_REGISTRY_REPOSITORY_PREFIX: ((cf_for_k8s_private_dockerhub.username))
+      APP_REGISTRY_USERNAME: ((cf_for_k8s_private_dockerhub.username))
+      APP_REGISTRY_PASSWORD: ((cf_for_k8s_private_dockerhub.password))
+      USE_EXTERNAL_DB: "true"
+
+  - in_parallel:
+    - task: run-smoke-tests
+      on_failure: *on_failure_uptime_pr_comment
+      file: cf-for-k8s-ci/ci/tasks/run-smoke-tests/task.yml
+      params:
+        SMOKE_TEST_SKIP_SSL: false
+      input_mapping:
+        cf-for-k8s: cf-for-k8s-pr-all-branches-and-forks
+    - task: verify-existing-app
+      on_failure: *on_failure_uptime_pr_comment
+      file: cf-for-k8s-ci/ci/tasks/push-test-app/task.yml
+      params:
+        APP_NAME: jp-node-app
+        VERIFY_EXISTING_APP: true
+      input_mapping:
+        cf-for-k8s: cf-for-k8s-pr-all-branches-and-forks
+
+  on_success:
+    put: cf-for-k8s-pr-all-branches-and-forks
+    params:
+      path: cf-for-k8s-pr-all-branches-and-forks
+      status: success
+      context: upgrade-check-uptime
+
+  ensure:
+    do:
+    - task: delete-cf
+      config:
+        <<: *common-task-config
+        inputs:
+        - name: cf-for-k8s-ci
+        - name: tf-vars
+        params:
+          GCP_SERVICE_ACCOUNT_JSON: ((ci_k8s_gcp_service_account_json))
+          GCP_PROJECT_NAME: ((ci_k8s_gcp_project_name))
+          GCP_PROJECT_ZONE: ((ci_k8s_gcp_project_zone))
+        run:
+          path: /bin/bash
+          args:
+          - -ec
+          - |
+            source cf-for-k8s-ci/ci/helpers/gke.sh
+            cluster_name="$(cat tf-vars/env-name.txt)"
+            gcloud_auth "${cluster_name}"
+            kapp delete -a cf --yes
+
+    - put: terraform
+      params:
+        terraform_source: cf-for-k8s-gke-terraform-templates/deploy/gke/terraform
+        env_name_file: tf-vars/env-name.txt
+        action: destroy
+        var_files: [tf-vars/input.tfvars]
+      get_params:
+        action: destroy
+
 
 - name: validate-pr-on-newest-k8s-kind
   plan:

--- a/ci/tasks/install-cf-on-gke/task.sh
+++ b/ci/tasks/install-cf-on-gke/task.sh
@@ -64,7 +64,12 @@ password="$(bosh interpolate --path /cf_admin_password cf-values.yml)"
 
 echo "Installing CF..."
 rendered_yaml="/tmp/rendered.yml"
-ytt -f cf-for-k8s/config -f cf-values.yml > ${rendered_yaml}
+additional_args=""
+if [[ "${USE_EXTERNAL_DB}" == "true" ]]; then
+  additional_args = "-f db-metadata/db-values.yaml"
+fi
+
+ytt -f cf-for-k8s/config -f cf-values.yml $additional_args > ${rendered_yaml}
 if [[ "${UPTIMER}" == "true" ]]; then
   echo "Running with uptimer"
   write_uptimer_deploy_config "${password}" "${rendered_yaml}"

--- a/ci/tasks/install-cf-on-gke/task.yml
+++ b/ci/tasks/install-cf-on-gke/task.yml
@@ -17,6 +17,8 @@ inputs:
     optional: true
   - name: env-metadata
     optional: true
+  - name: db-metadata
+    optional: true
 
 params:
   GCP_SERVICE_ACCOUNT_JSON:
@@ -30,6 +32,7 @@ params:
   APP_REGISTRY_PASSWORD:
   UPGRADE: false
   UPTIMER: false
+  EXTERNAL_DB_CONFIG: false
 
 outputs:
   - name: env-metadata

--- a/ci/tasks/install-postgres/task.sh
+++ b/ci/tasks/install-postgres/task.sh
@@ -53,20 +53,22 @@ cat > db-metadata/db-values.yaml <<EOT
 #@data/values
 ---
 capi:
-database:
-    adapter: postgres
-    host: postgresql.external-db.svc.cluster.local
-    port: 5432
-    user: $CCDB_USERNAME
-    password: $CCDB_PASSWORD
-    name: $CCDB_NAME
+  #@overlay/replace
+  database:
+      adapter: postgres
+      host: postgresql.external-db.svc.cluster.local
+      port: 5432
+      user: $CCDB_USERNAME
+      password: $CCDB_PASSWORD
+      name: $CCDB_NAME
 
 uaa:
-database:
-    adapter: postgresql
-    host: postgresql.external-db.svc.cluster.local
-    port: 5432
-    user: $UAADB_USERNAME
-    password: $UAADB_PASSWORD
-    name: $UAADB_NAME
+  #@overlay/replace
+  database:
+      adapter: postgresql
+      host: postgresql.external-db.svc.cluster.local
+      port: 5432
+      user: $UAADB_USERNAME
+      password: $UAADB_PASSWORD
+      name: $UAADB_NAME
 EOT

--- a/ci/tasks/install-postgres/task.sh
+++ b/ci/tasks/install-postgres/task.sh
@@ -1,0 +1,72 @@
+#!/bin/bash -eu
+
+source cf-for-k8s-ci/ci/helpers/gke.sh
+
+if [[ -d pool-lock ]]; then
+  if [[ -d tf-vars ]]; then
+    echo "You may not specify both pool-lock and tf-vars"
+    exit 1
+  fi
+  cluster_name="$(cat pool-lock/name)"
+  istio_static_ip="$(jq -r '.lb_static_ip' pool-lock/metadata)"
+elif [[ -d tf-vars ]]; then
+  if [[ -d terraform ]]; then
+    cluster_name="$(cat tf-vars/env-name.txt)"
+    istio_static_ip="$(jq -r '.lb_static_ip' terraform/metadata)"
+  else
+    echo "You must provide both tf-vars and terraform inputs together"
+    exit 1
+  fi
+else
+  echo "You must provide either pool-lock or tf-vars"
+  exit 1
+fi
+
+gcloud_auth "${cluster_name}"
+
+kubectl create namespace external-db
+helm repo add bitnami https://charts.bitnami.com/bitnami
+helm install -n external-db --wait postgresql bitnami/postgresql
+
+CCDB_USERNAME="capi_user"
+CCDB_PASSWORD="$(openssl rand -base64 32)"
+CCDB_NAME="capi_db"
+UAADB_USERNAME="uaa_user"
+UAADB_PASSWORD="$(openssl rand -base64 32)"
+UAADB_NAME="uaa_db"
+
+cat > /tmp/setup_db.sql <<EOT
+CREATE DATABASE ${CCDB_NAME};
+CREATE ROLE ${CCDB_USERNAME} LOGIN PASSWORD '${CCDB_PASSWORD}';
+CREATE DATABASE ${UAADB_NAME};
+CREATE ROLE ${UAADB_USERNAME} LOGIN PASSWORD '${UAADB_PASSWORD}';
+\c ${CCDB_NAME};
+CREATE EXTENSION citext;
+\c ${UAADB_NAME};
+CREATE EXTENSION citext;
+EOT
+
+export POSTGRES_PASSWORD=$(kubectl get secret -n external-db postgresql -o jsonpath="{.data.postgresql-password}" | base64 -d)
+kubectl exec -n external-db statefulset/postgresql-postgresql -i -- psql "postgresql://postgres:$POSTGRES_PASSWORD@localhost:5432/postgres" < /tmp/setup_db.sql
+
+cat > db-metadata/db-values.yaml <<EOT
+#@data/values
+---
+capi:
+database:
+    adapter: postgres
+    host: postgresql.external-db.svc.cluster.local
+    port: 5432
+    user: $CCDB_USERNAME
+    password: $CCDB_PASSWORD
+    name: $CCDB_NAME
+
+uaa:
+database:
+    adapter: postgresql
+    host: postgresql.external-db.svc.cluster.local
+    port: 5432
+    user: $UAADB_USERNAME
+    password: $UAADB_PASSWORD
+    name: $UAADB_NAME
+EOT

--- a/ci/tasks/install-postgres/task.yml
+++ b/ci/tasks/install-postgres/task.yml
@@ -1,0 +1,27 @@
+---
+platform: linux
+
+image_resource:
+  type: docker-image
+  source:
+    repository: relintdockerhubpushbot/cf-for-k8s-ci
+
+inputs:
+  - name: cf-for-k8s-ci
+  - name: pool-lock
+    optional: true
+  - name: tf-vars
+    optional: true
+  - name: terraform
+    optional: true
+
+params:
+  GCP_SERVICE_ACCOUNT_JSON:
+  GCP_PROJECT_NAME:
+  GCP_PROJECT_ZONE:
+
+outputs:
+  - name: db-metadata
+
+run:
+  path: cf-for-k8s-ci/ci/tasks/install-postgres/task.sh


### PR DESCRIPTION
Add a check for external DB functionality to pull request checks in the concourse pipeline (#168)

We could not test this on our concourse. Integrations and configurations for GCP are missing.

Acceptance Steps*
Update Concourse Pipeline and see if new pull request steps are working

See also #291

@lucaschimweg @modulo11 