### PR TITLE
Re-apply "Initial NetworkPolicies for System Components"

### DIFF
--- a/config/minio/minio.yml
+++ b/config/minio/minio.yml
@@ -18,6 +18,8 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: cf-blobstore
+  labels:
+    name: cf-blobstore
 
 #@overlay/match by=overlay.subset({"kind": "Secret", "metadata": {"name": "cf-blobstore-minio"}})
 ---

--- a/config/networking/network-policies.yaml
+++ b/config/networking/network-policies.yaml
@@ -18,7 +18,7 @@ to:
       release: cf-db
 #@ else:
 - ipBlock:
-    cidr: 0.0.0.0/32
+    cidr: 0.0.0.0/0
 #@ end
 ports:
 - protocol: TCP 

--- a/config/networking/network-policies.yaml
+++ b/config/networking/network-policies.yaml
@@ -3,6 +3,30 @@
 #! TODO: Should be labeled in capi-k8s-release
 #@ load("@ytt:overlay", "overlay")
 #@overlay/match by=overlay.and_op(overlay.subset({"metadata":{"name":"cf-workloads-staging"}}), overlay.subset({"kind": "Namespace"}))
+#@ def cfdb_enabled():
+#@   return len(data.values.uaa.database.host) == 0 or len(data.values.capi.database.host) == 0
+#@ end
+
+#@ def database_egress():
+to:
+#@ if cfdb_enabled():
+- namespaceSelector:
+    matchLabels:
+      name: cf-db
+  podSelector:
+    matchLabels:
+      release: cf-db
+#@ else:
+- ipBlock:
+    cidr: 0.0.0.0/32
+#@ end
+ports:
+- protocol: TCP 
+  port: #@ data.values.capi.database.port  
+- protocol: TCP 
+  port: #@ data.values.uaa.database.port
+#@ end
+
 ---
 metadata:
   #@overlay/match missing_ok=True
@@ -20,6 +44,7 @@ spec:
   podSelector: {}
   policyTypes:
   - Ingress
+#@ if cfdb_enabled():
 ---
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
@@ -30,6 +55,7 @@ spec:
   podSelector: {}
   policyTypes:
   - Ingress
+#@ end
 ---
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
@@ -61,6 +87,7 @@ spec:
   policyTypes:
   - Ingress
   - Egress
+#@ if cfdb_enabled():
 ---
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
@@ -82,6 +109,7 @@ spec:
   policyTypes:
   - Ingress
   - Egress
+#@ end
 ---
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
@@ -121,6 +149,7 @@ spec:
       port: 53
   policyTypes:
   - Egress
+#@ if cfdb_enabled():
 ---
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
@@ -139,6 +168,7 @@ spec:
       port: 53
   policyTypes:
   - Egress
+#@ end
 ---
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
@@ -157,6 +187,7 @@ spec:
       port: 53
   policyTypes:
   - Egress
+#@ if cfdb_enabled():
 ---
 kind: NetworkPolicy
 apiVersion: networking.k8s.io/v1
@@ -207,6 +238,7 @@ spec:
       namespaceSelector:
         matchLabels:
           cf-for-k8s.cloudfoundry.org/cf-system-ns: ""
+#@ end
 ---
 kind: NetworkPolicy
 apiVersion: networking.k8s.io/v1
@@ -293,7 +325,7 @@ spec:
 kind: NetworkPolicy
 apiVersion: networking.k8s.io/v1
 metadata:
-  name: cf-api-deployment-updater
+  name: cf-api-deployment-updater-eirini
   namespace: #@ data.values.system_namespace
 spec:
   policyTypes:
@@ -305,10 +337,39 @@ spec:
   - to:
     - namespaceSelector:
         matchLabels:
-          name: cf-db
+          cf-for-k8s.cloudfoundry.org/cf-system-ns: ""
       podSelector:
         matchLabels:
-          release: cf-db
+          name: eirini
+---
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: cf-api-deployment-updater
+  namespace: #@ data.values.system_namespace
+spec:
+  policyTypes:
+  - Egress
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: cf-api-deployment-updater
+  egress:
+  - #@ database_egress()
+
+---
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: cf-api-clock-eirini
+  namespace: #@ data.values.system_namespace
+spec:
+  policyTypes:
+  - Egress
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: cf-api-clock
+  egress:
+  - to:
     - namespaceSelector:
         matchLabels:
           cf-for-k8s.cloudfoundry.org/cf-system-ns: ""
