### PR TITLE
Move UAA encryption keys and login info to secrets

### DIFF
--- a/config/uaa/uaa.yml
+++ b/config/uaa/uaa.yml
@@ -67,8 +67,6 @@ encryption:
   - label: #@ data.values.uaa.encryption_key.label
     passphrase: #@ data.values.uaa.encryption_key.passphrase
 
-LOGIN_SECRET: #@ data.values.uaa.login_secret_name
-
 #@overlay/match missing_ok=True
 scim:
   userids_enabled: true
@@ -158,13 +156,17 @@ zones:
 #@overlay/match-child-defaults missing_ok=True
 login:
   url: #@ "https://login." + data.values.system_domain
-#@ if len(data.values.uaa.login.service_provider.key) > 0:
   entityBaseURL: #@ "https://uaa." + data.values.system_domain
   entityID: cloudfoundry-saml-login
+  #@overlay/remove
   serviceProviderKey: #@ data.values.uaa.login.service_provider.key
+  #@overlay/remove
   serviceProviderKeyPassword: #@ data.values.uaa.login.service_provider.key_password
+  #@overlay/remove
   serviceProviderCertificate: #@ data.values.uaa.login.service_provider.certificate
-#@ end
+
+#@overlay/remove
+LOGIN_SECRET: #@ data.values.uaa.login_secret
 
 #@overlay/match missing_ok=True
 uaa:
@@ -253,6 +255,24 @@ type: Opaque
 stringData:
   password: #@ data.values.uaa.encryption_key.passphrase
 
+#@ def uaa_login_secret_config(saml_provider_key, saml_provider_key_password, saml_provider_cert, login_secret):
+login:
+  serviceProviderKey: #@ saml_provider_key
+  serviceProviderKeyPassword: #@ saml_provider_key_password
+  serviceProviderCertificate: #@ saml_provider_cert
+LOGIN_SECRET: #@ login_secret
+#@ end
+
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: uaa-login-secret-config
+  namespace: #@ data.values.system_namespace
+type: Opaque
+stringData:
+  login_secret_config.yml: #@ yaml.encode(uaa_login_secret_config(data.values.uaa.login.service_provider.key, data.values.uaa.login.service_provider.key_password, data.values.uaa.login.service_provider.certificate, data.values.uaa.login_secret))
+
 #@ def uaa_client_credential_data(client_name, credential):
 oauth:
   #@yaml/text-templated-strings
@@ -323,6 +343,11 @@ spec:
           mountPath: #@ "{}/cf_api_controllers_client_credentials.yml".format(secrets_dir)
           subPath: client_credentials.yml
           readOnly: true
+        #@overlay/append
+        - name: login-secret-config-file
+          mountPath: #@ "{}/login_secret_config.yml".format(secrets_dir)
+          subPath: login_secret_config.yml
+          readOnly: true
       volumes:
       #@overlay/append
       - name: cf-admin-user-credentials-file
@@ -340,4 +365,8 @@ spec:
       - name: cf-api-controllers-client-credentials-file
         secret:
           secretName: uaa-cf-api-controllers-client-secret
+      #@overlay/append
+      - name: login-secret-config-file
+        secret:
+          secretName: uaa-login-secret-config
 

--- a/config/uaa/uaa.yml
+++ b/config/uaa/uaa.yml
@@ -62,10 +62,8 @@ jwt:
 #@overlay/match missing_ok=True
 encryption:
   active_key_label: #@ data.values.uaa.encryption_key.label
-  #@overlay/replace
+  #@overlay/remove
   encryption_keys:
-  - label: #@ data.values.uaa.encryption_key.label
-    passphrase: #@ data.values.uaa.encryption_key.passphrase
 
 #@overlay/match missing_ok=True
 scim:
@@ -245,15 +243,23 @@ type: Opaque
 data:
   uaa.key: #@ data.values.internal_certificate.key
   uaa.crt: #@ data.values.internal_certificate.crt
+
+#@ def encryption_key_data(label, passphrase):
+encryption:
+  encryption_keys:
+  - label: #@ label
+    passphrase: #@ passphrase
+#@ end
+
 ---
 apiVersion: v1
 kind: Secret
 metadata:
-  name: #@ data.values.uaa.encryption_key_passphrase_secret_name
+  name: uaa-encryption-key-config
   namespace: #@ data.values.system_namespace
 type: Opaque
 stringData:
-  password: #@ data.values.uaa.encryption_key.passphrase
+  encryption_key_config.yml: #@ yaml.encode(encryption_key_data(data.values.uaa.encryption_key.label, data.values.uaa.encryption_key.passphrase))
 
 #@ def uaa_login_secret_config(saml_provider_key, saml_provider_key_password, saml_provider_cert, login_secret):
 login:
