### PR TITLE
[WIP] add revision info task at beginning of every job

### DIFF
--- a/ci/configure
+++ b/ci/configure
@@ -14,9 +14,16 @@ function main() {
 
 EOF
 
+    REVISION="$(git remote get-url origin) $(git rev-parse HEAD) $(git ls-files --full-name "${PROJECT_DIR}/ci/templates/${PIPELINE}.yml")"
+    if [[ -n $(git status --porcelain) ]] ; then
+      REVISION="$REVISION \e[31mdirty\e[0m"
+    fi
+
     ytt template \
       -f "${PROJECT_DIR}/ci/templates/${PIPELINE}.yml" \
       -f "${PROJECT_DIR}/ci/inputs/${PIPELINE}.yml" \
+      -f "${PROJECT_DIR}/ci/overlays/" \
+      -v "pipeline_revision=$REVISION" \
       >> "${PROJECT_DIR}/ci/pipelines/${PIPELINE}.yml"
   fi
 

--- a/ci/overlays/inject-pipeline-revision.yaml
+++ b/ci/overlays/inject-pipeline-revision.yaml
@@ -1,0 +1,22 @@
+#@ load("@ytt:overlay", "overlay")
+#@ load("@ytt:data", "data")
+
+#@overlay/match by=overlay.all,expects="1+"
+---
+jobs:
+  #@overlay/match by=overlay.all,expects="1+"
+  - plan:
+     #@overlay/match by=overlay.index(0)
+     #@overlay/insert before=True
+     - task: pipeline-revision-info
+       config:
+        platform: "linux"
+        image_resource:
+          source:
+            repository: busybox
+          type: docker-image
+        run:
+          path: /bin/echo
+          args: 
+            - "-e"
+            - #@ str(data.values.pipeline_revision)

--- a/ci/overlays/values.yaml
+++ b/ci/overlays/values.yaml
@@ -1,0 +1,6 @@
+#@data/values
+#@ load("@ytt:overlay", "overlay")
+
+---
+#@overlay/match missing_ok=True
+pipeline_revision: "<unknown>"

--- a/ci/pipelines/cf-for-k8s-contributions.yml
+++ b/ci/pipelines/cf-for-k8s-contributions.yml
@@ -288,6 +288,18 @@ jobs:
 - name: fail-prs-to-cf-for-k8s-master
   public: true
   plan:
+  - task: pipeline-revision-info
+    config:
+      platform: linux
+      image_resource:
+        source:
+          repository: busybox
+        type: docker-image
+      run:
+        path: /bin/echo
+        args:
+        - -e
+        - git@github.com:sap-contributions/cf-for-k8s.git f8a549d2a21a0518f27a80c4557c5844b58b5d66 ci/templates/cf-for-k8s-contributions.yml \e[31mdirty\e[0m
   - in_parallel:
     - get: cf-for-k8s-pr-master
       trigger: true
@@ -306,6 +318,18 @@ jobs:
 - name: pass-prs-to-cf-for-k8s-develop
   public: true
   plan:
+  - task: pipeline-revision-info
+    config:
+      platform: linux
+      image_resource:
+        source:
+          repository: busybox
+        type: docker-image
+      run:
+        path: /bin/echo
+        args:
+        - -e
+        - git@github.com:sap-contributions/cf-for-k8s.git f8a549d2a21a0518f27a80c4557c5844b58b5d66 ci/templates/cf-for-k8s-contributions.yml \e[31mdirty\e[0m
   - get: cf-for-k8s-pr-develop
     trigger: true
     version: every
@@ -317,6 +341,18 @@ jobs:
 - name: run-unit-tests-on-pr
   public: true
   plan:
+  - task: pipeline-revision-info
+    config:
+      platform: linux
+      image_resource:
+        source:
+          repository: busybox
+        type: docker-image
+      run:
+        path: /bin/echo
+        args:
+        - -e
+        - git@github.com:sap-contributions/cf-for-k8s.git f8a549d2a21a0518f27a80c4557c5844b58b5d66 ci/templates/cf-for-k8s-contributions.yml \e[31mdirty\e[0m
   - in_parallel:
     - get: cf-for-k8s-pr-all-branches-and-forks
       trigger: true
@@ -353,6 +389,18 @@ jobs:
 - name: test-vendir-sync-on-cf-for-k8s-pr
   public: true
   plan:
+  - task: pipeline-revision-info
+    config:
+      platform: linux
+      image_resource:
+        source:
+          repository: busybox
+        type: docker-image
+      run:
+        path: /bin/echo
+        args:
+        - -e
+        - git@github.com:sap-contributions/cf-for-k8s.git f8a549d2a21a0518f27a80c4557c5844b58b5d66 ci/templates/cf-for-k8s-contributions.yml \e[31mdirty\e[0m
   - in_parallel:
     - get: runtime-ci
     - get: cf-for-k8s-pr-all-branches-and-forks
@@ -394,6 +442,18 @@ jobs:
 - name: validate-pr-on-gke
   public: true
   plan:
+  - task: pipeline-revision-info
+    config:
+      platform: linux
+      image_resource:
+        source:
+          repository: busybox
+        type: docker-image
+      run:
+        path: /bin/echo
+        args:
+        - -e
+        - git@github.com:sap-contributions/cf-for-k8s.git f8a549d2a21a0518f27a80c4557c5844b58b5d66 ci/templates/cf-for-k8s-contributions.yml \e[31mdirty\e[0m
   - in_parallel:
     - get: cf-for-k8s-pr-all-branches-and-forks
       params:
@@ -506,6 +566,18 @@ jobs:
   serial: true
   public: true
   plan:
+  - task: pipeline-revision-info
+    config:
+      platform: linux
+      image_resource:
+        source:
+          repository: busybox
+        type: docker-image
+      run:
+        path: /bin/echo
+        args:
+        - -e
+        - git@github.com:sap-contributions/cf-for-k8s.git f8a549d2a21a0518f27a80c4557c5844b58b5d66 ci/templates/cf-for-k8s-contributions.yml \e[31mdirty\e[0m
   - in_parallel:
     - get: cf-for-k8s-pr-all-branches-and-forks
       params:
@@ -673,6 +745,18 @@ jobs:
   serial: true
   public: true
   plan:
+  - task: pipeline-revision-info
+    config:
+      platform: linux
+      image_resource:
+        source:
+          repository: busybox
+        type: docker-image
+      run:
+        path: /bin/echo
+        args:
+        - -e
+        - git@github.com:sap-contributions/cf-for-k8s.git f8a549d2a21a0518f27a80c4557c5844b58b5d66 ci/templates/cf-for-k8s-contributions.yml \e[31mdirty\e[0m
   - in_parallel:
     - get: cf-for-k8s-pr-all-branches-and-forks
       params:
@@ -843,6 +927,18 @@ jobs:
 - name: validate-pr-on-newest-k8s-kind
   public: true
   plan:
+  - task: pipeline-revision-info
+    config:
+      platform: linux
+      image_resource:
+        source:
+          repository: busybox
+        type: docker-image
+      run:
+        path: /bin/echo
+        args:
+        - -e
+        - git@github.com:sap-contributions/cf-for-k8s.git f8a549d2a21a0518f27a80c4557c5844b58b5d66 ci/templates/cf-for-k8s-contributions.yml \e[31mdirty\e[0m
   - in_parallel:
     - get: cf-for-k8s-pr-all-branches-and-forks
       trigger: true
@@ -928,6 +1024,18 @@ jobs:
 - name: validate-pr-on-oldest-k8s-kind
   public: true
   plan:
+  - task: pipeline-revision-info
+    config:
+      platform: linux
+      image_resource:
+        source:
+          repository: busybox
+        type: docker-image
+      run:
+        path: /bin/echo
+        args:
+        - -e
+        - git@github.com:sap-contributions/cf-for-k8s.git f8a549d2a21a0518f27a80c4557c5844b58b5d66 ci/templates/cf-for-k8s-contributions.yml \e[31mdirty\e[0m
   - in_parallel:
     - get: cf-for-k8s-pr-all-branches-and-forks
       trigger: true
@@ -1013,6 +1121,18 @@ jobs:
 - name: capi-k8s-release-run-unit-tests
   public: true
   plan:
+  - task: pipeline-revision-info
+    config:
+      platform: linux
+      image_resource:
+        source:
+          repository: busybox
+        type: docker-image
+      run:
+        path: /bin/echo
+        args:
+        - -e
+        - git@github.com:sap-contributions/cf-for-k8s.git f8a549d2a21a0518f27a80c4557c5844b58b5d66 ci/templates/cf-for-k8s-contributions.yml \e[31mdirty\e[0m
   - in_parallel:
     - get: cf-for-k8s-ci
     - get: cf-for-k8s-develop
@@ -1036,6 +1156,18 @@ jobs:
 - name: capi-k8s-release-validate-on-oldest-k8s-version
   public: true
   plan:
+  - task: pipeline-revision-info
+    config:
+      platform: linux
+      image_resource:
+        source:
+          repository: busybox
+        type: docker-image
+      run:
+        path: /bin/echo
+        args:
+        - -e
+        - git@github.com:sap-contributions/cf-for-k8s.git f8a549d2a21a0518f27a80c4557c5844b58b5d66 ci/templates/cf-for-k8s-contributions.yml \e[31mdirty\e[0m
   - in_parallel:
     - get: cf-for-k8s-ci
     - get: cf-for-k8s-develop
@@ -1124,6 +1256,18 @@ jobs:
 - name: capi-k8s-release-validate-on-newest-k8s-version
   public: true
   plan:
+  - task: pipeline-revision-info
+    config:
+      platform: linux
+      image_resource:
+        source:
+          repository: busybox
+        type: docker-image
+      run:
+        path: /bin/echo
+        args:
+        - -e
+        - git@github.com:sap-contributions/cf-for-k8s.git f8a549d2a21a0518f27a80c4557c5844b58b5d66 ci/templates/cf-for-k8s-contributions.yml \e[31mdirty\e[0m
   - in_parallel:
     - get: cf-for-k8s-ci
     - get: cf-for-k8s-develop
@@ -1212,6 +1356,18 @@ jobs:
 - name: capi-k8s-release-validate-upgrade
   public: true
   plan:
+  - task: pipeline-revision-info
+    config:
+      platform: linux
+      image_resource:
+        source:
+          repository: busybox
+        type: docker-image
+      run:
+        path: /bin/echo
+        args:
+        - -e
+        - git@github.com:sap-contributions/cf-for-k8s.git f8a549d2a21a0518f27a80c4557c5844b58b5d66 ci/templates/cf-for-k8s-contributions.yml \e[31mdirty\e[0m
   - in_parallel:
     - get: cf-for-k8s-ci
     - get: cf-for-k8s-develop
@@ -1294,6 +1450,18 @@ jobs:
 - name: capi-k8s-release-push-to-develop
   public: true
   plan:
+  - task: pipeline-revision-info
+    config:
+      platform: linux
+      image_resource:
+        source:
+          repository: busybox
+        type: docker-image
+      run:
+        path: /bin/echo
+        args:
+        - -e
+        - git@github.com:sap-contributions/cf-for-k8s.git f8a549d2a21a0518f27a80c4557c5844b58b5d66 ci/templates/cf-for-k8s-contributions.yml \e[31mdirty\e[0m
   - in_parallel:
     - get: cf-for-k8s-ci
     - get: cf-for-k8s-develop
@@ -1324,6 +1492,18 @@ jobs:
 - name: cf-k8s-logging-run-unit-tests
   public: true
   plan:
+  - task: pipeline-revision-info
+    config:
+      platform: linux
+      image_resource:
+        source:
+          repository: busybox
+        type: docker-image
+      run:
+        path: /bin/echo
+        args:
+        - -e
+        - git@github.com:sap-contributions/cf-for-k8s.git f8a549d2a21a0518f27a80c4557c5844b58b5d66 ci/templates/cf-for-k8s-contributions.yml \e[31mdirty\e[0m
   - in_parallel:
     - get: cf-for-k8s-ci
     - get: cf-for-k8s-develop
@@ -1346,6 +1526,18 @@ jobs:
 - name: cf-k8s-logging-validate-on-oldest-k8s-version
   public: true
   plan:
+  - task: pipeline-revision-info
+    config:
+      platform: linux
+      image_resource:
+        source:
+          repository: busybox
+        type: docker-image
+      run:
+        path: /bin/echo
+        args:
+        - -e
+        - git@github.com:sap-contributions/cf-for-k8s.git f8a549d2a21a0518f27a80c4557c5844b58b5d66 ci/templates/cf-for-k8s-contributions.yml \e[31mdirty\e[0m
   - in_parallel:
     - get: cf-for-k8s-ci
     - get: cf-for-k8s-develop
@@ -1434,6 +1626,18 @@ jobs:
 - name: cf-k8s-logging-validate-on-newest-k8s-version
   public: true
   plan:
+  - task: pipeline-revision-info
+    config:
+      platform: linux
+      image_resource:
+        source:
+          repository: busybox
+        type: docker-image
+      run:
+        path: /bin/echo
+        args:
+        - -e
+        - git@github.com:sap-contributions/cf-for-k8s.git f8a549d2a21a0518f27a80c4557c5844b58b5d66 ci/templates/cf-for-k8s-contributions.yml \e[31mdirty\e[0m
   - in_parallel:
     - get: cf-for-k8s-ci
     - get: cf-for-k8s-develop
@@ -1522,6 +1726,18 @@ jobs:
 - name: cf-k8s-logging-validate-upgrade
   public: true
   plan:
+  - task: pipeline-revision-info
+    config:
+      platform: linux
+      image_resource:
+        source:
+          repository: busybox
+        type: docker-image
+      run:
+        path: /bin/echo
+        args:
+        - -e
+        - git@github.com:sap-contributions/cf-for-k8s.git f8a549d2a21a0518f27a80c4557c5844b58b5d66 ci/templates/cf-for-k8s-contributions.yml \e[31mdirty\e[0m
   - in_parallel:
     - get: cf-for-k8s-ci
     - get: cf-for-k8s-develop
@@ -1604,6 +1820,18 @@ jobs:
 - name: cf-k8s-logging-push-to-develop
   public: true
   plan:
+  - task: pipeline-revision-info
+    config:
+      platform: linux
+      image_resource:
+        source:
+          repository: busybox
+        type: docker-image
+      run:
+        path: /bin/echo
+        args:
+        - -e
+        - git@github.com:sap-contributions/cf-for-k8s.git f8a549d2a21a0518f27a80c4557c5844b58b5d66 ci/templates/cf-for-k8s-contributions.yml \e[31mdirty\e[0m
   - in_parallel:
     - get: cf-for-k8s-ci
     - get: cf-for-k8s-develop
@@ -1634,6 +1862,18 @@ jobs:
 - name: eirini-release-run-unit-tests
   public: true
   plan:
+  - task: pipeline-revision-info
+    config:
+      platform: linux
+      image_resource:
+        source:
+          repository: busybox
+        type: docker-image
+      run:
+        path: /bin/echo
+        args:
+        - -e
+        - git@github.com:sap-contributions/cf-for-k8s.git f8a549d2a21a0518f27a80c4557c5844b58b5d66 ci/templates/cf-for-k8s-contributions.yml \e[31mdirty\e[0m
   - in_parallel:
     - get: cf-for-k8s-ci
     - get: cf-for-k8s-develop
@@ -1656,6 +1896,18 @@ jobs:
 - name: eirini-release-validate-on-oldest-k8s-version
   public: true
   plan:
+  - task: pipeline-revision-info
+    config:
+      platform: linux
+      image_resource:
+        source:
+          repository: busybox
+        type: docker-image
+      run:
+        path: /bin/echo
+        args:
+        - -e
+        - git@github.com:sap-contributions/cf-for-k8s.git f8a549d2a21a0518f27a80c4557c5844b58b5d66 ci/templates/cf-for-k8s-contributions.yml \e[31mdirty\e[0m
   - in_parallel:
     - get: cf-for-k8s-ci
     - get: cf-for-k8s-develop
@@ -1744,6 +1996,18 @@ jobs:
 - name: eirini-release-validate-on-newest-k8s-version
   public: true
   plan:
+  - task: pipeline-revision-info
+    config:
+      platform: linux
+      image_resource:
+        source:
+          repository: busybox
+        type: docker-image
+      run:
+        path: /bin/echo
+        args:
+        - -e
+        - git@github.com:sap-contributions/cf-for-k8s.git f8a549d2a21a0518f27a80c4557c5844b58b5d66 ci/templates/cf-for-k8s-contributions.yml \e[31mdirty\e[0m
   - in_parallel:
     - get: cf-for-k8s-ci
     - get: cf-for-k8s-develop
@@ -1832,6 +2096,18 @@ jobs:
 - name: eirini-release-validate-upgrade
   public: true
   plan:
+  - task: pipeline-revision-info
+    config:
+      platform: linux
+      image_resource:
+        source:
+          repository: busybox
+        type: docker-image
+      run:
+        path: /bin/echo
+        args:
+        - -e
+        - git@github.com:sap-contributions/cf-for-k8s.git f8a549d2a21a0518f27a80c4557c5844b58b5d66 ci/templates/cf-for-k8s-contributions.yml \e[31mdirty\e[0m
   - in_parallel:
     - get: cf-for-k8s-ci
     - get: cf-for-k8s-develop
@@ -1914,6 +2190,18 @@ jobs:
 - name: eirini-release-push-to-develop
   public: true
   plan:
+  - task: pipeline-revision-info
+    config:
+      platform: linux
+      image_resource:
+        source:
+          repository: busybox
+        type: docker-image
+      run:
+        path: /bin/echo
+        args:
+        - -e
+        - git@github.com:sap-contributions/cf-for-k8s.git f8a549d2a21a0518f27a80c4557c5844b58b5d66 ci/templates/cf-for-k8s-contributions.yml \e[31mdirty\e[0m
   - in_parallel:
     - get: cf-for-k8s-ci
     - get: cf-for-k8s-develop
@@ -1944,6 +2232,18 @@ jobs:
 - name: kpack-run-unit-tests
   public: true
   plan:
+  - task: pipeline-revision-info
+    config:
+      platform: linux
+      image_resource:
+        source:
+          repository: busybox
+        type: docker-image
+      run:
+        path: /bin/echo
+        args:
+        - -e
+        - git@github.com:sap-contributions/cf-for-k8s.git f8a549d2a21a0518f27a80c4557c5844b58b5d66 ci/templates/cf-for-k8s-contributions.yml \e[31mdirty\e[0m
   - in_parallel:
     - get: cf-for-k8s-ci
     - get: cf-for-k8s-develop
@@ -1966,6 +2266,18 @@ jobs:
 - name: kpack-validate-on-oldest-k8s-version
   public: true
   plan:
+  - task: pipeline-revision-info
+    config:
+      platform: linux
+      image_resource:
+        source:
+          repository: busybox
+        type: docker-image
+      run:
+        path: /bin/echo
+        args:
+        - -e
+        - git@github.com:sap-contributions/cf-for-k8s.git f8a549d2a21a0518f27a80c4557c5844b58b5d66 ci/templates/cf-for-k8s-contributions.yml \e[31mdirty\e[0m
   - in_parallel:
     - get: cf-for-k8s-ci
     - get: cf-for-k8s-develop
@@ -2054,6 +2366,18 @@ jobs:
 - name: kpack-validate-on-newest-k8s-version
   public: true
   plan:
+  - task: pipeline-revision-info
+    config:
+      platform: linux
+      image_resource:
+        source:
+          repository: busybox
+        type: docker-image
+      run:
+        path: /bin/echo
+        args:
+        - -e
+        - git@github.com:sap-contributions/cf-for-k8s.git f8a549d2a21a0518f27a80c4557c5844b58b5d66 ci/templates/cf-for-k8s-contributions.yml \e[31mdirty\e[0m
   - in_parallel:
     - get: cf-for-k8s-ci
     - get: cf-for-k8s-develop
@@ -2142,6 +2466,18 @@ jobs:
 - name: kpack-validate-upgrade
   public: true
   plan:
+  - task: pipeline-revision-info
+    config:
+      platform: linux
+      image_resource:
+        source:
+          repository: busybox
+        type: docker-image
+      run:
+        path: /bin/echo
+        args:
+        - -e
+        - git@github.com:sap-contributions/cf-for-k8s.git f8a549d2a21a0518f27a80c4557c5844b58b5d66 ci/templates/cf-for-k8s-contributions.yml \e[31mdirty\e[0m
   - in_parallel:
     - get: cf-for-k8s-ci
     - get: cf-for-k8s-develop
@@ -2224,6 +2560,18 @@ jobs:
 - name: kpack-push-to-develop
   public: true
   plan:
+  - task: pipeline-revision-info
+    config:
+      platform: linux
+      image_resource:
+        source:
+          repository: busybox
+        type: docker-image
+      run:
+        path: /bin/echo
+        args:
+        - -e
+        - git@github.com:sap-contributions/cf-for-k8s.git f8a549d2a21a0518f27a80c4557c5844b58b5d66 ci/templates/cf-for-k8s-contributions.yml \e[31mdirty\e[0m
   - in_parallel:
     - get: cf-for-k8s-ci
     - get: cf-for-k8s-develop
@@ -2254,6 +2602,18 @@ jobs:
 - name: metric-proxy-run-unit-tests
   public: true
   plan:
+  - task: pipeline-revision-info
+    config:
+      platform: linux
+      image_resource:
+        source:
+          repository: busybox
+        type: docker-image
+      run:
+        path: /bin/echo
+        args:
+        - -e
+        - git@github.com:sap-contributions/cf-for-k8s.git f8a549d2a21a0518f27a80c4557c5844b58b5d66 ci/templates/cf-for-k8s-contributions.yml \e[31mdirty\e[0m
   - in_parallel:
     - get: cf-for-k8s-ci
     - get: cf-for-k8s-develop
@@ -2276,6 +2636,18 @@ jobs:
 - name: metric-proxy-validate-on-oldest-k8s-version
   public: true
   plan:
+  - task: pipeline-revision-info
+    config:
+      platform: linux
+      image_resource:
+        source:
+          repository: busybox
+        type: docker-image
+      run:
+        path: /bin/echo
+        args:
+        - -e
+        - git@github.com:sap-contributions/cf-for-k8s.git f8a549d2a21a0518f27a80c4557c5844b58b5d66 ci/templates/cf-for-k8s-contributions.yml \e[31mdirty\e[0m
   - in_parallel:
     - get: cf-for-k8s-ci
     - get: cf-for-k8s-develop
@@ -2364,6 +2736,18 @@ jobs:
 - name: metric-proxy-validate-on-newest-k8s-version
   public: true
   plan:
+  - task: pipeline-revision-info
+    config:
+      platform: linux
+      image_resource:
+        source:
+          repository: busybox
+        type: docker-image
+      run:
+        path: /bin/echo
+        args:
+        - -e
+        - git@github.com:sap-contributions/cf-for-k8s.git f8a549d2a21a0518f27a80c4557c5844b58b5d66 ci/templates/cf-for-k8s-contributions.yml \e[31mdirty\e[0m
   - in_parallel:
     - get: cf-for-k8s-ci
     - get: cf-for-k8s-develop
@@ -2452,6 +2836,18 @@ jobs:
 - name: metric-proxy-validate-upgrade
   public: true
   plan:
+  - task: pipeline-revision-info
+    config:
+      platform: linux
+      image_resource:
+        source:
+          repository: busybox
+        type: docker-image
+      run:
+        path: /bin/echo
+        args:
+        - -e
+        - git@github.com:sap-contributions/cf-for-k8s.git f8a549d2a21a0518f27a80c4557c5844b58b5d66 ci/templates/cf-for-k8s-contributions.yml \e[31mdirty\e[0m
   - in_parallel:
     - get: cf-for-k8s-ci
     - get: cf-for-k8s-develop
@@ -2534,6 +2930,18 @@ jobs:
 - name: metric-proxy-push-to-develop
   public: true
   plan:
+  - task: pipeline-revision-info
+    config:
+      platform: linux
+      image_resource:
+        source:
+          repository: busybox
+        type: docker-image
+      run:
+        path: /bin/echo
+        args:
+        - -e
+        - git@github.com:sap-contributions/cf-for-k8s.git f8a549d2a21a0518f27a80c4557c5844b58b5d66 ci/templates/cf-for-k8s-contributions.yml \e[31mdirty\e[0m
   - in_parallel:
     - get: cf-for-k8s-ci
     - get: cf-for-k8s-develop
@@ -2564,6 +2972,18 @@ jobs:
 - name: uaa-run-unit-tests
   public: true
   plan:
+  - task: pipeline-revision-info
+    config:
+      platform: linux
+      image_resource:
+        source:
+          repository: busybox
+        type: docker-image
+      run:
+        path: /bin/echo
+        args:
+        - -e
+        - git@github.com:sap-contributions/cf-for-k8s.git f8a549d2a21a0518f27a80c4557c5844b58b5d66 ci/templates/cf-for-k8s-contributions.yml \e[31mdirty\e[0m
   - in_parallel:
     - get: cf-for-k8s-ci
     - get: cf-for-k8s-develop
@@ -2586,6 +3006,18 @@ jobs:
 - name: uaa-validate-on-oldest-k8s-version
   public: true
   plan:
+  - task: pipeline-revision-info
+    config:
+      platform: linux
+      image_resource:
+        source:
+          repository: busybox
+        type: docker-image
+      run:
+        path: /bin/echo
+        args:
+        - -e
+        - git@github.com:sap-contributions/cf-for-k8s.git f8a549d2a21a0518f27a80c4557c5844b58b5d66 ci/templates/cf-for-k8s-contributions.yml \e[31mdirty\e[0m
   - in_parallel:
     - get: cf-for-k8s-ci
     - get: cf-for-k8s-develop
@@ -2674,6 +3106,18 @@ jobs:
 - name: uaa-validate-on-newest-k8s-version
   public: true
   plan:
+  - task: pipeline-revision-info
+    config:
+      platform: linux
+      image_resource:
+        source:
+          repository: busybox
+        type: docker-image
+      run:
+        path: /bin/echo
+        args:
+        - -e
+        - git@github.com:sap-contributions/cf-for-k8s.git f8a549d2a21a0518f27a80c4557c5844b58b5d66 ci/templates/cf-for-k8s-contributions.yml \e[31mdirty\e[0m
   - in_parallel:
     - get: cf-for-k8s-ci
     - get: cf-for-k8s-develop
@@ -2762,6 +3206,18 @@ jobs:
 - name: uaa-validate-upgrade
   public: true
   plan:
+  - task: pipeline-revision-info
+    config:
+      platform: linux
+      image_resource:
+        source:
+          repository: busybox
+        type: docker-image
+      run:
+        path: /bin/echo
+        args:
+        - -e
+        - git@github.com:sap-contributions/cf-for-k8s.git f8a549d2a21a0518f27a80c4557c5844b58b5d66 ci/templates/cf-for-k8s-contributions.yml \e[31mdirty\e[0m
   - in_parallel:
     - get: cf-for-k8s-ci
     - get: cf-for-k8s-develop
@@ -2844,6 +3300,18 @@ jobs:
 - name: uaa-push-to-develop
   public: true
   plan:
+  - task: pipeline-revision-info
+    config:
+      platform: linux
+      image_resource:
+        source:
+          repository: busybox
+        type: docker-image
+      run:
+        path: /bin/echo
+        args:
+        - -e
+        - git@github.com:sap-contributions/cf-for-k8s.git f8a549d2a21a0518f27a80c4557c5844b58b5d66 ci/templates/cf-for-k8s-contributions.yml \e[31mdirty\e[0m
   - in_parallel:
     - get: cf-for-k8s-ci
     - get: cf-for-k8s-develop
@@ -2874,6 +3342,18 @@ jobs:
 - name: bump-buildpacks
   public: true
   plan:
+  - task: pipeline-revision-info
+    config:
+      platform: linux
+      image_resource:
+        source:
+          repository: busybox
+        type: docker-image
+      run:
+        path: /bin/echo
+        args:
+        - -e
+        - git@github.com:sap-contributions/cf-for-k8s.git f8a549d2a21a0518f27a80c4557c5844b58b5d66 ci/templates/cf-for-k8s-contributions.yml \e[31mdirty\e[0m
   - in_parallel:
     - get: ruby-buildpack
       trigger: true


### PR DESCRIPTION

## WHAT is this change about?
It adds a task to the beginning of every job of every pipeline (created by a template) which prints the current git revision

e.g.:
```yaml
  plan:
  - task: pipeline-revision-info
    config:
      platform: linux
      image_resource:
        source:
          repository: busybox
        type: docker-image
      run:
        path: /bin/echo
        args:
        - -e
        - git@github.com:cloudfoundry/cf-for-k8s.git 5c6c847fcdfa25765084d2f659f212c46099cb5f ci/templates/cf-for-k8s-contributions.yml \e[31mdirty\e[0m
```
![image](https://user-images.githubusercontent.com/24714828/90791299-521c0400-e309-11ea-8b89-8a137de1df3b.png)

We do this for quite some time now for our internal pipelines and it is helpful from time to time.  

## Limitation

The current implementation is WIP and has a limitation. If you're interested we can find a way to resolve the limitation:

As the result of the templating process is currently check into git, it will always be marked as dirty (as the result contains the hash and the hash is unknown before committing).
We could either stop doing that or run a 2nd `ytt template` only to add this overlay.


## Does this PR introduce a change to `config/values.yml`?
No

## Acceptance Steps
run `ci/configure <some pipeline>`