@@ -328,20 +389,7 @@ spec:
     matchLabels:
       app.kubernetes.io/name: cf-api-clock
   egress:
-  - to:
-    - namespaceSelector:
-        matchLabels:
-          name: cf-db
-      podSelector:
-        matchLabels:
-          release: cf-db
-  - to:
-    - namespaceSelector:
-        matchLabels:
-          cf-for-k8s.cloudfoundry.org/cf-system-ns: ""
-      podSelector:
-        matchLabels:
-          name: eirini
+  - #@ database_egress()
 ---
 kind: NetworkPolicy
 apiVersion: networking.k8s.io/v1
@@ -369,13 +417,7 @@ spec:
     matchLabels:
       job-name: ccdb-migrate
   egress:
-  - to:
-    - namespaceSelector:
-        matchLabels:
-          name: cf-db
-      podSelector:
-        matchLabels:
-          release: cf-db
+  - #@ database_egress()
 ---
 kind: NetworkPolicy
 apiVersion: networking.k8s.io/v1

--- a/config/networking/network-policies.yaml
+++ b/config/networking/network-policies.yaml
@@ -1,0 +1,656 @@
+#@ load("@ytt:data", "data")
+
+#! TODO: Should be labeled in capi-k8s-release
+#@ load("@ytt:overlay", "overlay")
+#@overlay/match by=overlay.and_op(overlay.subset({"metadata":{"name":"cf-workloads-staging"}}), overlay.subset({"kind": "Namespace"}))
+---
+metadata:
+  #@overlay/match missing_ok=True
+  labels:
+    #@overlay/match missing_ok=True
+    name: #@ data.values.staging_namespace
+
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default-deny-ingress
+  namespace: #@ data.values.system_namespace
+spec:
+  podSelector: {}
+  policyTypes:
+  - Ingress
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default-deny-ingress
+  namespace: cf-db
+spec:
+  podSelector: {}
+  policyTypes:
+  - Ingress
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default-deny-ingress
+  namespace: cf-blobstore
+spec:
+  podSelector: {}
+  policyTypes:
+  - Ingress
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-istio-control-plane
+  namespace: #@ data.values.system_namespace
+spec:
+  podSelector: {}
+  ingress:
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          cf-for-k8s.cloudfoundry.org/istio-system-ns: ""
+  egress:
+  - to:
+    - namespaceSelector:
+        matchLabels:
+          cf-for-k8s.cloudfoundry.org/istio-system-ns: ""
+  policyTypes:
+  - Ingress
+  - Egress
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-istio-control-plane
+  namespace: cf-db
+spec:
+  podSelector: {}
+  ingress:
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          cf-for-k8s.cloudfoundry.org/istio-system-ns: ""
+  egress:
+  - to:
+    - namespaceSelector:
+        matchLabels:
+          cf-for-k8s.cloudfoundry.org/istio-system-ns: ""
+  policyTypes:
+  - Ingress
+  - Egress
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-istio-control-plane
+  namespace: cf-blobstore
+spec:
+  podSelector: {}
+  ingress:
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          cf-for-k8s.cloudfoundry.org/istio-system-ns: ""
+  egress:
+  - to:
+    - namespaceSelector:
+        matchLabels:
+          cf-for-k8s.cloudfoundry.org/istio-system-ns: ""
+  policyTypes:
+  - Ingress
+  - Egress
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-dns-egress
+  namespace: #@ data.values.system_namespace
+spec:
+  podSelector: {}
+  egress:
+  - to:
+    - namespaceSelector: {}
+    ports:
+    - protocol: UDP
+      port: 53
+    - protocol: TCP
+      port: 53
+  policyTypes:
+  - Egress
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-dns-egress
+  namespace: cf-db
+spec:
+  podSelector: {}
+  egress:
+  - to:
+    - namespaceSelector: {}
+    ports:
+    - protocol: UDP
+      port: 53
+    - protocol: TCP
+      port: 53
+  policyTypes:
+  - Egress
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-dns-egress
+  namespace: cf-blobstore
+spec:
+  podSelector: {}
+  egress:
+  - to:
+    - namespaceSelector: {}
+    ports:
+    - protocol: UDP
+      port: 53
+    - protocol: TCP
+      port: 53
+  policyTypes:
+  - Egress
+---
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: cf-db
+  namespace: cf-db
+spec:
+  policyTypes:
+  - Ingress
+  podSelector:
+    matchLabels:
+      release: cf-db
+  ingress:
+  - from:
+    - podSelector:
+        matchLabels:
+          job-name: ccdb-migrate
+      namespaceSelector:
+        matchLabels:
+          cf-for-k8s.cloudfoundry.org/cf-system-ns: ""
+    - podSelector:
+        matchLabels:
+          app.kubernetes.io/name: cf-api-worker
+      namespaceSelector:
+        matchLabels:
+          cf-for-k8s.cloudfoundry.org/cf-system-ns: ""
+    - podSelector:
+        matchLabels:
+          app.kubernetes.io/name: cf-api-clock
+      namespaceSelector:
+        matchLabels:
+          cf-for-k8s.cloudfoundry.org/cf-system-ns: ""
+    - podSelector:
+        matchLabels:
+          app.kubernetes.io/name: cf-api-server
+      namespaceSelector:
+        matchLabels:
+          cf-for-k8s.cloudfoundry.org/cf-system-ns: ""
+    - podSelector:
+        matchLabels:
+          app.kubernetes.io/name: cf-api-deployment-updater
+      namespaceSelector:
+        matchLabels:
+          cf-for-k8s.cloudfoundry.org/cf-system-ns: ""
+    - podSelector:
+        matchLabels:
+          app.kubernetes.io/name: uaa
+      namespaceSelector:
+        matchLabels:
+          cf-for-k8s.cloudfoundry.org/cf-system-ns: ""
+---
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: uaa
+  namespace: #@ data.values.system_namespace
+spec:
+  policyTypes:
+  - Ingress
+  - Egress
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: uaa
+  ingress:
+  - from:
+    - podSelector:
+        matchLabels:
+          istio: ingressgateway
+      namespaceSelector:
+        matchLabels:
+          cf-for-k8s.cloudfoundry.org/istio-system-ns: ""
+    - podSelector:
+        matchLabels:
+          app: log-cache
+      namespaceSelector:
+        matchLabels:
+          cf-for-k8s.cloudfoundry.org/cf-system-ns: ""
+    - podSelector:
+        matchLabels:
+          app.kubernetes.io/name: cf-api-server
+      namespaceSelector:
+        matchLabels:
+          cf-for-k8s.cloudfoundry.org/cf-system-ns: ""
+    - podSelector:
+        matchLabels:
+          app.kubernetes.io/name: cf-api-kpack-watcher
+      namespaceSelector:
+        matchLabels:
+          cf-for-k8s.cloudfoundry.org/cf-system-ns: ""
+  egress:
+  - {}
+---
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: cf-api-server
+  namespace: #@ data.values.system_namespace
+spec:
+  policyTypes:
+  - Ingress
+  - Egress
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: cf-api-server
+  ingress:
+  - from:
+    - podSelector:
+        matchLabels:
+          istio: ingressgateway
+      namespaceSelector:
+        matchLabels:
+          cf-for-k8s.cloudfoundry.org/istio-system-ns: ""
+    - podSelector:
+        matchLabels:
+          app.kubernetes.io/name: cf-api-kpack-watcher
+      namespaceSelector:
+        matchLabels:
+          cf-for-k8s.cloudfoundry.org/cf-system-ns: ""
+    - podSelector:
+        matchLabels:
+          name: eirini
+      namespaceSelector:
+        matchLabels:
+          cf-for-k8s.cloudfoundry.org/cf-system-ns: ""
+    - podSelector:
+        matchLabels:
+          app: log-cache
+      namespaceSelector:
+        matchLabels:
+          cf-for-k8s.cloudfoundry.org/cf-system-ns: ""
+  egress:
+  - {}
+---
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: cf-api-deployment-updater
+  namespace: #@ data.values.system_namespace
+spec:
+  policyTypes:
+  - Egress
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: cf-api-deployment-updater
+  egress:
+  - to:
+    - namespaceSelector:
+        matchLabels:
+          name: cf-db
+      podSelector:
+        matchLabels:
+          release: cf-db
+    - namespaceSelector:
+        matchLabels:
+          cf-for-k8s.cloudfoundry.org/cf-system-ns: ""
+      podSelector:
+        matchLabels:
+          name: eirini
+---
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: cf-api-clock
+  namespace: #@ data.values.system_namespace
+spec:
+  policyTypes:
+  - Egress
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: cf-api-clock
+  egress:
+  - to:
+    - namespaceSelector:
+        matchLabels:
+          name: cf-db
+      podSelector:
+        matchLabels:
+          release: cf-db
+  - to:
+    - namespaceSelector:
+        matchLabels:
+          cf-for-k8s.cloudfoundry.org/cf-system-ns: ""
+      podSelector:
+        matchLabels:
+          name: eirini
+---
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: cf-api-worker
+  namespace: #@ data.values.system_namespace
+spec:
+  policyTypes:
+  - Egress
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: cf-api-worker
+  egress:
+  - {}
+---
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: ccdb-migrate
+  namespace: #@ data.values.system_namespace
+spec:
+  policyTypes:
+  - Egress
+  podSelector:
+    matchLabels:
+      job-name: ccdb-migrate
+  egress:
+  - to:
+    - namespaceSelector:
+        matchLabels:
+          name: cf-db
+      podSelector:
+        matchLabels:
+          release: cf-db
+---
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: cf-blobstore-minio
+  namespace: cf-blobstore
+spec:
+  policyTypes:
+  - Ingress
+  podSelector:
+    matchLabels:
+      release: cf-blobstore
+  ingress:
+  - from:
+    - podSelector:
+        matchLabels:
+          istio: ingressgateway
+      namespaceSelector:
+        matchLabels:
+          cf-for-k8s.cloudfoundry.org/istio-system-ns: ""
+    - podSelector:
+        matchLabels:
+          cloudfoundry.org/source_type: STG
+      namespaceSelector:
+        matchLabels:
+          name: #@ data.values.staging_namespace
+    - namespaceSelector:
+        matchLabels:
+          cf-for-k8s.cloudfoundry.org/cf-system-ns: ""
+      podSelector:
+        matchLabels:
+          app.kubernetes.io/name: cf-api-server
+    - namespaceSelector:
+        matchLabels:
+          cf-for-k8s.cloudfoundry.org/cf-system-ns: ""
+      podSelector:
+        matchLabels:
+          app.kubernetes.io/name: cf-api-worker
+    - namespaceSelector:
+        matchLabels:
+          cf-for-k8s.cloudfoundry.org/cf-system-ns: ""
+      podSelector:
+        matchLabels:
+          app.kubernetes.io/name: cf-api-deployment-updater
+    - namespaceSelector:
+        matchLabels:
+          cf-for-k8s.cloudfoundry.org/cf-system-ns: ""
+      podSelector:
+        matchLabels:
+          app.kubernetes.io/name: cf-api-clock
+---
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: eirini
+  namespace: #@ data.values.system_namespace
+spec:
+  policyTypes:
+  - Ingress
+  - Egress
+  podSelector:
+    matchLabels:
+      name: eirini
+  ingress:
+  - from:
+    - podSelector:
+        matchLabels:
+          app.kubernetes.io/name: cf-api-deployment-updater
+      namespaceSelector:
+        matchLabels:
+          cf-for-k8s.cloudfoundry.org/cf-system-ns: ""
+    - podSelector:
+        matchLabels:
+          app.kubernetes.io/name: cf-api-clock
+      namespaceSelector:
+        matchLabels:
+          cf-for-k8s.cloudfoundry.org/cf-system-ns: ""
+    - podSelector:
+        matchLabels:
+          app.kubernetes.io/name: cf-api-worker
+      namespaceSelector:
+        matchLabels:
+          cf-for-k8s.cloudfoundry.org/cf-system-ns: ""
+    - podSelector:
+        matchLabels:
+          app.kubernetes.io/name: cf-api-server
+      namespaceSelector:
+        matchLabels:
+          cf-for-k8s.cloudfoundry.org/cf-system-ns: ""
+    ports:
+    - port: 8085
+      protocol: TCP
+  egress:
+  - {}
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: eirini-events
+  namespace: #@ data.values.system_namespace
+spec:
+  podSelector:
+    matchLabels:
+      name: eirini-events
+  egress:
+  - {}
+  policyTypes:
+  - Ingress
+  - Egress
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: eirini-task-reporter
+  namespace: #@ data.values.system_namespace
+spec:
+  podSelector:
+    matchLabels:
+      name: eirini-events-task-reporter
+  egress:
+  - {}
+  policyTypes:
+  - Ingress
+  - Egress
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: eirini-lrp-controller
+  namespace: #@ data.values.system_namespace
+spec:
+  podSelector:
+    matchLabels:
+      name: eirini-lrp-controller
+  egress:
+  - {}
+  policyTypes:
+  - Ingress
+  - Egress
+---
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: capi-kpack-watcher
+  namespace: #@ data.values.system_namespace
+spec:
+  policyTypes:
+  - Egress
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: cf-api-kpack-watcher
+  egress:
+  - {}
+---
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: routecontroller
+  namespace: #@ data.values.system_namespace
+spec:
+  policyTypes:
+  - Egress
+  podSelector:
+    matchLabels:
+      app: routecontroller
+  egress:
+  - {}
+---
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: log-cache
+  namespace: #@ data.values.system_namespace
+spec:
+  policyTypes:
+  - Ingress
+  - Egress
+  podSelector:
+    matchLabels:
+      app: log-cache
+  ingress:
+  - from:
+    - podSelector:
+        matchLabels:
+          istio: ingressgateway
+      namespaceSelector:
+        matchLabels:
+          cf-for-k8s.cloudfoundry.org/istio-system-ns: ""
+    - podSelector:
+        matchLabels:
+          app: fluentd
+      namespaceSelector:
+        matchLabels:
+          cf-for-k8s.cloudfoundry.org/cf-system-ns: ""
+  egress:
+  - to:
+    - podSelector:
+        matchLabels:
+          app.kubernetes.io/name: uaa
+      namespaceSelector:
+        matchLabels:
+          cf-for-k8s.cloudfoundry.org/cf-system-ns: ""
+    - podSelector:
+        matchLabels:
+          app.kubernetes.io/name: cf-api-server
+      namespaceSelector:
+        matchLabels:
+          cf-for-k8s.cloudfoundry.org/cf-system-ns: ""
+---
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: metric-proxy
+  namespace: #@ data.values.system_namespace
+spec:
+  policyTypes:
+  - Ingress
+  - Egress
+  podSelector:
+    matchLabels:
+      app: metric-proxy
+  ingress:
+  - from:
+    - podSelector:
+        matchLabels:
+          app.kubernetes.io/name: cf-api-server
+      namespaceSelector:
+        matchLabels:
+          cf-for-k8s.cloudfoundry.org/cf-system-ns: ""
+  egress:
+  - {}
+---
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: fluentd
+  namespace: #@ data.values.system_namespace
+spec:
+  policyTypes:
+  - Ingress
+  - Egress
+  podSelector:
+    matchLabels:
+      app: fluentd
+  ingress:
+  - from:
+    - podSelector:
+        matchLabels:
+          app.kubernetes.io/name: cf-api-server
+      namespaceSelector:
+        matchLabels:
+          cf-for-k8s.cloudfoundry.org/cf-system-ns: ""
+    - podSelector:
+        matchLabels:
+          app.kubernetes.io/name: cf-api-worker
+      namespaceSelector:
+        matchLabels:
+          cf-for-k8s.cloudfoundry.org/cf-system-ns: ""
+    - podSelector:
+        matchLabels:
+          app.kubernetes.io/name: cf-api-clock
+      namespaceSelector:
+        matchLabels:
+          cf-for-k8s.cloudfoundry.org/cf-system-ns: ""
+    - podSelector:
+        matchLabels:
+          app.kubernetes.io/name: cf-api-deployment-updater
+      namespaceSelector:
+        matchLabels:
+          cf-for-k8s.cloudfoundry.org/cf-system-ns: ""
+    - podSelector:
+        matchLabels:
+          istio: ingressgateway
+      namespaceSelector:
+        matchLabels:
+          cf-for-k8s.cloudfoundry.org/istio-system-ns: ""
+  egress:
+  - {}

