### PR TITLE
Kapp rebase rules

### DIFF
--- a/config/kapp-rebase-rules.yml
+++ b/config/kapp-rebase-rules.yml
@@ -4,44 +4,18 @@ kind: Config
 metadata:
   name: "kapp-config"
 rebaseRules:
-- path: [webhooks, {allIndexes: true}, rules]
-  type: copy
-  sources: [new, existing]
-  resourceMatchers: &kpack_webhook
-  - apiVersionKindMatcher:
-      apiVersion: admissionregistration.k8s.io/v1beta1
-      kind: MutatingWebhookConfiguration
-      name: resource.webhook.kpack.pivotal.io
+- paths:
+  - [metadata, annotations]
+  - [webhooks, {allIndexes: true}, rules]
+  - [webhooks, {allIndexes: true}, namespaceSelector]
+  - [webhooks, {allIndexes: true}, clientConfig, service, path]
+  - [webhooks, {allIndexes: true}, sideEffects]
+  - [webhooks, {allIndexes: true}, timeoutSeconds]
 
-- path: [metadata, annotations]
   type: copy
   sources: [new, existing]
   resourceMatchers:
   - apiVersionKindMatcher:
-      apiVersion: v1
-      kind: ServiceAccount
-
-- path: [metadata, annotations]
-  type: copy
-  sources: [new, existing]
-  resourceMatchers: *kpack_webhook
-
-- path: [webhooks, {allIndexes: true}, namespaceSelector]
-  type: copy
-  sources: [new, existing]
-  resourceMatchers: *kpack_webhook
-
-- path: [webhooks, {allIndexes: true}, clientConfig, service, path]
-  type: copy
-  sources: [new, existing]
-  resourceMatchers: *kpack_webhook
-
-- path: [webhooks, {allIndexes: true}, sideEffects]
-  type: copy
-  sources: [new, existing]
-  resourceMatchers: *kpack_webhook
-
-- path: [webhooks, {allIndexes: true}, timeoutSeconds]
-  type: copy
-  sources: [new, existing]
-  resourceMatchers: *kpack_webhook
+      apiVersion: admissionregistration.k8s.io/v1beta1
+      kind: MutatingWebhookConfiguration
+      name: resource.webhook.kpack.pivotal.io

--- a/config/kapp-rebase-rules.yml
+++ b/config/kapp-rebase-rules.yml
@@ -4,29 +4,6 @@ kind: Config
 metadata:
   name: "kapp-config"
 rebaseRules:
-- path: [metadata, annotations, pv.kubernetes.io/bind-completed]
-  type: copy
-  sources: [existing]
-  resourceMatchers: &pvcs
-  - apiVersionKindMatcher:
-      apiVersion: v1
-      kind: PersistentVolumeClaim
-
-- path: [metadata, annotations, pv.kubernetes.io/bound-by-controller]
-  type: copy
-  sources: [existing]
-  resourceMatchers: *pvcs
-
-- path: [metadata, annotations, volume.beta.kubernetes.io/storage-provisioner]
-  type: copy
-  sources: [existing]
-  resourceMatchers: *pvcs
-
-- path: [spec, volumeMode]
-  type: copy
-  sources: [new, existing]
-  resourceMatchers: *pvcs
-
 - path: [webhooks, {allIndexes: true}, rules]
   type: copy
   sources: [new, existing]
@@ -68,11 +45,3 @@ rebaseRules:
   type: copy
   sources: [new, existing]
   resourceMatchers: *kpack_webhook
-
-- path: [spec, healthCheckNodePort]
-  type: copy
-  sources: [new, existing]
-  resourceMatchers:
-  - apiVersionKindMatcher:
-      apiVersion: v1
-      kind: Service


### PR DESCRIPTION
## WHAT is this change about?
Refactor the kapp rebase rules to be more concise given the updates kapp has gotten since the previous minimum version. Functionally, the rebase rules should remain unchanged.

## Does this PR introduce a change to `config/values.yml`?
No.

## Acceptance Steps
Following the deployment docs continues to work normally. After that try redeploying with the same yaml and notice that the deployment succeeds again. (Even if it currently reports a diff in service accounts for which we do not yet have a rebase rule as mentioned in issue #110 .

## Tag your pair, your PM, and/or team
cc @cloudfoundry/cf-release-integration 
