### PR TITLE
Make the docs simpler

### DIFF
--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -82,7 +82,7 @@ To be able to push source-code based apps to your cf-for-k8s installation, you w
    1. Generate certificates for the above domains and paste them in `crt`, `key`, `ca` values
       - **IMPORTANT** Your certificates must include a subject alternative name entry for the internal `*.cf-system.svc.cluster.local` domain in addition to your chosen external domain.
 
-1. To enable Cloud Native buildpacks feature, configure access to an external dockerhub registry in `cf-values.yml` you setup above in the section **Setup a a docker registry**
+1. Configure access to the dockerhub registry in `cf-values.yml` that you setup in the above section [Setup docker registry](#setup-a-docker-registry)
 
       ```yml
 

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -43,8 +43,8 @@ To deploy cf-for-k8s as is, the cluster should:
 To be able to push source-code based apps to your cf-for-k8s installation, you will need to add OCI compliant registry (e.g. hub.docker.com) to the configuration.
 
 [hub.docker.com](https://hub.docker.com/) is pretty easy to get started
-  1. Create an account in [hub.docker.com](https://hub.docker.com/). Note down the user name and password you used during signup.
-  1. Create a repository in your account. Note down the repository name.
+  1. Create an account in [hub.docker.com](https://hub.docker.com/). Note down the **username** and **password** you used during signup. You will use them in deployment steps below.
+  1. Create a repository in your account. Note down the **repository** name.
 
 ## Steps to deploy
 
@@ -82,7 +82,7 @@ To be able to push source-code based apps to your cf-for-k8s installation, you w
    1. Generate certificates for the above domains and paste them in `crt`, `key`, `ca` values
       - **IMPORTANT** Your certificates must include a subject alternative name entry for the internal `*.cf-system.svc.cluster.local` domain in addition to your chosen external domain.
 
-1. Configure access to the dockerhub registry in `cf-values.yml` that you setup in the above section [Setup docker registry](#setup-a-docker-registry)
+1. Copy the following configuration to add the dockerhub registry in `${TMP_DIR}/cf-values.yml`. 
 
       ```yml
 
@@ -94,8 +94,7 @@ To be able to push source-code based apps to your cf-for-k8s installation, you w
 
       ```
 
-      1. Update `<my_username>` with your docker username.
-      1. Update `<my_password>` with your docker password.
+      Update `<my_username>` and `<my_password>` with your docker username and password that you created in the above section [Setup docker registry](#setup-a-docker-registry).
 
 1. Run the following commands to install Cloud Foundry on your Kubernetes cluster.
 
@@ -171,38 +170,20 @@ To be able to push source-code based apps to your cf-for-k8s installation, you w
    ```console
    cf push test-node-app -p tests/smoke/assets/test-node-app
    ```
+   
+   You should she the following output from the above command
 
    ```console
    Pushing app test-node-app to org test-org / space test-space as admin...
    Getting app info...
    Creating app with these attributes...
-
-   name: test-node-app
-   path: /Users/pivotal/workspace/cf-for-k8s/tests/smoke/assets/test-node-app
-   routes: test-node-app.<cf-domain>
-
-   Creating app test-node-app...
-   Mapping routes...
-   Comparing local files to remote cache...
-   Packaging files to upload...
-   Uploading files...
-
-   .... logs omitted for brevity
-
-
-   Waiting for app to start...
-
-   name: test-node-app
-   requested state: started
-   isolation segment: placeholder
-   routes: test-node-app.<cf-domain>
-   last uploaded: Tue 17 Mar 19:24:21 PDT 2020
-   stack:
-   buildpacks:
-
+    
+   ... omitted for brevity ...
+    
    type: web
    instances: 1/1
    memory usage: 1024M
+   routes: test-node-app.<cf-domain>
    state since cpu memory disk details
    #0 running 2020-03-18T02:24:51Z 0.0% 0 of 1G 0 of 1G
    ```
@@ -212,10 +193,10 @@ To be able to push source-code based apps to your cf-for-k8s installation, you w
 1. Validate the app is reachable over **https**
 
    ```console
-   # for self-signed certs, use -k to allow insecure server connections when using SSL
-   curl -k https://test-node-app.<cf-domain>
+   curl -Lk https://test-node-app.<cf-domain>
    ```
 
+   You should she the following output
    ```console
    Hello World
    ```
@@ -225,7 +206,6 @@ To be able to push source-code based apps to your cf-for-k8s installation, you w
 You can delete the cf-for-k8s deployment by running the following command.
 
    ```console
-   # Assuming that you ran `kapp deploy -a cf...`
    kapp delete -a cf
    ```
 

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -1,16 +1,18 @@
 # Deploying Cloud Foundry on a Kubernetes cluster
 
-- [Prerequisites](#prerequisites)
-  - [Required Tools](#required-tools)
-  - [Kubernetes Cluster Requirements](#kubernetes-cluster-requirements)
-  - [Setup an OCI-compliant registry](#setup-an-oci-compliant-registry)
-- [Steps to deploy](#steps-to-deploy)
-  - [Option A - Use the included hack-script to generate the install values](#option-a---use-the-included-hack-script-to-generate-the-install-values)
-  - [Option B - Create the install values by hand](#option-b---create-the-install-values-by-hand)
-- [Validate the deployment](#validate-the-deployment)
-- [Delete the cf-for-k8s deployment](#delete-the-cf-for-k8s-deployment)
-- [Additional Resources](#additional-resources)
-- [Roadmap and milestones](#roadmap-and-milestones)
+* [Prerequisites](#prerequisites)
+  + [Required Tools](#required-tools)
+  + [Kubernetes Cluster Requirements](#kubernetes-cluster-requirements)
+  + [Setup an OCI-compliant registry](#setup-an-oci-compliant-registry)
+* [Steps to deploy](#steps-to-deploy)
+    - [Option A - Use the included hack-script to generate the install values(#option-a---use-the-included-hack-script-to-generate-the-install-values)
+    - [Option B - Create the install values by hand](#option-b---create-the-install-values-by-hand)
+* [Validate the deployment](#validate-the-deployment)
+* [Delete the cf-for-k8s deployment](#delete-the-cf-for-k8s-deployment)
+* [Additional resources](#additional-resources)
+* [Roadmap and milestones](#roadmap-and-milestones)
+
+<small><i><a href='http://ecotrust-canada.github.io/markdown-toc/'>Table of contents generated with markdown-toc</a></i></small>
 
 ## Prerequisites
 

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -18,10 +18,12 @@
 
 You need the following CLIs on your system to be able to run the script:
 
-- [`cf cli`](https://docs.cloudfoundry.org/cf-cli/install-go-cli.html) (v6.50+)
-- [`kapp`](https://k14s.io/#install)
-- [`ytt`](https://k14s.io/#install)
+- `ytt` [install link](https://k14s.io/#install) [github repo](https://github.com/k14s/ytt)
+  - cf-for-k8s uses `ytt` to create and maintain reusable YAML templates. You can visit the ytt [playground](https://get-ytt.io/) to learn more about its templating features.
+- `kapp` [install link](https://k14s.io/#install) [github repo](https://github.com/k14s/kapp)
+  - cf-for-k8s uses `kapp` to manage its lifecycle. `kapp` will first show you a list of resources it plans to install on the cluster and then will attempt to install those resources. `kapp` will not exit until all resources are deployed and their status is running. See all options by running `kapp help`.
 - [`kubectl`](https://kubernetes.io/docs/tasks/tools/install-kubectl/)
+- [`cf cli`](https://docs.cloudfoundry.org/cf-cli/install-go-cli.html) (v7+)
 
 > Make sure that your Kubernetes config (e.g, `~/.kube/config`) is pointing to the cluster you intend to deploy cf-for-k8s to.
 
@@ -33,8 +35,7 @@ To deploy cf-for-k8s as is, the cluster should:
 - have a minimum of 5 nodes
 - have a minimum of 4 CPU, 15GB memory per node
 - support `LoadBalancer` services
-- support `metrics-server`
-  - most IaaSes come with `metrics-server`, but if yours does not come (for example, if you are using `kind`), you will need to include `add_metrics_server_components: true` in your values file.
+- most IaaSes come with `metrics-server`, but if yours does not come with one (for example, if you are using `kind`), you will need to include `add_metrics_server_components: true` in your values file.
 - defines a default StorageClass
   - requires [additional config on vSphere](https://vmware.github.io/vsphere-storage-for-kubernetes/documentation/storageclass.html), for example
 
@@ -88,7 +89,7 @@ Currently, we test the following two container registries:
    1. Generate certificates for the above domains and paste them in `crt`, `key`, `ca` values
       - **IMPORTANT** Your certificates must include a subject alternative name entry for the internal `*.cf-system.svc.cluster.local` domain in addition to your chosen external domain.
 
-1. Configure an external app registry:
+1. Provide your credentials to an external app registry:
 
       1. To configure Dockerhub.com, add the following registry config block to the end of `cf-values.yml` file:
 
@@ -233,8 +234,8 @@ Use the following resources to enable additional features in cf-for-k8s:
 
 - [Setup ingress certs with letsencrypt](platform_operators/setup-ingress-certs-with-letsencrypt.md)
 - [Setup static loadbalancer IP](platform_operators/setup-static-loadbalancer-ip.md)
-- [Setup an external database](platform_operators/external-databases.md)
+- [Setup an external database](platform_operators/external-databases.md), which we recommend for Production environments
 - [Setup an external blobstore](platform_operators/external-blobstore.md)
 
 ## Roadmap and milestones
-Please take a moment to review the [roadmap](https://github.com/cloudfoundry/cf-for-k8s/projects/4) and our upcoming [milestones](https://github.com/cloudfoundry/cf-for-k8s/milestones). Feel free to ask questions or submit new feature requests or issues.
+You can find the project roadmap (github project) [here](https://github.com/cloudfoundry/cf-for-k8s/projects/4) and our upcoming milestones [here]](https://github.com/cloudfoundry/cf-for-k8s/milestones). Feel free to ask questions in the [#cf-for-k8s channel](https://cloudfoundry.slack.com/archives/CH9LF6V1P) in the CloudFoundry slack or submit new feature requests or issues on this repo.


### PR DESCRIPTION
## WHAT is this change about?
- Remove unnecessary distractions
- Reduce the number of options and instead choose the easiest option (e.g. dockerhub over gcr/acr)
- Add roadmap/milestones at the end

## Acceptance Steps
Running through the steps should install a successful cf-for-k8s