--- a/config/networking/network-policies.yaml
+++ b/config/networking/network-policies.yaml
@@ -1,8 +1,6 @@
 #@ load("@ytt:data", "data")
-
-#! TODO: Should be labeled in capi-k8s-release
 #@ load("@ytt:overlay", "overlay")
-#@overlay/match by=overlay.and_op(overlay.subset({"metadata":{"name":"cf-workloads-staging"}}), overlay.subset({"kind": "Namespace"}))
+
 #@ def cfdb_enabled():
 #@   return len(data.values.uaa.database.host) == 0 or len(data.values.capi.database.host) == 0
 #@ end
@@ -21,12 +19,14 @@ to:
     cidr: 0.0.0.0/0
 #@ end
 ports:
-- protocol: TCP 
-  port: #@ data.values.capi.database.port  
-- protocol: TCP 
+- protocol: TCP
+  port: #@ data.values.capi.database.port
+- protocol: TCP
   port: #@ data.values.uaa.database.port
 #@ end
 
+#! TODO: Should be labeled in capi-k8s-release
+#@overlay/match by=overlay.and_op(overlay.subset({"metadata":{"name":"cf-workloads-staging"}}), overlay.subset({"kind": "Namespace"}))
 ---
 metadata:
   #@overlay/match missing_ok=True

