### PR TITLE
bump cf-k8s-networking to include istio 1.6.4 changes

### DIFF
--- a/config/networking/_ytt_lib/cf-k8s-networking/config/crd/networking.cloudfoundry.org_routes.yaml
+++ b/config/networking/_ytt_lib/cf-k8s-networking/config/crd/networking.cloudfoundry.org_routes.yaml
@@ -17,6 +17,13 @@ spec:
   scope: Namespaced
   subresources:
     status: {}
+  additionalPrinterColumns:
+  - name: URL
+    type: string
+    JSONPath: .spec.url
+  - name: Age
+    type: date
+    JSONPath: .metadata.creationTimestamp
   validation:
     openAPIV3Schema:
       description: Route is the Schema for the routes API

--- a/config/networking/_ytt_lib/cf-k8s-networking/config/istio/generated/xxx-generated-istio.yaml
+++ b/config/networking/_ytt_lib/cf-k8s-networking/config/istio/generated/xxx-generated-istio.yaml
@@ -5316,10 +5316,10 @@ metadata:
   annotations:
     kbld.k14s.io/images: |
       - Metas:
-        - Tag: 1.6.0
+        - Tag: 1.6.4
           Type: resolved
-          URL: gcr.io/cf-routing/proxyv2:1.6.0
-        URL: gcr.io/cf-routing/proxyv2@sha256:0671300037c5d706f20f01ebc4e403f44fff648245b5e121851c81a389b9ea0f
+          URL: gcr.io/cf-routing/proxyv2:1.6.4
+        URL: gcr.io/cf-routing/proxyv2@sha256:4e4d05059e65080b158a347bcfac67090968e96f302dea54c0efac9a16ef62f0
   labels:
     app: istio-ingressgateway
     istio: ingressgateway
@@ -5443,7 +5443,7 @@ spec:
           value: sni-dnat
         - name: ISTIO_META_CLUSTER_ID
           value: Kubernetes
-        image: gcr.io/cf-routing/proxyv2@sha256:0671300037c5d706f20f01ebc4e403f44fff648245b5e121851c81a389b9ea0f
+        image: gcr.io/cf-routing/proxyv2@sha256:4e4d05059e65080b158a347bcfac67090968e96f302dea54c0efac9a16ef62f0
         name: istio-proxy
         ports:
         - containerPort: 15021
@@ -5733,10 +5733,10 @@ metadata:
   annotations:
     kbld.k14s.io/images: |
       - Metas:
-        - Tag: 1.6.0
+        - Tag: 1.6.4
           Type: resolved
-          URL: gcr.io/cf-routing/pilot:1.6.0
-        URL: gcr.io/cf-routing/pilot@sha256:b952b244c0de5151ccf14457187f41dd16b1e1da617ca2a429e2d0771ae743cb
+          URL: gcr.io/cf-routing/pilot:1.6.4
+        URL: gcr.io/cf-routing/pilot@sha256:0516ef03cc2fb03e0202c7d08e73ffc761caad6946b664bd9ad1814020462c09
   labels:
     app: istiod
     istio: pilot
@@ -5809,7 +5809,7 @@ spec:
           value: Kubernetes
         - name: CENTRAL_ISTIOD
           value: "false"
-        image: gcr.io/cf-routing/pilot@sha256:b952b244c0de5151ccf14457187f41dd16b1e1da617ca2a429e2d0771ae743cb
+        image: gcr.io/cf-routing/pilot@sha256:0516ef03cc2fb03e0202c7d08e73ffc761caad6946b664bd9ad1814020462c09
         name: discovery
         ports:
         - containerPort: 8080
@@ -6301,6 +6301,13 @@ data:
           {{- end }}
       {{- end }}
       podRedirectAnnot:
+      {{- if and (.Values.istio_cni.enabled) (not .Values.istio_cni.chained) }}
+      {{ if isset .ObjectMeta.Annotations `k8s.v1.cni.cncf.io/networks` }}
+        k8s.v1.cni.cncf.io/networks: "{{ index .ObjectMeta.Annotations `k8s.v1.cni.cncf.io/networks`}}, istio-cni"
+      {{- else }}
+        k8s.v1.cni.cncf.io/networks: "istio-cni"
+      {{- end }}
+      {{- end }}
         sidecar.istio.io/interceptionMode: "{{ annotation .ObjectMeta `sidecar.istio.io/interceptionMode` .ProxyConfig.InterceptionMode }}"
         traffic.sidecar.istio.io/includeOutboundIPRanges: "{{ annotation .ObjectMeta `traffic.sidecar.istio.io/includeOutboundIPRanges` .Values.global.proxy.includeIPRanges }}"
         traffic.sidecar.istio.io/excludeOutboundIPRanges: "{{ annotation .ObjectMeta `traffic.sidecar.istio.io/excludeOutboundIPRanges` .Values.global.proxy.excludeIPRanges }}"
@@ -6310,6 +6317,12 @@ data:
         traffic.sidecar.istio.io/excludeOutboundPorts: "{{ annotation .ObjectMeta `traffic.sidecar.istio.io/excludeOutboundPorts` .Values.global.proxy.excludeOutboundPorts }}"
       {{- end }}
         traffic.sidecar.istio.io/kubevirtInterfaces: "{{ index .ObjectMeta.Annotations `traffic.sidecar.istio.io/kubevirtInterfaces` }}"
