### PR TITLE
Allow ingress to cf-api-server from eirini-events

### DIFF
--- a/config/networking/network-policies.yaml
+++ b/config/networking/network-policies.yaml
@@ -321,6 +321,12 @@ spec:
           cf-for-k8s.cloudfoundry.org/cf-system-ns: ""
     - podSelector:
         matchLabels:
+          name: eirini-events
+      namespaceSelector:
+        matchLabels:
+          cf-for-k8s.cloudfoundry.org/cf-system-ns: ""
+    - podSelector:
+        matchLabels:
           app: log-cache
       namespaceSelector:
         matchLabels:


### PR DESCRIPTION
## WHAT is this change about?

When an app container crashes, eirini-events will report it to cf-api-server. Create rule to allow this in network policies.

## Does this PR introduce a change to `config/values.yml`?
No.

## Acceptance Steps
* Run the following:
  ```
  cf push catnip
  curl <catnip-url>/sigterm/KILL
  cf events catnip
  ```
* See crash events in the output

## Tag your pair, your PM, and/or team
@cloudfoundry/eirini 
