### PR TITLE
Investigation: Components contribute their databases to the postgres component

### DIFF
--- a/config/capi/capi.yml
+++ b/config/capi/capi.yml
@@ -4,6 +4,7 @@
 #@ load("@ytt:overlay", "overlay")
 #@ load("@ytt:template", "template")
 #@ load("@ytt:yaml", "yaml")
+#@ load("@ytt:base64", "base64")
 
 #@ def capi_host():
 #@   if len(data.values.capi.database.host) > 0:
@@ -142,3 +143,42 @@ metadata:
 type: Opaque
 stringData:
   password: #@ data.values.capi.database.encryption_key
+
+#@ def cfdb_enabled():
+#@   return len(data.values.uaa.database.host) == 0 or len(data.values.capi.database.host) == 0
+#@ end
+
+#@ if cfdb_enabled():
+#@overlay/match by=overlay.subset({"kind": "ConfigMap", "metadata":{"name":"cf-db-postgresql-init-scripts"}}),expects="0+"
+---
+#@ ccdb = data.values.capi.database
+#@yaml/text-templated-strings
+data:
+  #@overlay/match missing_ok=True
+  ccdb_init.sh: |
+    #!/bin/bash
+    CCDB_USERNAME=$(cat /docker-entrypoint-initdb.d/secret/ccdb-username)
+    CCDB_PASSWORD=$(cat /docker-entrypoint-initdb.d/secret/ccdb-password)
+    cat > /tmp/setup_db.sql <<EOT
+    CREATE DATABASE (@= ccdb.name @);
+    CREATE ROLE ${CCDB_USERNAME} LOGIN PASSWORD '${CCDB_PASSWORD}';
+    EOT
+    psql -U postgres -f /tmp/setup_db.sql
+    psql -U postgres -d (@= ccdb.name @) -c "CREATE EXTENSION citext"
+
+#@overlay/match by=overlay.subset({"kind": "Secret", "metadata":{"name":"cf-db-credentials"}}),expects="0+"
+---
+#@overlay/match missing_ok=True
+data:
+  #@ if len(data.values.capi.database.user) == 0:
+  #@  assert.fail("capi.database.user cannot be empty")
+  #@ end
+  #@overlay/match missing_ok=True
+  ccdb-username: #@ base64.encode(data.values.capi.database.user)
+  #@ if len(data.values.capi.database.password) == 0:
+  #@  assert.fail("capi.database.password cannot be empty")
+  #@ end
+  #@overlay/match missing_ok=True
+  ccdb-password: #@ base64.encode(data.values.capi.database.password)
+
+#@ end

--- a/config/postgres/postgres.yml
+++ b/config/postgres/postgres.yml
@@ -41,46 +41,7 @@ kind: Secret
 metadata:
   name: cf-db-credentials
   namespace: cf-db
-data:
-  #@ if len(data.values.capi.database.user) == 0:
-  #@  assert.fail("capi.database.user cannot be empty")
-  #@ end
-  ccdb-username: #@ base64.encode(data.values.capi.database.user)
-  #@ if len(data.values.capi.database.password) == 0:
-  #@  assert.fail("capi.database.password cannot be empty")
-  #@ end
-  ccdb-password: #@ base64.encode(data.values.capi.database.password)
-  #@ if len(data.values.uaa.database.user) == 0:
-  #@  assert.fail("uaa.database.user cannot be empty")
-  #@ end
-  uaadb-username: #@ base64.encode(data.values.uaa.database.user)
-  #@ if len(data.values.uaa.database.password) == 0:
-  #@  assert.fail("uaa.database.password cannot be empty")
-  #@ end
-  uaadb-password: #@ base64.encode(data.values.uaa.database.password)
-
-#@overlay/match by=overlay.subset({"kind": "ConfigMap", "metadata":{"name":"cf-db-postgresql-init-scripts"}})
----
-#@ ccdb = data.values.capi.database
-#@ uaadb = data.values.uaa.database
-#@yaml/text-templated-strings
-data:
-  #@overlay/match missing_ok=True
-  init.sh: |
-    #!/bin/bash
-    CCDB_USERNAME=$(cat /docker-entrypoint-initdb.d/secret/ccdb-username)
-    CCDB_PASSWORD=$(cat /docker-entrypoint-initdb.d/secret/ccdb-password)
-    UAADB_USERNAME=$(cat /docker-entrypoint-initdb.d/secret/uaadb-username)
-    UAADB_PASSWORD=$(cat /docker-entrypoint-initdb.d/secret/uaadb-password)
-    cat > /tmp/setup_db.sql <<EOT
-    CREATE DATABASE (@= ccdb.name @);
-    CREATE ROLE ${CCDB_USERNAME} LOGIN PASSWORD '${CCDB_PASSWORD}';
-    CREATE DATABASE (@= uaadb.name @);
-    CREATE ROLE ${UAADB_USERNAME} LOGIN PASSWORD '${UAADB_PASSWORD}';
-    EOT
-    psql -U postgres -f /tmp/setup_db.sql
-    psql -U postgres -d (@= ccdb.name @) -c "CREATE EXTENSION citext"
-    psql -U postgres -d (@= uaadb.name @) -c "CREATE EXTENSION citext"
+data: {}
 
 --- #@ template.replace(overlay.apply(library.get("postgres").eval(), add_cf_db_namespace()))
 #@ end

