### PR TITLE
Allow blobstore to be configured

### DIFF
--- a/config/capi/capi.yml
+++ b/config/capi/capi.yml
@@ -24,14 +24,15 @@ app_domains:
 - #@ domain
 
 blobstore:
-  endpoint: "http://cf-blobstore-minio.cf-blobstore.svc.cluster.local:9000"
-  region: "''"
-  access_key_id: "admin"
+  endpoint: #@ data.values.blobstore.endpoint
+  region: #@ data.values.blobstore.region
+  access_key_id: #@ data.values.blobstore.access_key_id
   secret_access_key_secret_name: capi-blobstore-secret-key
-  package_directory_key: cc-packages
-  droplet_directory_key: cc-droplets
-  resource_directory_key: cc-resources
-  buildpack_directory_key: cc-buildpacks
+  package_directory_key: #@ data.values.blobstore.package_directory_key
+  droplet_directory_key: #@ data.values.blobstore.droplet_directory_key
+  resource_directory_key: #@ data.values.blobstore.resource_directory_key
+  buildpack_directory_key: #@ data.values.blobstore.buildpack_directory_key
+  aws_signature_version: #@ data.values.blobstore.aws_signature_version
 
 ccdb:
   adapter: #@ data.values.capi.database.adapter
@@ -114,7 +115,7 @@ metadata:
   namespace: #@ data.values.system_namespace
 type: Opaque
 stringData:
-  password: #@ data.values.cf_blobstore.secret_key
+  password: #@ data.values.blobstore.secret_access_key
 ---
 apiVersion: v1
 kind: Secret

--- a/config/minio/minio.yml
+++ b/config/minio/minio.yml
@@ -24,7 +24,7 @@ metadata:
 #@overlay/match by=overlay.subset({"kind": "Secret", "metadata": {"name": "cf-blobstore-minio"}})
 ---
 data:
-  accesskey: #@ base64.encode("admin")
-  secretkey: #@ base64.encode(must_exist(data.values, "cf_blobstore.secret_key"))
+  accesskey: #@ base64.encode(must_exist(data.values, "blobstore.access_key_id"))
+  secretkey: #@ base64.encode(must_exist(data.values, "blobstore.secret_access_key"))
 
 --- #@ template.replace(overlay.apply(library.get("minio").eval(), add_cf_blobstore_namespace()))

--- a/config/values/00-values.yml
+++ b/config/values/00-values.yml
@@ -73,3 +73,15 @@ use_external_dns_for_wildcard: false
 enable_automount_service_account_token: false
 metrics_server_prefer_internal_kubelet_address: false
 use_first_party_jwt_tokens: false
+
+#! configuration for the CF blobstore
+blobstore:
+  endpoint: "http://cf-blobstore-minio.cf-blobstore.svc.cluster.local:9000"
+  region: "''"
+  access_key_id: "admin"
+  secret_access_key: ""
+  package_directory_key: "cc-packages"
+  droplet_directory_key: "cc-droplets"
+  resource_directory_key: "cc-resources"
+  buildpack_directory_key: "cc-buildpacks"
+  aws_signature_version: "2"

--- a/config/values/20-secrets-config-values.yml
+++ b/config/values/20-secrets-config-values.yml
@@ -5,10 +5,6 @@ capi:
   cf_api_controllers_client_secret: ""
   cc_username_lookup_client_secret: ""
 
-#! control deployment of a blobstore for CF
-cf_blobstore:
-  secret_key: ""
-
 #! control optional deployment of a database for CF
 cf_db:
   admin_password: ""

--- a/hack/generate-values.sh
+++ b/hack/generate-values.sh
@@ -223,8 +223,8 @@ app_domains:
 - "apps.${DOMAIN}"
 cf_admin_password: $(bosh interpolate ${VARS_FILE} --path=/cf_admin_password)
 
-cf_blobstore:
-  secret_key: $(bosh interpolate ${VARS_FILE} --path=/blobstore_secret_key)
+blobstore:
+  secret_access_key: $(bosh interpolate ${VARS_FILE} --path=/blobstore_secret_key)
 
 cf_db:
   admin_password: $(bosh interpolate ${VARS_FILE} --path=/db_admin_password)


### PR DESCRIPTION
## WHAT is this change about?
This is one of the first steps towards external blobstores. Documentation, tests, disabling minio when an external blobstore is configured etc. will follow. With this PR, an external blobstore (e.g. S3) can be configured to be used by cf-for-k8s. See #344 for details.
It depends on [capi-release](https://github.com/cloudfoundry/capi-k8s-release/pull/64) to be merged first. 

## Does this PR introduce a change to `config/values/00-values.yml`?
Yes

## Acceptance Steps
1. Create the needed buckets e.g. in S3:
```
aws s3api create-bucket --bucket <cc-buildpacks-bucket> --region eu-central-1 --create-bucket-configuration LocationConstraint=eu-central-1 --acl private
aws s3api create-bucket --bucket <cc-droplets-bucket> --region eu-central-1 --create-bucket-configuration LocationConstraint=eu-central-1 --acl private
aws s3api create-bucket --bucket <cc-packages-bucket> --region eu-central-1 --create-bucket-configuration LocationConstraint=eu-central-1 --acl private
aws s3api create-bucket --bucket <cc-resources-bucket> --region eu-central-1 --create-bucket-configuration LocationConstraint=eu-central-1 --acl private
```
2. Ensure your user has proper credentials and create access key and secret key
3. Generate values as described in [Deploying CF for K8s](https://github.com/cloudfoundry/cf-for-k8s/blob/master/docs/deploy.md#steps-to-deploy)
4. Adjust the `${TMP_DIR}/cf-values.yml` and add (for recent S3 buckets use `aws_signature_version: '4'`):
```
blobstore:
  endpoint: https://s3.<your-region>.amazonaws.com/
  region: <your-region>
  access_key_id: <your-access_key_id>
  secret_access_key: <your-secret_access_key>
  package_directory_key: <cc-packages-bucket>
  droplet_directory_key: <cc-droplets-bucket>
  resource_directory_key: <cc-resources-bucket>
  buildpack_directory_key: <cc-buildpacks-bucket>
  aws_signature_version: <your-signature-version>
```

## Tag your pair, your PM, and/or team
@Haegi 
@phil9909 
