### PR TITLE
Remove metric_proxy certs from sample values file

### DIFF
--- a/sample-cf-install-values.yml
+++ b/sample-cf-install-values.yml
@@ -95,15 +95,6 @@ log_cache_syslog:
   crt: log_cache_syslog_certificate
   key: log_cache_syslog_private_key
 
-metric_proxy:
-  ca:
-    crt: *crt
-    key: *key
-  cert:
-    #! This certificate should be valid for metric-proxy.cf-system.svc.cluster.local
-    crt: *crt
-    key: *key
-
 uaa:
   database:
     #! The db password shared between UAA and the database.


### PR DESCRIPTION
[#173597144]

## WHAT is this change about?
Remove metric_proxy from sample values file now that TLS has been removed here: https://github.com/cloudfoundry/cf-for-k8s/pull/391

## Does this PR introduce a change to `config/values.yml`?
No