--- a/config/uaa/uaa.yml
+++ b/config/uaa/uaa.yml
@@ -4,6 +4,7 @@
 #@ load("@ytt:overlay", "overlay")
 #@ load("@ytt:template", "template")
 #@ load("@ytt:yaml", "yaml")
+#@ load("@ytt:base64", "base64")
 
 #@ def uaa_db_host():
 #@   if len(data.values.uaa.database.host) > 0:
@@ -385,3 +386,41 @@ spec:
         secret:
           secretName: uaa-encryption-key-config
 
+#@ def cfdb_enabled():
+#@   return len(data.values.uaa.database.host) == 0 or len(data.values.capi.database.host) == 0
+#@ end
+
+#@ if cfdb_enabled():
+#@overlay/match by=overlay.subset({"kind": "ConfigMap", "metadata":{"name":"cf-db-postgresql-init-scripts"}}),expects="0+"
+---
+#@ uaadb = data.values.uaa.database
+#@yaml/text-templated-strings
+data:
+  #@overlay/match missing_ok=True
+  uaadb_init.sh: |
+    #!/bin/bash
+    UAADB_USERNAME=$(cat /docker-entrypoint-initdb.d/secret/uaadb-username)
+    UAADB_PASSWORD=$(cat /docker-entrypoint-initdb.d/secret/uaadb-password)
+    cat > /tmp/setup_db.sql <<EOT
+    CREATE DATABASE (@= uaadb.name @);
+    CREATE ROLE ${UAADB_USERNAME} LOGIN PASSWORD '${UAADB_PASSWORD}';
+    EOT
+    psql -U postgres -f /tmp/setup_db.sql
+    psql -U postgres -d (@= uaadb.name @) -c "CREATE EXTENSION citext"
+
+#@overlay/match by=overlay.subset({"kind": "Secret", "metadata":{"name":"cf-db-credentials"}}),expects="0+"
+---
+#@overlay/match missing_ok=True
+data:
+  #@ if len(data.values.uaa.database.user) == 0:
+  #@  assert.fail("uaa.database.user cannot be empty")
+  #@ end
+  #@overlay/match missing_ok=True
+  uaadb-username: #@ base64.encode(data.values.uaa.database.user)
+  #@ if len(data.values.uaa.database.password) == 0:
+  #@  assert.fail("uaa.database.password cannot be empty")
+  #@ end
+  #@overlay/match missing_ok=True
+  uaadb-password: #@ base64.encode(data.values.uaa.database.password)
+
+#@ end

--- a/tests/ytt/uaa/uaa-values.yml
+++ b/tests/ytt/uaa/uaa-values.yml
@@ -27,8 +27,8 @@ uaa:
     port:
     name:
     ca_cert: ""
-    user:
-    password:
+    user: "foo"
+    password: "bar"
 
   jwt_policy:
     key_id: "some-key"
@@ -41,6 +41,8 @@ uaa:
     passphrase:
 
 capi:
+  database:
+    host: ""
   cc_username_lookup_client_secret:
   cf_api_controllers_client_secret:
 


### PR DESCRIPTION
This is a *refactor investigation* to see if there is a better pattern/approach to the problem of components injecting their database definitions into the postgres component.  Ideally, the postgres component would be more generic and configurable as-is.  We would like to get to a point where contributing components don't have to PR changes into the `cf-for-k8s/config/postgres` as this is less than desirable and sometimes not even possible; i.e. editions building on top of, or alongside cf-for-k8s.

This is a specific example of a more generic requirement to make components extensible to encourage re-use and composability of the cf-for-k8s as a platform.

NB: this still leaves components knowing about each other through the `cfdb_enabled` method (that looks to [have started proliferating](https://github.com/cloudfoundry/cf-for-k8s/blob/9340af45e0fbd3599e1c8c87269f99052fe11d64/config/networking/network-policies.yaml#L4)).  It seems reasonable that capi knows about uaa but not necessarily the other way around and it seems unlikely that networking components have a "real" dependency on either capi or uaa.  We should probably see if we can also refactor somehow, but I was treating it as a separate problem to this.