### PR TITLE
Skip minio installation if external blobstore is configured

### DIFF
--- a/config/kpack/kpack.yml
+++ b/config/kpack/kpack.yml
@@ -5,8 +5,11 @@
 #@ load("@ytt:overlay", "overlay")
 #@ load("@ytt:template", "template")
 
+#@ load("/minio/minio.star", "minio_enabled")
+
 #@ kpack = library.get("kpack")
 --- #@ template.replace(kpack.eval())
+#@ if minio_enabled():
 --- #! explanation: the blobstore's sidecar needs to accept plain text connections from kpack build init containers.
     #! see https://github.com/cloudfoundry/capi-k8s-release/issues/12
 apiVersion: security.istio.io/v1beta1
@@ -20,6 +23,7 @@ spec:
       app: minio
   mtls:
     mode: PERMISSIVE
+#@ end
 ---
 #! apiServer fails to validate certs provided by istio endpoints.
 #! traffic from apiServer to kpack-webhook is TLS even without istio

--- a/config/minio/minio.star
+++ b/config/minio/minio.star
@@ -1,0 +1,5 @@
+load("@ytt:data", "data")
+
+def minio_enabled():
+  return data.values.blobstore.endpoint == "http://cf-blobstore-minio.cf-blobstore.svc.cluster.local:9000"
+end

--- a/config/minio/minio.yml
+++ b/config/minio/minio.yml
@@ -4,6 +4,9 @@
 #@ load("@ytt:overlay", "overlay")
 #@ load("@ytt:template", "template")
 #@ load("must_exist.star", "must_exist")
+#@ load("minio.star", "minio_enabled")
+
+#@ if minio_enabled():
 
 #@ def add_cf_blobstore_namespace():
 #@overlay/match by=overlay.all, expects="1+"
@@ -28,3 +31,5 @@ data:
   secretkey: #@ base64.encode(must_exist(data.values, "blobstore.secret_access_key"))
 
 --- #@ template.replace(overlay.apply(library.get("minio").eval(), add_cf_blobstore_namespace()))
+
+#@ end

--- a/config/networking/network-policies.yaml
+++ b/config/networking/network-policies.yaml
@@ -1,9 +1,6 @@
 #@ load("@ytt:data", "data")
 #@ load("@ytt:overlay", "overlay")
-
-#@ def cfdb_enabled():
-#@   return len(data.values.uaa.database.host) == 0 or len(data.values.capi.database.host) == 0
-#@ end
+#@ load("/postgres/postgres.star", "cfdb_enabled")
 
 #@ def database_egress():
 to:

--- a/config/networking/network-policies.yaml
+++ b/config/networking/network-policies.yaml
@@ -1,6 +1,7 @@
 #@ load("@ytt:data", "data")
 #@ load("@ytt:overlay", "overlay")
 #@ load("/postgres/postgres.star", "cfdb_enabled")
+#@ load("/minio/minio.star", "minio_enabled")
 
 #@ def database_egress():
 to:
@@ -53,6 +54,7 @@ spec:
   policyTypes:
   - Ingress
 #@ end
+#@ if minio_enabled():
 ---
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
@@ -63,6 +65,7 @@ spec:
   podSelector: {}
   policyTypes:
   - Ingress
+#@ end
 ---
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
@@ -107,6 +110,7 @@ spec:
   - Ingress
   - Egress
 #@ end
+#@ if minio_enabled():
 ---
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
@@ -128,6 +132,7 @@ spec:
   policyTypes:
   - Ingress
   - Egress
+#@ end
 ---
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
@@ -166,6 +171,7 @@ spec:
   policyTypes:
   - Egress
 #@ end
+#@ if minio_enabled():
 ---
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
@@ -184,6 +190,7 @@ spec:
       port: 53
   policyTypes:
   - Egress
+#@ end
 #@ if cfdb_enabled():
 ---
 kind: NetworkPolicy
@@ -427,6 +434,7 @@ spec:
       job-name: ccdb-migrate
   egress:
   - #@ database_egress()
