### PR TITLE
Remove unused capi secrets

### DIFF
--- a/config/capi/capi.yml
+++ b/config/capi/capi.yml
@@ -27,8 +27,6 @@ blobstore:
   endpoint: "http://cf-blobstore-minio.cf-blobstore.svc.cluster.local:9000"
   region: "''"
   access_key_id: "admin"
-  #! TODO: this should be removed
-  secret_access_key: #@ data.values.cf_blobstore.secret_key
   secret_access_key_secret_name: capi-blobstore-secret-key
   package_directory_key: cc-packages
   droplet_directory_key: cc-droplets
@@ -40,8 +38,6 @@ ccdb:
   host: #@ capi_host()
   port: #@ data.values.capi.database.port
   user: #@ data.values.capi.database.user
-  #! TODO: this should be removed
-  password: #@ data.values.capi.database.password
   password_secret_name: capi-database-password
   database: #@ data.values.capi.database.name
   ca_cert: #@ data.values.capi.database.ca_cert
@@ -67,8 +63,6 @@ uaa:
     secretName: uaa-certs
   clients:
     cloud_controller_username_lookup:
-      #! TODO: this should be removed
-      secret: #@ data.values.capi.cc_username_lookup_client_secret
       secret_name: cloud-controller-username-lookup-client-secret
     cf_api_controllers:
       secret: #@ data.values.capi.cf_api_controllers_client_secret


### PR DESCRIPTION
Now that CAPI is using k8s secrets, we no longer need the secret ytt variables

---

- Make sure this PR is based off the `develop` branch
- If you're adding/removing/changing any values in `config/values.yml`, please review [this "cf-for-k8s values for contributors" doc](https://docs.google.com/document/d/1Y3jAx48TCGIQdzOFmzqp_R_0WT8Hfjx9oyqs2Tk0Otw/edit#) for up-to-date principles and guidelines for contributing values changes.
- Checkout the [contributing guidelines](https://github.com/cloudfoundry/cf-for-k8s/blob/develop/community/CONTRIBUTING.md)
- Include any links to related PRs, issues, stories, slack discussions, etc... that will help establish context.
- Is there anything else of note that the reviewers should know about this change?

**Acceptance Steps**

cf-for-k8s continues to deploy properly with a valid values file. There should be no behavioral changes.

@cloudfoundry/cf-capi 