+      {{- if .Values.global.imagePullSecrets }}
+      imagePullSecrets:
+        {{- range .Values.global.imagePullSecrets }}
+        - name: {{ . }}
+        {{- end }}
+      {{- end }}
   values: |-
     {
       "global": {
@@ -6418,7 +6431,7 @@ data:
         "sts": {
           "servicePort": 0
         },
-        "tag": "1.6.0",
+        "tag": "1.6.4",
         "telemetryNamespace": "istio-system",
         "tracer": {
           "datadog": {
@@ -6496,6 +6509,7 @@ webhooks:
     - CREATE
     resources:
     - pods
+  sideEffects: None
 ---
 apiVersion: policy/v1beta1
 kind: PodDisruptionBudget

--- a/config/networking/_ytt_lib/cf-k8s-networking/config/routecontroller/cluster-role-binding.yaml
+++ b/config/networking/_ytt_lib/cf-k8s-networking/config/routecontroller/cluster-role-binding.yaml
@@ -6,6 +6,10 @@ kind: ClusterRoleBinding
 metadata:
   name: routecontroller
   namespace: #@ data.values.systemNamespace
+  labels:
+    app.kubernetes.io/name: routecontroller
+    app.kubernetes.io/component: cf-networking
+    app.kubernetes.io/part-of: cloudfoundry
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/config/networking/_ytt_lib/cf-k8s-networking/config/routecontroller/cluster-role.yaml
+++ b/config/networking/_ytt_lib/cf-k8s-networking/config/routecontroller/cluster-role.yaml
@@ -6,6 +6,10 @@ kind: ClusterRole
 metadata:
   name: routecontroller
   namespace: #@ data.values.systemNamespace
+  labels:
+    app.kubernetes.io/name: routecontroller
+    app.kubernetes.io/component: cf-networking
+    app.kubernetes.io/part-of: cloudfoundry
 rules:
 - apiGroups: ["networking.cloudfoundry.org"]
   resources: ["routes", "routes/status"]

--- a/config/networking/_ytt_lib/cf-k8s-networking/config/routecontroller/routecontroller-configmap.yaml
+++ b/config/networking/_ytt_lib/cf-k8s-networking/config/routecontroller/routecontroller-configmap.yaml
@@ -8,6 +8,10 @@ metadata:
   annotations:
     kapp.k14s.io/versioned: ""
     kapp.k14s.io/num-versions: "2"
+  labels:
+    app.kubernetes.io/name: routecontroller-config
+    app.kubernetes.io/component: cf-networking
+    app.kubernetes.io/part-of: cloudfoundry
 data:
   ISTIO_GATEWAY_NAME: cf-system/istio-ingressgateway
   RESYNC_INTERVAL: "900"

--- a/config/networking/_ytt_lib/cf-k8s-networking/config/routecontroller/routecontroller.yaml
+++ b/config/networking/_ytt_lib/cf-k8s-networking/config/routecontroller/routecontroller.yaml
@@ -8,6 +8,9 @@ metadata:
   namespace: #@ data.values.systemNamespace
   labels:
     app: routecontroller
+    app.kubernetes.io/name: routecontroller
+    app.kubernetes.io/component: cf-networking
+    app.kubernetes.io/part-of: cloudfoundry
 spec:
   replicas: 1
   selector:
@@ -18,6 +21,9 @@ spec:
       namespace: #@ data.values.systemNamespace
       labels:
         app: routecontroller
+        app.kubernetes.io/name: routecontroller
+        app.kubernetes.io/component: cf-networking
+        app.kubernetes.io/part-of: cloudfoundry
     spec:
       containers:
       - name: routecontroller

--- a/config/networking/_ytt_lib/cf-k8s-networking/config/routecontroller/service-account.yaml
+++ b/config/networking/_ytt_lib/cf-k8s-networking/config/routecontroller/service-account.yaml
@@ -6,3 +6,7 @@ kind: ServiceAccount
 metadata:
   name: routecontroller
   namespace: #@ data.values.systemNamespace
+  labels:
+    app.kubernetes.io/name: routecontroller
+    app.kubernetes.io/component: cf-networking
+    app.kubernetes.io/part-of: cloudfoundry

--- a/config/networking/_ytt_lib/cf-k8s-networking/config/values.yaml
+++ b/config/networking/_ytt_lib/cf-k8s-networking/config/values.yaml
@@ -6,18 +6,8 @@
 systemNamespace: cf-system
 workloadsNamespace: cf-workloads
 
-cfroutesync:
-  image: gcr.io/cf-networking-images/cf-k8s-networking/cfroutesync@sha256:87704f76960a66e5f11a73ad1a853f5e06203d29d00ef4dc3f61ad81feee1898
-
-  ccCA: 'base64_encoded_cloud_controller_ca'
-  ccBaseURL: 'https://api.example.com'
-  uaaCA: 'base64_encoded_uaa_ca'
-  uaaBaseURL: 'https://uaa.example.com'
-  clientName: 'uaaClientName'
-  clientSecret: 'base64_encoded_uaaClientSecret'
-
 routecontroller:
-  image: gcr.io/cf-networking-images/cf-k8s-networking/routecontroller@sha256:ed4b3e351a31313ebf974439e4fb43210281a02f0a9125cb8ea880c572385b5f
+  image: gcr.io/cf-networking-images/cf-k8s-networking/routecontroller@sha256:8ef88e0dcaa5228c2b325cf5296ff31666bd3e7525e994f4495ba4e8fc052ac8
 
 service:
   externalPort: 80

--- a/vendir.lock.yml
+++ b/vendir.lock.yml
@@ -8,8 +8,8 @@ directories:
   path: config/capi/_ytt_lib/capi-k8s-release
 - contents:
   - git:
-      commitTitle: increase routecontroller resync_interval time...
-      sha: a7e5484bcc075e71d68101225c1fd492833ca8d6
+      commitTitle: generate istio config assuming third-party-jwt...
+      sha: c62024c07a6251d3b5db7dc49c115a5d2669bdfb
     path: .
   path: config/networking/_ytt_lib/cf-k8s-networking
 - contents:

--- a/vendir.yml
+++ b/vendir.yml
@@ -17,7 +17,7 @@ directories:
   - path: .
     git:
       url: https://github.com/cloudfoundry/cf-k8s-networking
-      ref: v0.2.0
+      ref: c62024c07a6251d3b5db7dc49c115a5d2669bdfb
     includePaths:
     - config/*
     - config/crd/**/*


### PR DESCRIPTION
## WHAT is this change about?
In our [previous PR](https://github.com/cloudfoundry/cf-for-k8s/pull/349) to bump Istio to version 1.6.4, we accidentally upgraded to only Istio 1.6.0. This PR bumps the cf-k8s-networking component in vendir.yml to a commit that uses Istio 1.6.4 and not Istio 1.6.0.

## Does this PR introduce a change to `config/values.yml`?
No

## Acceptance Steps
Given I have deployed cf-for-k8s.
When I describe an istio-ingressgateway pod with kubectl -n istio-system get pods -l app=istio-ingressgateway -o yaml | grep image:
Then I can see that the istio-ingressgateway pod uses the image gcr.io/cf-routing/proxyv2:1.6.4

## Tag your pair, your PM, and/or team
@XanderStrike @ndhanushkodi @keshav-pivotal 
