### PR TITLE
Minor docs grammar fix (it's -> its)

### DIFF
--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -28,7 +28,7 @@ You need the following CLIs on your system to be able to run the script:
 
 ### Kubernetes Cluster Requirements
 
-:exclamation: This project is in it's early stages of development and hence the resource requirements are subject to change in the future. This document and the release notes will be updated accordingly. :exclamation:
+:exclamation: This project is in its early stages of development and hence the resource requirements are subject to change in the future. This document and the release notes will be updated accordingly. :exclamation:
 
 To deploy cf-for-k8s as is, the cluster should:
 
@@ -58,7 +58,7 @@ Currently, we have tested the following two container registries:
   1. Create a Service Key JSON and download it to the machine from which you will install cf-for-k8s (referred to, below, as `path-to-kpack-gcr-service-account`).
 
 ## <a name='knownissues'></a> Known Issues
-This project is in it's early stages of development and hence there are features missing. For a list of the known issues, take a look at the [GitHub issues tagged 'known-issue'](https://github.com/cloudfoundry/cf-for-k8s/issues?q=is%3Aissue+is%3Aopen+label%3Aknown-issue).
+This project is in its early stages of development and hence there are features missing. For a list of the known issues, take a look at the [GitHub issues tagged 'known-issue'](https://github.com/cloudfoundry/cf-for-k8s/issues?q=is%3Aissue+is%3Aopen+label%3Aknown-issue).
 
 
 ### Requirements to use an external database
@@ -142,14 +142,14 @@ cf-for-k8s can be configured to [use an external database](platform_operators/ex
       ```console
       ytt -f config -f ${TMP_DIR}/cf-values.yml > ${TMP_DIR}/cf-for-k8s-rendered.yml
       ```
-      > cf-for-k8s uses [ytt](https://github.com/k14s/ytt) to create and maintain reusable YAML templates. You can visit the ytt [playground](https://get-ytt.io/) to learn more about it's templating features.
+      > cf-for-k8s uses [ytt](https://github.com/k14s/ytt) to create and maintain reusable YAML templates. You can visit the ytt [playground](https://get-ytt.io/) to learn more about its templating features.
       > In the above command, `ytt` can take a folder e.g. `config` or file via `-f`. See all options by running `ytt help`.
 
       ii. Install using `kapp` and pass the above K8s configuration file
       ```console
       kapp deploy -a cf -f ${TMP_DIR}/cf-for-k8s-rendered.yml -y
       ```
-      > cf-for-k8s uses [kapp](https://github.com/k14s/kapp) to manage it's lifecycle. `kapp` will first show you a list of resources it plans to install on the cluster and then will attempt to install those resources. `kapp` will not exit untill all resources are installed and their status is running. See all options by running `kapp help`.
+      > cf-for-k8s uses [kapp](https://github.com/k14s/kapp) to manage its lifecycle. `kapp` will first show you a list of resources it plans to install on the cluster and then will attempt to install those resources. `kapp` will not exit untill all resources are installed and their status is running. See all options by running `kapp help`.
 
    Once you run the command, it should take about 10 minutes depending on your cluster bandwidth, size. `kapp` will provide updates on pending resource creations in the cluster and will wait until all resources are created and running. Here is a sample snippet from `kapp` output:
 


### PR DESCRIPTION
## WHAT is this change about?
This is a tiny change to the deploy docs to fix incorrect instances of "it's" where "its" is the correct form.

## Does this PR introduce a change to `config/values.yml`?
No

## Acceptance Steps
When I look at the deploy docs, there are no incorrect usages of "it's".
