### PR TITLE
Fix status context for external-db pipeline jobs

### DIFF
--- a/ci/pipelines/cf-for-k8s-contributions.yml
+++ b/ci/pipelines/cf-for-k8s-contributions.yml
@@ -478,7 +478,7 @@ jobs:
     params:
       path: cf-for-k8s-pr-all-branches-and-forks
       status: pending
-      context: upgrade-check-uptime
+      context: external-db
   - task: create-tf-vars-file
     config:
       platform: linux
@@ -582,14 +582,14 @@ jobs:
       params:
         path: cf-for-k8s-pr-all-branches-and-forks
         status: failure
-        context: upgrade-check-uptime
+        context: external-db
         comment_file: pull-request-comment/comment
   on_success:
     put: cf-for-k8s-pr-all-branches-and-forks
     params:
       path: cf-for-k8s-pr-all-branches-and-forks
       status: success
-      context: upgrade-check-uptime
+      context: external-db
   ensure:
     do:
     - task: delete-cf


### PR DESCRIPTION
Currently the status of builds related to external database jobs are reported with the same context as other tests.
This PR will fix this.

This came up, because the reason for the failure of #336 was not clear.

We have no experience with the status reporting in github. We suppose that before merging this PR, you need to [create a new status for github](https://developer.github.com/v3/repos/statuses/).

**Acceptance Steps**

* Create status in github
* Merge PR
* Apply new pipeline


@modulo11 
CC: @Syerram 