--- a/config/networking/network-policies.yaml
+++ b/config/networking/network-policies.yaml
@@ -274,7 +274,7 @@ spec:
           cf-for-k8s.cloudfoundry.org/cf-system-ns: ""
     - podSelector:
         matchLabels:
-          app.kubernetes.io/name: cf-api-kpack-watcher
+          app.kubernetes.io/name: cf-api-controllers
       namespaceSelector:
         matchLabels:
           cf-for-k8s.cloudfoundry.org/cf-system-ns: ""
@@ -303,7 +303,7 @@ spec:
           cf-for-k8s.cloudfoundry.org/istio-system-ns: ""
     - podSelector:
         matchLabels:
-          app.kubernetes.io/name: cf-api-kpack-watcher
+          app.kubernetes.io/name: cf-api-controllers
       namespaceSelector:
         matchLabels:
           cf-for-k8s.cloudfoundry.org/cf-system-ns: ""
@@ -546,12 +546,12 @@ spec:
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
-  name: eirini-lrp-controller
+  name: eirini-controller
   namespace: #@ data.values.system_namespace
 spec:
   podSelector:
     matchLabels:
-      name: eirini-lrp-controller
+      name: eirini-controller
   egress:
   - {}
   policyTypes:
@@ -561,14 +561,14 @@ spec:
 kind: NetworkPolicy
 apiVersion: networking.k8s.io/v1
 metadata:
