### PR TITLE
remove HPA and fix istiod replicas to 1

### DIFF
--- a/config/istio/remove-hpas-and-scale-istiod.yml
+++ b/config/istio/remove-hpas-and-scale-istiod.yml
@@ -1,0 +1,13 @@
+#@ load("@ytt:overlay", "overlay")
+
+#@ load("@ytt:data", "data")
+
+#@overlay/match by=overlay.subset({"kind":"HorizontalPodAutoscaler"}), expects="1+"
+#@overlay/remove
+---
+
+#@overlay/match by=overlay.subset({"kind": "Deployment", "metadata":{"name":"istiod"}}),expects=1
+---
+spec:
+  #@overlay/match missing_ok=True
+  replicas: 1


### PR DESCRIPTION
Co-authored-by: Kauana dos Santos <kdossantos@vmware.com>
Co-authored-by: Alex Standke <astandke@vmware.com>
Co-authored-by: Clay Kauzlaric <ckauzlaric@vmware.com>
Co-authored-by: Nitya Dhanushkodi <ndhanushkodi@pivotal.io>

## WHAT is this change about?
- the ingressgateway one does not function, because we deploy a
daemonset
- we know from previous research that hpas do not help overloaded
pilot/istiods
- defaults to 1 istiod for proof-of-concept/local deployments

[#174764287](https://www.pivotaltracker.com/story/show/174764287)


## Does this PR introduce a change to `config/values.yml`?
No

## Acceptance Steps
When I deploy cf-for-k8s with this PR
I can see that istiod has 1 replica with `kubectl get pods -n istio-system`

## Tag your pair, your PM, and/or team
@kauana @KauzClay @XanderStrike 

