### PR TITLE
Add validation test for external database

### DIFF
--- a/ci/pipelines/cf-for-k8s-contributions.yml
+++ b/ci/pipelines/cf-for-k8s-contributions.yml
@@ -651,6 +651,16 @@ jobs:
         APP_REGISTRY_USERNAME: ((cf_for_k8s_private_dockerhub.username))
         APP_REGISTRY_PASSWORD: ((cf_for_k8s_private_dockerhub.password))
         USE_EXTERNAL_DB: "true"
+  - task: run-external-db-validation-test
+    file: cf-for-k8s-ci/ci/tasks/run-external-db-validation-test/task.yml
+    params:
+      GCP_PROJECT_NAME: ((ci_k8s_gcp_project_name))
+      GCP_PROJECT_ZONE: ((ci_k8s_gcp_project_zone))
+      GCP_SERVICE_ACCOUNT_JSON: ((ci_k8s_gcp_service_account_json))
+      EXTERNAL_DB: incluster
+    input_mapping:
+      pool-lock: ready-pool
+      cf-for-k8s: cf-for-k8s-develop
   - task: push-test-app
     file: cf-for-k8s-ci/ci/tasks/push-test-app/task.yml
     input_mapping:
@@ -828,6 +838,12 @@ jobs:
       APP_REGISTRY_USERNAME: ((cf_for_k8s_private_dockerhub.username))
       APP_REGISTRY_PASSWORD: ((cf_for_k8s_private_dockerhub.password))
       USE_EXTERNAL_DB: "true"
+  - task: run-rds-validation-test
+    file: cf-for-k8s-ci/ci/tasks/run-external-db-validation-test/task.yml
+    params:
+      PGPASSWORD: ((ci_k8s_aws_rds_database_password))
+    input_mapping:
+      cf-for-k8s: cf-for-k8s-develop
   - task: push-test-app
     file: cf-for-k8s-ci/ci/tasks/push-test-app/task.yml
     input_mapping:

--- a/ci/pipelines/cf-for-k8s-main.yml
+++ b/ci/pipelines/cf-for-k8s-main.yml
@@ -267,6 +267,17 @@ jobs:
         DOMAIN: k8s-dev.relint.rocks
       file: cf-for-k8s-ci/ci/tasks/install-cf/task.yml
 
+    - task: run-external-db-validation-test
+      file: cf-for-k8s-ci/ci/tasks/run-external-db-validation-test/task.yml
+      params:
+        GCP_PROJECT_NAME: ((ci_k8s_gcp_project_name))
+        GCP_PROJECT_ZONE: ((ci_k8s_gcp_project_zone))
+        GCP_SERVICE_ACCOUNT_JSON: ((ci_k8s_gcp_service_account_json))
+        EXTERNAL_DB: "incluster"
+      input_mapping:
+        pool-lock: ready-pool
+        cf-for-k8s: cf-for-k8s-develop
+
     - task: run-smoke-test
       file: cf-for-k8s-ci/ci/tasks/run-smoke-tests/task.yml
       params:
@@ -374,6 +385,13 @@ jobs:
         ADDITIONAL_YAML_CONFIG: db-metadata/db-values.yaml
         DOMAIN: k8s-dev.relint.rocks
       file: cf-for-k8s-ci/ci/tasks/install-cf/task.yml
+
+    - task: run-rds-validation-test
+      file: cf-for-k8s-ci/ci/tasks/run-external-db-validation-test/task.yml
+      params:
+        PGPASSWORD: ((ci_k8s_aws_rds_database_password))
+      input_mapping:
+        cf-for-k8s: cf-for-k8s-develop
 
     - task: run-smoke-test
       file: cf-for-k8s-ci/ci/tasks/run-smoke-tests/task.yml

--- a/ci/tasks/install-cf-on-gke/task.sh
+++ b/ci/tasks/install-cf-on-gke/task.sh
@@ -53,7 +53,8 @@ app_registry:
    hostname: ${APP_REGISTRY_HOSTNAME}
    repository_prefix: ${APP_REGISTRY_REPOSITORY_PREFIX}
    username: ${APP_REGISTRY_USERNAME}
-   password: ${APP_REGISTRY_PASSWORD}
+   password: |
+     ${APP_REGISTRY_PASSWORD}
 EOT
 else
   cf-for-k8s/hack/generate-values.sh --cf-domain "${DNS_DOMAIN}" --gcr-service-account-json gcp-service-account.json > cf-values.yml