@@ -348,6 +354,11 @@ spec:
           mountPath: #@ "{}/login_secret_config.yml".format(secrets_dir)
           subPath: login_secret_config.yml
           readOnly: true
+        #@overlay/append
+        - name: encryption-key-config-file
+          mountPath: #@ "{}/encryption_key_config.yml".format(secrets_dir)
+          subPath: encryption_key_config.yml
+          readOnly: true
       volumes:
       #@overlay/append
       - name: cf-admin-user-credentials-file
@@ -369,4 +380,8 @@ spec:
       - name: login-secret-config-file
         secret:
           secretName: uaa-login-secret-config
+      #@overlay/append
+      - name: encryption-key-config-file
+        secret:
+          secretName: uaa-encryption-key-config
 

--- a/config/values.yml
+++ b/config/values.yml
@@ -119,7 +119,8 @@ uaa:
       #! Plain text certificate
       certificate: ""
 
-  login_secret_name: "uaa-login-secret"
+  #! Plain text password
+  login_secret: ""
 
 log_cache_ca:
   crt: "" #! Base64-encoded ca for the log cache

--- a/config/values.yml
+++ b/config/values.yml
@@ -104,7 +104,6 @@ uaa:
     #! Plain text private key
     signing_key: ""
 
-  encryption_key_passphrase_secret_name: uaa-encryption-key-passphrase
   encryption_key:
     label: "default_encryption_key"
     #! Plain text passphrase

--- a/hack/generate-values.sh
+++ b/hack/generate-values.sh
@@ -99,6 +99,8 @@ variables:
   type: password
 - name: uaa_db_password
   type: password
+- name: uaa_login_secret
+  type: password
 - name: uaa_admin_client_secret
   type: password
 - name: uaa_encryption_key_passphrase
@@ -144,6 +146,12 @@ variables:
   options:
     ca: default_ca
     common_name: uaa_jwt_policy_signing_key
+
+- name: uaa_login_service_provider
+  type: certificate
+  options:
+    ca: default_ca
+    common_name: uaa_login_service_provider
 
 - name: log_cache_ca
   type: certificate
@@ -283,6 +291,13 @@ uaa:
 $(bosh interpolate "${VARS_FILE}" --path=/uaa_jwt_policy_signing_key/private_key | sed -e 's#^#      #')
   encryption_key:
     passphrase: $(bosh interpolate "${VARS_FILE}" --path=/uaa_encryption_key_passphrase)
+  login:
+    service_provider:
+      key: |
+$(bosh interpolate "${VARS_FILE}" --path=/uaa_login_service_provider/private_key | sed -e 's#^#        #')
+      certificate: |
+$(bosh interpolate "${VARS_FILE}" --path=/uaa_login_service_provider/certificate | sed -e 's#^#        #')
+  login_secret: $(bosh interpolate "${VARS_FILE}" --path=/uaa_login_secret)
 EOF
 
 if [[ -n "${GCP_SERVICE_ACCOUNT_JSON_FILE:=}" ]]; then

--- a/sample-cf-install-values.yml
+++ b/sample-cf-install-values.yml
@@ -113,6 +113,12 @@ uaa:
   #! Encyption key for encrypting data stored in the database
   encryption_key:
     passphrase: encryption_key_passphrase
+  #! Configuration for UAA's SAML provider
+  login:
+    service_provider:
+      #! This certificate/key should NOT be base64 encoded
+      key: login_service_provider_key
+      certificate: login_service_provider_certificate
 
 #! To push apps from source code, you need to configure the `app_registry` block
 #! Example below is for docker hub. For other registry examples, see below.


### PR DESCRIPTION
**Description**
Enhancement/Refactor: Move plaintext secrets from the uaa config map into kubernetes secrets and mount them on the uaa deployment.
Replaces the previously deleted login saml provider cert, as we found out that the functionality cannot be disabled and could present a vulnerability.

Fixes #229, #230.

**Open Questions**
- Do we have any user-facing requirements for the actual contents of the config map in the final rendered yaml file?
  - I've added some overlay removes to eliminate some default placeholder values under the assumption that we don't want to mislead users into thinking the ConfigMap is the final source of information on that configuration when the secret contents are actually being merged in from the mounted volumes.
- Do we need to also add a second encryption key option to the config at this point to support rotation?

**Acceptance Steps**
Follow the standard deployment process and expect no failures in a smoke test run after deployment.


_Tag your pair, your PM, and/or team_
cc @cloudfoundry/cf-release-integration 