### PR TITLE
remove capi eirini cert config

### DIFF
--- a/config/capi/capi.yml
+++ b/config/capi/capi.yml
@@ -43,16 +43,6 @@ ccdb:
   database: #@ data.values.capi.database.name
   ca_cert: #@ data.values.capi.database.ca_cert
 
-eirini:
-  serverCerts:
-    secretName: eirini-internal-tls-certs
-
-apiServer:
-  opi:
-    client_cert: #@ data.values.internal_certificate.crt
-    client_key: #@ data.values.internal_certificate.key
-    ca: #@ data.values.internal_certificate.ca
-
 uaa:
   serverCerts:
     secretName: uaa-certs


### PR DESCRIPTION
this allows us to remove cert configuration and bogus defaults from capi-k8s-release default values files.


## WHAT is this change about?
This removes a few unnecessary properties from capi.yml that used to configure TLS communication between CAPI and eirini.

## Does this PR introduce a change to `config/values.yml`?
No.

## Acceptance Steps
It should deploy without a hitch. After this is merged, please poke us to merge cloudfoundry/capi-k8s-release#68 .
