### PR TITLE
Move CF API internal endpoints to a different port

### DIFF
--- a/config/capi/_ytt_lib/capi-k8s-release/templates/api_server_deployment.yml
+++ b/config/capi/_ytt_lib/capi-k8s-release/templates/api_server_deployment.yml
@@ -77,11 +77,34 @@ spec:
           #@ if/end data.values.ccdb.ca_cert:
           - name: database-ca-cert
             mountPath: /config/database/certs
+        - name: package-image-uploader
+          image: #@ data.values.images.package_image_uploader
+          imagePullPolicy: Always
+          securityContext:
+            runAsUser: 0
+          readinessProbe:
+            tcpSocket:
+              port: 8080
+          volumeMounts:
+          - name: nginx-uploads
+            mountPath: /tmp/uploads
+          env:
+          - name: REGISTRY_USERNAME
+            valueFrom:
+              secretKeyRef:
+                name: cc-package-registry-upload-secret
+                key: username
+          - name: REGISTRY_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: cc-package-registry-upload-secret
+                key: password
         - name: nginx
           image: #@ data.values.images.nginx
           imagePullPolicy: Always
           ports:
           - containerPort: 80
+          - containerPort: 9023
           readinessProbe:
             httpGet:
               port: 80

--- a/config/capi/_ytt_lib/capi-k8s-release/templates/cc-kpack-registry-service-account.yml
+++ b/config/capi/_ytt_lib/capi-k8s-release/templates/cc-kpack-registry-service-account.yml
@@ -19,3 +19,15 @@ type: kubernetes.io/basic-auth
 stringData:
   username: #@ data.values.kpack.registry.username
   password: #@ data.values.kpack.registry.password
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: cc-package-registry-upload-secret
+  namespace: #@ data.values.system_namespace
+  annotations:
+    build.pivotal.io/docker: #@ data.values.kpack.registry.hostname
+type: kubernetes.io/basic-auth
+stringData:
+  username: #@ data.values.kpack.registry.username
+  password: #@ data.values.kpack.registry.password

--- a/config/capi/_ytt_lib/capi-k8s-release/templates/ccng-config.lib.yml
+++ b/config/capi/_ytt_lib/capi-k8s-release/templates/ccng-config.lib.yml
@@ -15,6 +15,7 @@ fluent:
   port: 24224
 
 internal_service_hostname: #@ "capi.{}.svc.cluster.local".format(data.values.system_namespace)
+internal_service_port: 9023
 
 pid_filename: /cloud_controller_ng/cloud_controller_ng.pid
 newrelic_enabled: false
@@ -192,13 +193,14 @@ packages:
     path_style: true
   max_valid_packages_stored: 5
   max_package_size: 1073741824
-
-  cdn:
-    uri:
-    key_pair_id:
-    private_key: ""
-
   fog_aws_storage_options: {}
+  image_registry: {
+    base_path: #@ data.values.kpack.registry.repository_prefix
+  }
+
+package_image_uploader:
+  host: 127.0.0.1
+  port: 8080
 
 droplets:
   droplet_directory_key: #@ data.values.blobstore.droplet_directory_key

--- a/config/capi/_ytt_lib/capi-k8s-release/templates/nginx-configmap.yml
+++ b/config/capi/_ytt_lib/capi-k8s-release/templates/nginx-configmap.yml
@@ -28,10 +28,12 @@ data:
       }
 
       server {
-          # TODO: get TLS working
-          # include nginx_server_mtls.conf;
-
           listen 80;
+
+          # Prevent access to internal endpoints
+          location ~ /(internal|staging)/ {
+            return 403 'Forbidden';
+          }
 
           # TODO: move to a separate file and `include` like capi-release?
           # proxy and log all CC traffic
@@ -45,7 +47,6 @@ data:
             proxy_connect_timeout       10;
             proxy_pass                  http://cloud_controller;
           }
-
           location @cc_uploads {
             proxy_pass http://cloud_controller;
           }
@@ -64,6 +65,21 @@ data:
 
             upload_pass_args on;
             upload_pass_form_field "^resources$";
+          }
+      }
+
+      server {
+          listen 9023;
+
+          location /internal/v4/ {
+            access_log  /cloud_controller_ng/nginx-access.log;
+            proxy_buffering             off;
+            proxy_set_header            Host $host;
+            proxy_set_header            X-Real_IP $remote_addr;
+            proxy_set_header            X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_redirect              off;
+            proxy_connect_timeout       10;
+            proxy_pass http://cloud_controller;
           }
       }
     }

--- a/config/capi/_ytt_lib/capi-k8s-release/templates/service.yml
+++ b/config/capi/_ytt_lib/capi-k8s-release/templates/service.yml
@@ -11,5 +11,9 @@ spec:
       targetPort: 80
       protocol: TCP
       name: http
+    - port: 9023
+      targetPort: 9023
+      protocol: TCP
+      name: http-internal
   selector:
     app.kubernetes.io/name: cf-api-server

--- a/config/capi/_ytt_lib/capi-k8s-release/values/images.yml
+++ b/config/capi/_ytt_lib/capi-k8s-release/values/images.yml
@@ -1,11 +1,11 @@
 #@data/values
 ---
 images:
-  ccng: cloudfoundry/cloud-controller-ng@sha256:36c889a7188d9c36b8c6230226a87330c5baa2207b8ab5e82d49f40f6061351a
-  cf_api_controllers: cloudfoundry/cf-api-controllers@sha256:afe5933b8d97fe91e6aa6f7b8ec79a478df2838d56ac2736982b61b86dafbe25
+  ccng: cloudfoundry/cloud-controller-ng@sha256:f0f043ddfc33c57d7506a12f5cd143507e6ea222605c097cfe102012bd18825f
+  cf_api_controllers: cloudfoundry/cf-api-controllers@sha256:9cd6557f411c42b2bafe8487f63fae608f0dafd9f56c4268de8ec6fcd88ff7d9
   cf_autodetect_builder: cloudfoundry/cnb:0.0.94-bionic@sha256:5b03a853e636b78c44e475bbc514e2b7b140cc41cca8ab907e9753431ae8c0b0
   nginx: cloudfoundry/capi-nginx@sha256:980f50e190cbff72d23300bc422da23faa888271c2d07ac3abaa65af55a5316a
-  package_image_uploader: cloudfoundry/cf-api-package-image-uploader
+  package_image_uploader: cloudfoundry/cf-api-package-image-uploader@sha256:aae727a0960d10ce644035dee7041f7e882c7c58a37992252002ce7c95d8804d
   statsd_exporter: oratos/statsd_exporter:v0.15.0@sha256:10a64dc4ad0a3e3fe88372f0481dea5c02595c38d168617836a99a649d3ac407
 kbld:
   destination: null

--- a/config/eirini/eirini.yml
+++ b/config/eirini/eirini.yml
@@ -56,7 +56,7 @@ data:
   .dockerconfigjson: #@ base64.encode(json.encode({"auths": {data.values.app_registry.hostname: docker_creds}}))
 
 #@ def events():
-cc_internal_api: #@ "http://capi.{}.svc.cluster.local:80".format(data.values.system_namespace)
+cc_internal_api: #@ "http://capi.{}.svc.cluster.local:9023".format(data.values.system_namespace)
 #@ end
 
 #@ def opi():

--- a/config/networking/istio-authorization-policies.yml
+++ b/config/networking/istio-authorization-policies.yml
@@ -1,0 +1,37 @@
+#@ load("@ytt:data","data")
+
+#@ def principal(namespace, service_account):
+#@   return "cluster.local/ns/{}/sa/{}".format(namespace, service_account)
+#@ end
+
+#! https://istio.io/latest/docs/reference/config/security/authorization-policy/
+---
+apiVersion: security.istio.io/v1beta1
+kind: AuthorizationPolicy
+metadata:
+  name: default-allow-all
+  namespace: #@ data.values.system_namespace
+spec:
+  rules:
+    - {}
+---
+apiVersion: security.istio.io/v1beta1
+kind: AuthorizationPolicy
+metadata:
+  name: cf-api-server
+  namespace: #@ data.values.system_namespace
+spec:
+  action: DENY
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: cf-api-server
+  rules:
+    - from:
+        - source:
+            notPrincipals:
+            - #@ principal(data.values.system_namespace, "eirini-events")
+            - #@ principal(data.values.system_namespace, "eirini-task-reporter")
+      to:
+        - operation:
+            paths:
+            - "/internal*"

--- a/config/networking/network-policies.yaml
+++ b/config/networking/network-policies.yaml
@@ -315,6 +315,16 @@ spec:
           cf-for-k8s.cloudfoundry.org/cf-system-ns: ""
     - podSelector:
         matchLabels:
+          app: log-cache
+      namespaceSelector:
+        matchLabels:
+          cf-for-k8s.cloudfoundry.org/cf-system-ns: ""
+    ports:
+      - protocol: TCP
+        port: 80
+  - from:
+    - podSelector:
+        matchLabels:
           name: eirini-task-reporter
       namespaceSelector:
         matchLabels:
@@ -325,12 +335,9 @@ spec:
       namespaceSelector:
         matchLabels:
           cf-for-k8s.cloudfoundry.org/cf-system-ns: ""
-    - podSelector:
-        matchLabels:
-          app: log-cache
-      namespaceSelector:
-        matchLabels:
-          cf-for-k8s.cloudfoundry.org/cf-system-ns: ""
+    ports:
+    - protocol: TCP
+      port: 9023  
   egress:
   - {}
 ---

--- a/vendir.lock.yml
+++ b/vendir.lock.yml
@@ -2,8 +2,8 @@ apiVersion: vendir.k14s.io/v1alpha1
 directories:
 - contents:
   - git:
-      commitTitle: images.yml updated by CI...
-      sha: 7f2ceb55e07af35da0b830b25e7322994ef5b879
+      commitTitle: prevent access to internal cf-api endpoints...
+      sha: 126a3c64b475c5948e5a602b69ce1aba8a51cf16
     path: .
   path: config/capi/_ytt_lib/capi-k8s-release
 - contents:

--- a/vendir.yml
+++ b/vendir.yml
@@ -8,7 +8,7 @@ directories:
   - path: .
     git:
       url: https://github.com/cloudfoundry/capi-k8s-release
-      ref: 7f2ceb55e07af35da0b830b25e7322994ef5b879
+      ref: secure-cf-api-internal-endpoints-174455375
     includePaths:
     - templates/**/*
     - values/**/*


### PR DESCRIPTION
##  WHAT is this change about?
We are moving the CF API internal endpoints to a separate port (one that is not exposed externally) and layering on some security mechanisms (`NetworkPolicy`, Istio `AuthorizationPolicy`) to protect them.

## Does this PR introduce a change to `config/values.yml`?
No

## Acceptance Steps
See linked story

### Expected
The call fails with a `403 Forbidden` error

### Actual
The call succeeds

## Tag your pair, your PM, and/or team
@cloudfoundry/cf-capi 

## Things to remember
- CAPI Story [#174455375](https://www.pivotaltracker.com/story/show/174455375)