-  name: capi-kpack-watcher
+  name: cf-api-controllers
   namespace: #@ data.values.system_namespace
 spec:
   policyTypes:
   - Egress
   podSelector:
     matchLabels:
-      app.kubernetes.io/name: cf-api-kpack-watcher
+      app.kubernetes.io/name: cf-api-controllers
   egress:
   - {}
 ---

--- a/config/networking/network-policies.yaml
+++ b/config/networking/network-policies.yaml
@@ -507,9 +507,6 @@ spec:
       namespaceSelector:
         matchLabels:
           cf-for-k8s.cloudfoundry.org/cf-system-ns: ""
-    ports:
-    - port: 8085
-      protocol: TCP
   egress:
   - {}
 ---

--- a/config/postgres/postgres.yml
+++ b/config/postgres/postgres.yml
@@ -20,6 +20,8 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: cf-db
+  labels:
+    name: cf-db
 
 ---
 apiVersion: v1

--- a/config/workloads-namespace.yml
+++ b/config/workloads-namespace.yml
@@ -8,6 +8,8 @@ metadata:
   name: #@ data.values.workloads_namespace
   annotations:
     kapp.k14s.io/change-rule.cf-workloads-namespace: "delete before deleting cf-k8s-networking/routecontroller"
+  labels:
+    name: #@ data.values.workloads_namespace
 
 #! the following overlay ensures the cf-workloads namespace is deleted before the routecontroller
 #@ cr = overlay.subset({"kind":"ClusterRole","metadata":{"name":"routecontroller"}})

