### PR TITLE
Fix network policies for eirini

### DIFF
--- a/config/networking/network-policies.yaml
+++ b/config/networking/network-policies.yaml
@@ -315,6 +315,12 @@ spec:
           cf-for-k8s.cloudfoundry.org/cf-system-ns: ""
     - podSelector:
         matchLabels:
+          name: eirini-task-reporter
+      namespaceSelector:
+        matchLabels:
+          cf-for-k8s.cloudfoundry.org/cf-system-ns: ""
+    - podSelector:
+        matchLabels:
           app: log-cache
       namespaceSelector:
         matchLabels:
@@ -533,7 +539,7 @@ metadata:
 spec:
   podSelector:
     matchLabels:
-      name: eirini-events-task-reporter
+      name: eirini-task-reporter
   egress:
   - {}
   policyTypes:
@@ -550,6 +556,23 @@ spec:
     matchLabels:
       name: eirini-controller
   egress:
+  - {}
+  policyTypes:
+  - Ingress
+  - Egress
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: eirini-instance-index-env-injector
+  namespace: #@ data.values.system_namespace
+spec:
+  podSelector:
+    matchLabels:
+      name: instance-index-env-injector
+  egress:
+  - {}
+  ingress:
   - {}
   policyTypes:
   - Ingress


### PR DESCRIPTION
## WHAT is this change about?
The new network policies released in v0.6.0 need some tweaking for eirini to function. Currently, eirini-task-reporter cannot connect to the kube api, and cf-api-server cannot receive calls from eirini-task-reporter.

Also a new eirini component, the instance-index-env-injector service needs a network policy to allow communication to and from the kube api.

## Does this PR introduce a change to `config/values.yml`?
No

## Acceptance Steps
- Fixes issue #375 so that tasks will show as complete once finished.
- App containers will have the CF_INSTANCE_INDEX env var set appropriately

## Tag your pair, your PM, and/or team
@cloudfoundry/eirini @mnitchev 


## Things to remember
- Make sure this PR is based off the `develop` branch
- Include any links to related PRs, issues, stories, slack discussions, etc... that will help establish context.
- Is there anything else of note that the reviewers should know about this change?
- Our CI uses concourse task files from HEAD of the `develop` branch. If your PR includes/requires CI changes, please ping the RelInt interrupt and they'll help apply the CI changes for you.
- Checkout the [contributing guidelines](https://github.com/cloudfoundry/cf-for-k8s/blob/develop/community/CONTRIBUTING.md)
