### PR TITLE
Update the sample-cf-install-values.yml blobstore key

### DIFF
--- a/sample-cf-install-values.yml
+++ b/sample-cf-install-values.yml
@@ -15,8 +15,8 @@ app_domains:
 cf_admin_password: cfadminpassword
 
 #! The blobstore secret key shared between CAPI and the blobstore.
-cf_blobstore:
-  secret_key: the_blobstore_secret_key
+blobstore:
+  secret_access_key: the_blobstore_secret_key
 
 #! The admin password for operators to access the database.
 cf_db:


### PR DESCRIPTION
## WHAT is this change about?
The blobstore key in the sample-cf-install-values.yml file was out of sync with the corresponding data values key in config/values/00-values.yml

## Does this PR introduce a change to `config/values.yml`?
No

## Acceptance Steps
Use the sample-cf-install-values.yml file to hand-craft a configuration file to deploy with an external blobstore

## Tag your pair, your PM, and/or team