--- a/ci/tasks/run-external-db-validation-test/task.sh
+++ b/ci/tasks/run-external-db-validation-test/task.sh
@@ -1,0 +1,67 @@
+#!/bin/bash
+set -eu
+
+function setup_external_db {
+  source cf-for-k8s-ci/ci/helpers/gke.sh
+
+  if [[ -d pool-lock ]]; then
+    if [[ -d tf-vars ]]; then
+      echo "You may not specify both pool-lock and tf-vars"
+      exit 1
+    fi
+    cluster_name="$(cat pool-lock/name)"
+  elif [[ -d tf-vars ]]; then
+    if [[ -d terraform ]]; then
+      cluster_name="$(cat tf-vars/env-name.txt)"
+    else
+      echo "You must provide both tf-vars and terraform inputs together"
+      exit 1
+    fi
+  else
+    echo "You must provide either pool-lock or tf-vars"
+    exit 1
+  fi
+
+  gcloud_auth "${cluster_name}"
+}
+
+function read_db_values {
+  DB_VALUES=$(cat db-metadata/db-values.yaml)
+  CAPI_HOST=$(yq -r '.capi.database.host' <<< "$DB_VALUES")
+  CAPI_PORT=$(yq -r '.capi.database.port' <<< "$DB_VALUES")
+  CAPI_NAME=$(yq -r '.capi.database.name' <<< "$DB_VALUES")
+
+  UAA_HOST=$(yq -r '.uaa.database.host' <<< "$DB_VALUES")
+  UAA_PORT=$(yq -r '.uaa.database.port' <<< "$DB_VALUES")
+  UAA_NAME=$(yq -r '.uaa.database.name' <<< "$DB_VALUES")
+}
+
+read_db_values
+
+if [ ${EXTERNAL_DB} == "rds" ];then
+  CAPI_TABLE_COUNT=$(psql --host="$CAPI_HOST" --port="$CAPI_PORT" --username="postgres" "$CAPI_NAME" -c "select count(*) from information_schema.tables where table_schema='public';" -qtAX)
+  UAA_TABLE_COUNT=$(psql --host="$UAA_HOST" --port="$UAA_PORT" --username="postgres" "$UAA_NAME" -c "select count(*) from information_schema.tables where table_schema='public';" -qtAX)
+elif [ ${EXTERNAL_DB} == "incluster" ];then
+  setup_external_db
+  # shellcheck disable=SC2155
+  export PGPASSWORD=$(kubectl get secret -n external-db postgresql -o jsonpath="{.data.postgresql-password}" | base64 -d)
+  CAPI_TABLE_COUNT=$(kubectl exec -n external-db statefulset/postgresql-postgresql -i -- psql "postgresql://postgres:$PGPASSWORD@localhost:$CAPI_PORT/$CAPI_NAME" -c "select count(*) from information_schema.tables where table_schema='public';" -qtAX)
+  UAA_TABLE_COUNT=$(kubectl exec -n external-db statefulset/postgresql-postgresql -i -- psql "postgresql://postgres:$PGPASSWORD@localhost:$UAA_PORT/$UAA_NAME" -c "select count(*) from information_schema.tables where table_schema='public';" -qtAX)
+else
+  echo "You need to specifiy an EXTERNAL_DB"
+  exit 1
+fi
+
+echo "Checking if tables exist in database $CAPI_NAME on $CAPI_HOST"
+if [ ! ${CAPI_TABLE_COUNT} -gt 0 ];then
+    echo "No tables found in $CAPI_NAME"
+    exit 1
+fi
+
+echo "Checking if tables exist in database $UAA_NAME on $CAPI_HOST"
+if [ ! ${UAA_TABLE_COUNT} -gt 0 ];then
+    echo "No tables found in $UAA_NAME"
+    exit 1
+fi
+
+echo "Check successfully completed."

--- a/ci/tasks/run-external-db-validation-test/task.yml
+++ b/ci/tasks/run-external-db-validation-test/task.yml
@@ -1,0 +1,28 @@
+---
+platform: linux
+
+image_resource:
+  type: docker-image
+  source:
+    repository: relintdockerhubpushbot/cf-for-k8s-ci
+
+inputs:
+- name: cf-for-k8s
+- name: cf-for-k8s-ci
+- name: pool-lock
+  optional: true
+- name: tf-vars
+  optional: true
+- name: terraform
+  optional: true
+- name: db-metadata
+
+params:
+  GCP_SERVICE_ACCOUNT_JSON:
+  GCP_PROJECT_NAME:
+  GCP_PROJECT_ZONE:
+  EXTERNAL_DB: "rds"
+  PGPASSWORD:
+
+run:
+  path: cf-for-k8s-ci/ci/tasks/run-external-db-validation-test/task.sh

--- a/ci/templates/cf-for-k8s-contributions.yml
+++ b/ci/templates/cf-for-k8s-contributions.yml
@@ -530,6 +530,17 @@ jobs:
         APP_REGISTRY_PASSWORD: ((cf_for_k8s_private_dockerhub.password))
         USE_EXTERNAL_DB: "true"
 
+  - task: run-external-db-validation-test
+    file: cf-for-k8s-ci/ci/tasks/run-external-db-validation-test/task.yml
+    params:
+      GCP_PROJECT_NAME: ((ci_k8s_gcp_project_name))
+      GCP_PROJECT_ZONE: ((ci_k8s_gcp_project_zone))
+      GCP_SERVICE_ACCOUNT_JSON: ((ci_k8s_gcp_service_account_json))
+      EXTERNAL_DB: "incluster"
+    input_mapping:
+      pool-lock: ready-pool
+      cf-for-k8s: cf-for-k8s-develop
+
   - task: push-test-app
     file: cf-for-k8s-ci/ci/tasks/push-test-app/task.yml
     input_mapping:
@@ -709,6 +720,13 @@ jobs:
       APP_REGISTRY_USERNAME: ((cf_for_k8s_private_dockerhub.username))
       APP_REGISTRY_PASSWORD: ((cf_for_k8s_private_dockerhub.password))
       USE_EXTERNAL_DB: "true"
+
+  - task: run-rds-validation-test
+    file: cf-for-k8s-ci/ci/tasks/run-external-db-validation-test/task.yml
+    params:
+      PGPASSWORD: ((ci_k8s_aws_rds_database_password))
+    input_mapping:
+      cf-for-k8s: cf-for-k8s-develop
 
   - task: push-test-app
     file: cf-for-k8s-ci/ci/tasks/push-test-app/task.yml


### PR DESCRIPTION
## WHAT is this change about?
With this change, we verify that the configured database is actually used (#168).
We do so by verifying that tables exist in the public schema for `uaa` and `capi`.
This is implemented for in-cluster databases as well as external (rds) databases.

## Does this PR introduce a change to `config/values.yml`?
No

## Tag your pair, your PM, and/or team
@modulo11 
@phil9909 
