### PR TITLE
Remove unused uaa.clients.cf_api_controllers.secret

### DIFF
--- a/config/capi/capi.yml
+++ b/config/capi/capi.yml
@@ -65,8 +65,6 @@ uaa:
     cloud_controller_username_lookup:
       secret_name: cloud-controller-username-lookup-client-secret
     cf_api_controllers:
-      #! TODO: this should be removed
-      secret: #@ data.values.capi.cf_api_controllers_client_secret
       secret_name: cf-api-controllers-client-secret
 
 kpack:


### PR DESCRIPTION
Remove the unused `uaa.clients.cf_api_controllers.secret` value from config/capi/capi.yml

Also bump to a version of capi-k8s-release that no longer uses the value. This will happen automatically tonight, but I wanted to submit the PR sooner.


**Acceptance Steps**
This PR makes no behavioral changes

@cloudfoundry/cf-capi 
