### PR TITLE
bump capi-k8s-release to use OCI registry for packages

### DIFF
--- a/config/capi/_ytt_lib/capi-k8s-release/templates/api_server_deployment.yml
+++ b/config/capi/_ytt_lib/capi-k8s-release/templates/api_server_deployment.yml
@@ -46,6 +46,8 @@ spec:
           - #@ template.replace(shared_config_volume_mounts())
           - name: server-sock
             mountPath: /data/cloud_controller_ng
+          - name: nginx-uploads
+            mountPath: /tmp/uploads
           #@ if/end data.values.uaa.serverCerts.secretName:
           - name: uaa-certs
             mountPath: /config/uaa/certs
@@ -74,9 +76,33 @@ spec:
           - #@ template.replace(shared_config_volume_mounts())
           - name: nginx-uploads
             mountPath: /tmp/uploads
+          - name: tmp-packages
+            mountPath: /tmp/packages
           #@ if/end data.values.ccdb.ca_cert:
           - name: database-ca-cert
             mountPath: /config/database/certs
+        - name: package-image-uploader
+          image: #@ data.values.images.package_image_uploader
+          imagePullPolicy: Always
+          securityContext:
+            runAsUser: 0
+          readinessProbe:
+            tcpSocket:
+              port: 8080
+          volumeMounts:
+          - name: tmp-packages
+            mountPath: /tmp/packages
+          env:
+          - name: REGISTRY_USERNAME
+            valueFrom:
+              secretKeyRef:
+                name: cc-package-registry-upload-secret
+                key: username
+          - name: REGISTRY_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: cc-package-registry-upload-secret
+                key: password
         - name: nginx
           image: #@ data.values.images.nginx
           imagePullPolicy: Always
@@ -124,5 +150,7 @@ spec:
         secret:
           secretName: database-ca-cert
       - name: nginx-uploads
+        emptyDir: {}
+      - name: tmp-packages
         emptyDir: {}
 

--- a/config/capi/_ytt_lib/capi-k8s-release/templates/cc-kpack-registry-service-account.yml
+++ b/config/capi/_ytt_lib/capi-k8s-release/templates/cc-kpack-registry-service-account.yml
@@ -19,3 +19,15 @@ type: kubernetes.io/basic-auth
 stringData:
   username: #@ data.values.kpack.registry.username
   password: #@ data.values.kpack.registry.password
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: cc-package-registry-upload-secret
+  namespace: #@ data.values.system_namespace
+  annotations:
+    build.pivotal.io/docker: #@ data.values.kpack.registry.hostname
+type: kubernetes.io/basic-auth
+stringData:
+  username: #@ data.values.kpack.registry.username
+  password: #@ data.values.kpack.registry.password

--- a/config/capi/_ytt_lib/capi-k8s-release/templates/ccng-config.lib.yml
+++ b/config/capi/_ytt_lib/capi-k8s-release/templates/ccng-config.lib.yml
@@ -15,6 +15,7 @@ fluent:
   port: 24224
 
 internal_service_hostname: #@ "capi.{}.svc.cluster.local".format(data.values.system_namespace)
+internal_service_port: 80
 
 pid_filename: /cloud_controller_ng/cloud_controller_ng.pid
 newrelic_enabled: false
@@ -192,13 +193,14 @@ packages:
     path_style: true
   max_valid_packages_stored: 5
   max_package_size: 1073741824
-
-  cdn:
-    uri:
-    key_pair_id:
-    private_key: ""
-
   fog_aws_storage_options: {}
+  image_registry: {
+    base_path: #@ data.values.kpack.registry.repository_prefix
+  }
+
+package_image_uploader:
+  host: 127.0.0.1
+  port: 8080
 
 droplets:
   droplet_directory_key: #@ data.values.blobstore.droplet_directory_key
@@ -266,7 +268,7 @@ cc_service_key_client_secret: TODO
 allow_app_ssh_access: true
 default_app_ssh_access: true
 
-skip_cert_verify: true
+skip_cert_verify: false
 
 install_buildpacks: []
 

--- a/config/capi/_ytt_lib/capi-k8s-release/values/_default.yml
+++ b/config/capi/_ytt_lib/capi-k8s-release/values/_default.yml
@@ -119,5 +119,3 @@ images:
   nginx:
   statsd_exporter:
   package_image_uploader:
-kbld:
-  destination:

--- a/config/capi/_ytt_lib/capi-k8s-release/values/images.yml
+++ b/config/capi/_ytt_lib/capi-k8s-release/values/images.yml
@@ -1,11 +1,9 @@
 #@data/values
 ---
 images:
-  ccng: cloudfoundry/cloud-controller-ng@sha256:36c889a7188d9c36b8c6230226a87330c5baa2207b8ab5e82d49f40f6061351a
-  cf_api_controllers: cloudfoundry/cf-api-controllers@sha256:afe5933b8d97fe91e6aa6f7b8ec79a478df2838d56ac2736982b61b86dafbe25
+  ccng: cloudfoundry/cloud-controller-ng@sha256:f75fdc651f11634dc711389d2e4e1323ddc16c5316826d9ac786cea2152f200d
+  cf_api_controllers: cloudfoundry/cf-api-controllers@sha256:9cd6557f411c42b2bafe8487f63fae608f0dafd9f56c4268de8ec6fcd88ff7d9
   cf_autodetect_builder: cloudfoundry/cnb:0.0.94-bionic@sha256:5b03a853e636b78c44e475bbc514e2b7b140cc41cca8ab907e9753431ae8c0b0
-  nginx: cloudfoundry/capi-nginx@sha256:980f50e190cbff72d23300bc422da23faa888271c2d07ac3abaa65af55a5316a
-  package_image_uploader: cloudfoundry/cf-api-package-image-uploader
+  nginx: cloudfoundry/capi-nginx@sha256:81ce783601c1b471e5d389b9ad62e871d945be77bdaeb0660342fa247e81c8c2
+  package_image_uploader: cloudfoundry/cf-api-package-image-uploader@sha256:aae727a0960d10ce644035dee7041f7e882c7c58a37992252002ce7c95d8804d
   statsd_exporter: oratos/statsd_exporter:v0.15.0@sha256:10a64dc4ad0a3e3fe88372f0481dea5c02595c38d168617836a99a649d3ac407
-kbld:
-  destination: null

--- a/vendir.lock.yml
+++ b/vendir.lock.yml
@@ -3,7 +3,7 @@ directories:
 - contents:
   - git:
       commitTitle: images.yml updated by CI...
-      sha: 7f2ceb55e07af35da0b830b25e7322994ef5b879
+      sha: 4105a5ecbd21aef60ff7ecf5ab12c14594bd5027
     path: .
   path: config/capi/_ytt_lib/capi-k8s-release
 - contents:

--- a/vendir.yml
+++ b/vendir.yml
@@ -8,7 +8,7 @@ directories:
   - path: .
     git:
       url: https://github.com/cloudfoundry/capi-k8s-release
-      ref: 7f2ceb55e07af35da0b830b25e7322994ef5b879
+      ref: 4105a5ecbd21aef60ff7ecf5ab12c14594bd5027
     includePaths:
     - templates/**/*
     - values/**/*


### PR DESCRIPTION
Trying out just the image registry changes from https://github.com/cloudfoundry/cf-for-k8s/pull/430 to see if that passes the KinD cluster tests.
