### PR TITLE
Allow Istio loadBalancerSourceRanges to be configured

### DIFF
--- a/config/networking/external-routing.yml
+++ b/config/networking/external-routing.yml
@@ -47,3 +47,12 @@ spec:
   #@overlay/match missing_ok=True
   loadBalancerIP: #@ data.values.istio_static_ip
 #@ end
+
+#! This will restrict traffic through the cloud-provider load-balancer to the specified client IPs
+#@overlay/match by=overlay.subset({"kind": "Service", "metadata":{"name": "istio-ingressgateway"}})
+---
+#@ if data.values.istio_source_ranges:
+spec:
+  #@overlay/match missing_ok=True
+  loadBalancerSourceRanges: #@ data.values.istio_source_ranges
+#@ end

--- a/config/values/00-values.yml
+++ b/config/values/00-values.yml
@@ -11,6 +11,9 @@ cf_admin_password:
 #! reserved static ip for istio LoadBalancer
 istio_static_ip: ""
 
+#! restrict traffic for istio LoadBalancer to the specified IPs
+istio_source_ranges: []
+
 system_certificate:
   #! Base64-encoded certificate for the wildcard
   #! subdomain of the system domain (e.g., CN=*.system.cf.example.com)

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -276,3 +276,4 @@ Use the following resources to enable additional features in cf-for-k8s.
 
 - [Setup ingress certs with letsencrypt](platform_operators/setup-ingress-certs-with-letsencrypt.md)
 - [Setup static loadbalancer IP](platform_operators/setup-static-loadbalancer-ip.md)
+- [Define loadbalancer firewalls](platform_operators/define-loadbalancer-firewalls.md)

--- a/docs/platform_operators/define-loadbalancer-firewalls.md
+++ b/docs/platform_operators/define-loadbalancer-firewalls.md
@@ -1,0 +1,51 @@
+# Configure Cloud Provider's Firewalls for Istio Loadbalancer
+
+## Objective
+
+At end of this setup, you will be able to install cf-for-k8s with a loadbalancer that is only accessible to clients with the specific IP addresses.
+
+## Prerequisites
+
+- Cluster should support `LoadBalancer` services.
+
+## Steps to setup cloud provider firewalls
+
+The following instructions assume you have created `cf-install-values.yml`.
+
+1. Add `istio_source_ranges` key and the IP ranges that are allowed to access the load balancer to your `cf-install-values.yml`
+
+    > Note that the append annotation must be applied to each item you want to insert.
+
+    ```yaml
+    istio_source_ranges:
+    #@overlay/append
+    - "130.211.204.1/32"
+    #@overlay/append
+    - "130.211.204.2/32"
+    ```
+
+1. Follow the instructions from [deploy doc](../deploy.md) to generate the final deploy yml using `ytt` and then `kapp` deploy cf-for-k8s to your cluster.
+
+## Verify the cloud provider firewalls configuration
+
+1. Lookup the Loadbalancer firewall configuration. It should match the IP ranges you used above.
+
+    ```console
+    $ aws ec2 describe-security-groups --group-ids sg-06a0361d9ad14535f --output yaml
+    SecurityGroups:
+    - Description: Security group for Kubernetes ELB a73958422feb34578a87bc2185e739c8
+        (istio-system/istio-ingressgateway)
+      GroupId: sg-06a0361d9ad14535f
+      GroupName: k8s-elb-a73958422feb34578a87bc2185e739c8
+      IpPermissions:
+      - FromPort: 80
+        IpProtocol: tcp
+        IpRanges:
+        - CidrIp: 130.211.204.1/32
+        - CidrIp: 130.211.204.2/32
+        Ipv6Ranges: []
+        PrefixListIds: []
+        ToPort: 80
+        UserIdGroupPairs: []
+    ...
+    ```

--- a/docs/platform_operators/deploy-parameters.md
+++ b/docs/platform_operators/deploy-parameters.md
@@ -4,6 +4,7 @@
 | app_domains | list of app domains | Yes | no value | ["apps.cf.example.com"] | |
 | cf_admin_password | password for admin user in plain text | Yes | no value | 2fK2zLXPgvmsESrB87sADZQvdLeY5Kv4 | |
 | istio_static_ip | reserved static ip for istio LoadBalancer | No | no value | "192.168.0.0" | |
+| istio_source_ranges | restrict traffic for istio LoadBalancer to the specified IPs | No | no value | ["10.10.0.0/16"] | |
 | system_certificate.crt | Base64-encoded certificate for the wildcard - subdomain of the system domain | Yes | no value | CN=*.system.cf.example.com |  |
 | system_certificate.key | Base64-encoded private key for the system certificate | Yes | no value |  |  |
 | system_certificate.ca | Base64-encoded CA certificate used to sign the system certifcate | Yes | no value |  |  |


### PR DESCRIPTION
## WHAT is this change about?

Allow to install cf-for-k8s with a loadbalancer that is only accessible to clients with the specific IP addresses. This configuration will be ignored if the cloud-provider does not support the feature.

https://v1-17.docs.kubernetes.io/docs/tasks/access-application-cluster/configure-cloud-provider-firewall/

## Does this PR introduce a change to `config/values/00-values.yml`?

Yes.

## Acceptance Steps

Please follow the steps from the document which is part of this PR.