+#@ if minio_enabled():
 ---
 kind: NetworkPolicy
 apiVersion: networking.k8s.io/v1
@@ -477,6 +485,7 @@ spec:
       podSelector:
         matchLabels:
           app.kubernetes.io/name: cf-api-clock
+#@ end
 ---
 kind: NetworkPolicy
 apiVersion: networking.k8s.io/v1

--- a/tests/ytt/blobstore/blobstore-values.yml
+++ b/tests/ytt/blobstore/blobstore-values.yml
@@ -1,0 +1,12 @@
+#@data/values
+---
+blobstore:
+  endpoint: ""
+  region: ""
+  access_key_id: ""
+  secret_access_key: ""
+  package_directory_key: ""
+  droplet_directory_key: ""
+  resource_directory_key: ""
+  buildpack_directory_key: ""
+  aws_signature_version: ""

--- a/tests/ytt/external_blobstore_test.go
+++ b/tests/ytt/external_blobstore_test.go
@@ -1,0 +1,71 @@
+package ytt
+
+import (
+	. "code.cloudfoundry.org/yttk8smatchers/matchers"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("External Blobstore", func() {
+
+	var ctx RenderingContext
+	var data map[string]string
+	var templates []string
+
+	BeforeEach(func() {
+		templates = []string{
+			pathToFile("config/minio"),
+			pathToFile("tests/ytt/blobstore/blobstore-values.yml"),
+		}
+	})
+
+	JustBeforeEach(func() {
+		ctx = NewRenderingContext(templates...).WithData(data)
+	})
+
+	Context("disabled", func() {
+
+		BeforeEach(func() {
+			data = map[string]string{
+				"blobstore.endpoint":          "http://cf-blobstore-minio.cf-blobstore.svc.cluster.local:9000",
+				"blobstore.access_key_id":     "F4k3nuGo2PLQzN9ETk9VbNYx",
+				"blobstore.secret_access_key": "F4k3zsYvUUaVDlsWtFM1EJyH",
+			}
+		})
+
+		It("should have cf-blobstore namespace and cf-blobstore-minio deployment", func() {
+
+			Expect(ctx).To(ProduceYAML(
+				And(
+					WithNamespace("cf-blobstore"),
+					WithDeployment("cf-blobstore-minio", "cf-blobstore")),
+			))
+		})
+	})
+
+	Context("enabled", func() {
+
+		BeforeEach(func() {
+			data = map[string]string{
+				"blobstore.endpoint":                "https://s3.eu-central-1.amazonaws.com/",
+				"blobstore.region":                  "eu-central-1",
+				"blobstore.access_key_id":           "nuGo2PLQzN9ETk9VbNYxF4k3",
+				"blobstore.secret_access_key":       "ZsYvUUaVDlsWtFM1EJyHF4k3",
+				"blobstore.package_directory_key":   "cc-packages-dbf5",
+				"blobstore.droplet_directory_key":   "cc-droplets-dbf5",
+				"blobstore.resource_directory_key":  "cc-resources-dbf5",
+				"blobstore.buildpack_directory_key": "cc-buildpacks-dbf5",
+				"blobstore.aws_signature_version":   "4",
+			}
+		})
+
+		It("should not have cf-blobstore namespace and cf-blobstore-minio deployment", func() {
+
+			Expect(ctx).To(ProduceYAML(
+				And(
+					Not(WithNamespace("cf-blobstore")),
+					Not(WithDeployment("cf-blobstore-minio", "cf-blobstore")),
+				)))
+		})
+	})
+})


### PR DESCRIPTION
## WHAT is this change about?
With this PR, the installation of minio will be skipped if an external blobstore is configured. See #344 for details.

## Does this PR introduce a change to `config/values.yml`?
No

## Acceptance Steps
Install with external blobstore, ensure that no `cf-blobstore` namespace is created.

## Tag your pair, your PM, and/or team
@phil9909 
@loewenstein 