--- a/docs/component_authors/networking.md
+++ b/docs/component_authors/networking.md
@@ -1,0 +1,184 @@
+# Networking Configuration for System Components
+
+## Network Policies
+
+[Network Policies](https://kubernetes.io/docs/concepts/services-networking/network-policies/) provide a way to declaritively define how `Pods` are allowed to communicate.
+
+These policies, also known as ["Layer 3" Network Policies](https://en.wikipedia.org/wiki/OSI_model#Layer_3:_Network_Layer) (as opposed to "Layer 7" policy that might be applied by a service mesh), are used by a cluster's [CNI plugin](https://kubernetes.io/docs/concepts/extend-kubernetes/compute-storage-net/network-plugins/) to configure networking rules at the OS level. Not all CNI plugins support Network Policies and their specific implementation is left up to the plugin (many use `iptables` or `eBPF`).
+
+CF for Kubernetes has a goal for all network communication by System Components to be defined by Network Policies. The majority of these policies can be found in `config/network-policy.yml`.
+
+### Writing Network Policies
+
+Policies can be added by creating a new `NetworkPolicy` resource that selects on a set of `Pods` within a namespace. A namespace starts out allowing all ingress/egress traffic for all `Pods`, but as soon as a `Pod` is selected by _at least one_ `NetworkPolicy` it will deny all traffic that is not explicitly defined. `NetworkPolicies` act as additive allow rules so to open up communication for `Pods` you will need to create new `NetworkPolicy` resources.
+
+For example, `NetworkPolicies` similar to the following rule are already applied in cf-for-k8s and denies all `ingress` and `egress` traffic in the `cf-system` namespace:
+
+```yaml
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default-deny-all
+  namespace: cf-system
+spec:
+  podSelector: {}
+  policyTypes:
+  - Ingress
+  - Egress
+```
+
+
+Let's say you are introducing a new component that needs to talk to UAA internally. You need to create `NetworkPolicy` selecting UAA pods with `ingress` rules to allow traffic from your component, by either [creating]("#creating-a-new-networkpolicy") an ingress policy or [updating the existing]("#updating-an-existing-networkpolicy") ingress policy. Then, [you need to create an egress `NetworkPolicy`](#creating-an-egress-networkpolicy-for-your-component) selecting your component pods with `egress` rules to allow traffic to UAA.
+
+
+#### Creating a new NetworkPolicy
+The simplest way to create an allow rule for ingress to UAA from your component
+is to add a create a new `NetworkPolicy` resource. Network policy rules are
+additive so this rule will be applied _in addition_ to the existing to rule.
+
+So if you are adding a new component that wants to talk to UAA, include a
+`NetworkPolicy` similar to this with your installation YAML:
+
+```yaml
+---
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: uaa-ingress-from-my-new-component
+  namespace: cf-system
+spec:
+  policyTypes:
+  - Ingress
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: uaa
+  ingress:
+  - from:
+    - podSelector:
+        matchLabels:
+          app.kubernetes.io/name: my-new-component
+      namespaceSelector:
+        matchLabels:
+          cf-for-k8s.cloudfoundry.org/cf-system-ns: ""
+```
+
+#### Updating an Existing NetworkPolicy
+If you are adding a new core component and think the policy should be part of UAA's default `NetworkPolicy`, you can update the existing policy that looks similar to this:
+
+```yaml
+---
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: uaa
+  namespace: cf-system
+spec:
+  policyTypes:
+  - Ingress
+  - Egress
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: uaa
+  ingress:
+  - from:
+    - podSelector:
+        matchLabels:
+          istio: ingressgateway
+      namespaceSelector:
+        matchLabels:
+          cf-for-k8s.cloudfoundry.org/istio-system-ns: ""
+    - podSelector:
+        matchLabels:
+          app: log-cache
+      namespaceSelector:
+        matchLabels:
+          cf-for-k8s.cloudfoundry.org/cf-system-ns: ""
+    - podSelector:
+        matchLabels:
+          app.kubernetes.io/name: cf-api-server
+      namespaceSelector:
+        matchLabels:
+          cf-for-k8s.cloudfoundry.org/cf-system-ns: ""
+    - podSelector:
+        matchLabels:
+          app.kubernetes.io/name: cf-api-kpack-watcher
+      namespaceSelector:
+        matchLabels:
+          cf-for-k8s.cloudfoundry.org/cf-system-ns: ""
+  egress:
+  - {}
+```
+
+You just need to add an additional element to the `from` array. Something like this:
+
+```yaml
+- podSelector:
+    matchLabels:
+      app.kubernetes.io/name: my-new-component
+  namespaceSelector:
+    matchLabels:
+      cf-for-k8s.cloudfoundry.org/cf-system-ns: ""
+```
+
+This configures the UAA `NetworkPolicy` to allow ingress traffic from any `Pod` that has the label `app.kubernetes.io/name=my-new-component` in a namespace with the `cf-for-k8s.cloudfoundry.org/cf-system-ns=""` label.
+
+Once you've tested it and everything works, make a PR to update the `NetworkPolicy` in `config/network-policies.yaml`!
+
+#### Creating an Egress NetworkPolicy for your component
+Whether you created a new ingress `NetworkPolicy` for UAA or updated the
+existing list of ingress rules, you will still need to create a `NetworkPolicy`
+for your own component that allows it to egress to UAA.
+
+```yaml
+---
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: my-new-component
+  namespace: cf-system
+spec:
+  policyTypes:
+  - Egress
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: my-new-component
+  egress:
+  - to:
+    - podSelector:
+        matchLabels:
+          app.kubernetes.io/name: uaa
+      namespaceSelector:
+        matchLabels:
+          cf-for-k8s.cloudfoundry.org/cf-system-ns: ""
+```
+### Namespaces and Network Policies
+`NetworkPolicies` apply to `Pods` within a **single namespace**.
+
+If you're creating a new namespace we highly recommend creating an initial ["default deny all"](https://kubernetes.io/docs/concepts/services-networking/network-policies/#default-deny-all-ingress-and-all-egress-traffic) `NetworkPolicy` to block all ingress and egress traffic to `Pods` in the namespace.
+
+```yaml
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default-deny-all
+  namespace: YOUR_NAMESPACE_NAME
+spec:
+  podSelector: {}
+  policyTypes:
+  - Ingress
+  - Egress
+```
+
+Then add in the appropriate `allow` rules through additional `NetworkPolicies`.
+
+
+## Istio Sidecar Injection
+
+### Namespaces and Istio Sidecar Injection
+CF for Kubernetes uses Istio's [automatic mTLS](https://istio.io/latest/docs/tasks/security/authentication/authn-policy/#auto-mutual-tls) with a `STRICT` authentication policy. This means that all `Pods` that have an Istio sidecar will require incoming traffic to use mutual TLS.
+
+When you create a new namespace, in order to take advantage of all of Istio's features, and communicate with other `Pods` that Istio sidecars, your namespace must have an `istio-injection=enabled` label to turn on automatic [Sidecar Injection](https://istio.io/latest/docs/setup/additional-setup/sidecar-injection/). This makes it so the pods in your namespace will contain an [Istio sidecar proxy](https://istio.io/latest/docs/reference/config/networking/sidecar/) running alongside them. In CF for Kubernetes, Istio sidecar injection is added automatically by a `ytt` [overlay](https://github.com/cloudfoundry/cf-for-k8s/blob/master/config/networking.yml#L63).
+
+To confirm your namespace has automatic sidecar injection enabled, you can describe your namespace with `kubectl get namespace <namespace_name> -L istio-injection` and see that Istio Injection is set to "enabled".


### PR DESCRIPTION
This PR re-applies the changes from #270 that were temporarily reverted due to issues seen in CI.

* We saw that the external DB validation job [failed](https://release-integration.ci.cf-app.com/teams/main/pipelines/cf-for-k8s/jobs/validate-cf-for-k8s-gke-external-db/builds/37) due to the lack of a `cf-db` namespace
* We saw smoke-tests [failed](https://release-integration.ci.cf-app.com/teams/main/pipelines/cf-for-k8s/jobs/validate-cf-for-k8s-gke/builds/362) due to a timeout after successfully staging