### PR TITLE
Fix links in docs/maintaining.md

### DIFF
--- a/docs/maintaining.md
+++ b/docs/maintaining.md
@@ -4,11 +4,11 @@ This document is intended for cf-for-k8s maintainers.
 
 ## Dependencies
 
-see "Dependencies" in [docs/contributing.md](/docs/contributing.md#dependencies).
+see "Dependencies" in [community/PREPARING-FOR-DEVELOPMENT.md](/community/PREPARING-FOR-DEVELOPMENT.md#dependencies).
 
 ## Smoke tests
 
-see "Running Smoke Tests" in [docs/contributing.md](/docs/contributing.md#running-smoke-tests).
+see "Running Smoke Tests" in [community/PREPARING-FOR-DEVELOPMENT.md](/community/PREPARING-FOR-DEVELOPMENT.md#running-smoke-tests).
 
 ## Directory structure
 


### PR DESCRIPTION
## WHAT is this change about?
Just a simple docs update, fixing links that appear to be broken by this file change: docs/contributing.md -> community/CONTRIBUTING.md. Also curious whether this file itself shouldn't be merged with [community/MAINTAINING.md](https://github.com/cloudfoundry/cf-for-k8s/blob/fed095d55e948d9d6a5536fb56ee0b9d13a0c0dd/community/MAINTAINERS.md)?

## Does this PR introduce a change to `config/values.yml`?
No

## Acceptance Steps
N/A
