### PR TITLE
docs: warn operators against modifying resources with kubectl

### DIFF
--- a/docs/platform_operators/kubectl-for-operator.md
+++ b/docs/platform_operators/kubectl-for-operator.md
@@ -1,0 +1,10 @@
+# A Word of Caution for Operators
+Operators are welcome to "peek into the system" using `kubectl`. However, direct
+modification on cluster resources can lead to unexpected consequences. Many
+controllers have not yet built in any tolerance for direct user interaction with
+internal components, such as Istio and Fluentd. At the moment, some of our
+controllers don't actively reconcile: if someone modifies a resource belonging
+to CloudFoundry using `kubectl`, it could introduce conflicting configurations
+that CF is not able to handle. For example, if you modify a Route Custom
+Resource's hostname, the change will not be reflect when using the `cf` CLI.
+


### PR DESCRIPTION
We just made a first pass at this, looking for comments. This is a follow up to this [slack thread](https://cloudfoundry.slack.com/archives/CH9LF6V1P/p1597187862008100?thread_ts=1597187861.008000&cid=CH9LF6V1P).

[#174184789](https://www.pivotaltracker.com/story/show/174184789)

Co-authored-by: Mikael Manukyan <mmanukyan@vmware.com>
@mike1808 

