### PR TITLE
Minor README fix (concourse url)

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ This project is licensed under the APACHE LICENSE-2.0 - see the [LICENSE.md](LIC
 
 ## CI Pipelines
 
-This project includes a test suite that makes use of Concourse pipelines, which can be found [here](https://release-integration.ci.cf-app.com/teams/main/pipelines/cf-for-k8s).
+This project includes a test suite that makes use of Concourse pipelines, which can be found [here](https://release-integration.ci.cf-app.com).
 
 ## Have a question or feedback, reach out to us
 


### PR DESCRIPTION
## WHAT is this change about?
At the moment the concourse link in the [README](https://github.com/cloudfoundry/cf-for-k8s/blob/develop/README.md#ci-pipelines) points to https://release-integration.ci.cf-app.com/teams/main/pipelines/cf-for-k8s, which doesn't exist anymore.
With this change the concourse link in points directly to the concourse.

## Does this PR introduce a change to `config/values.yml`?
No

## Acceptance Steps
The concourse link in the [README](https://github.com/cloudfoundry/cf-for-k8s/blob/develop/README.md#ci-pipelines) works fine.