### PR TITLE
Bump to latest stable kpack (0.1.2) and latest capi-k8s-release which supports that kpack

### DIFF
--- a/ci/tasks/install-cf-on-kind/only-nodejs-builder-overlay.yml
+++ b/ci/tasks/install-cf-on-kind/only-nodejs-builder-overlay.yml
@@ -8,7 +8,7 @@
 #!
 #! See https://github.com/pivotal/kpack/issues/473 for more details.
 
-#@overlay/match by=overlay.subset({"kind": "CustomBuilder","metadata":{"name":"cf-default-builder"}})
+#@overlay/match by=overlay.subset({"kind": "Builder","metadata":{"name":"cf-default-builder"}})
 ---
 spec:
   #@overlay/replace

--- a/config/capi/_ytt_lib/capi-k8s-release/templates/api_server_deployment.yml
+++ b/config/capi/_ytt_lib/capi-k8s-release/templates/api_server_deployment.yml
@@ -21,7 +21,6 @@ spec:
       annotations:
         prometheus.io/scrape: 'true'
         prometheus.io/port: '9102'
-        traffic.sidecar.istio.io/excludeInboundPorts: "9102"
       labels:
         app.kubernetes.io/name: cf-api-server
     spec:
@@ -30,17 +29,22 @@ spec:
       containers:
         - name: cf-api-server
           image: #@ data.values.images.ccng
-          command:
-          - /cloud_controller_ng/bin/cloud_controller
-          - -c
-          - #@ ccng_config_mount_path
-          - -s
-          - #@ ccng_secrets_mount_path
+          #! TODO: temporary override while CI is backed up
+          command: [ "/cnb/lifecycle/launcher", "bin/cloud_controller",
+                     "-c", "/config/cloud_controller_ng.yml",
+                     "-s", "/config/secrets.yml" ]
+          env:
+          - name: CLOUD_CONTROLLER_NG_CONFIG
+            value: #@ ccng_config_mount_path
+          - name: CLOUD_CONTROLLER_NG_SECRETS
+            value: #@ ccng_secrets_mount_path
           imagePullPolicy: Always
           resources:
             requests:
+              cpu: 500m
               memory: 300Mi
             limits:
+              cpu: 1000m
               memory: 1.2Gi
           volumeMounts:
           - #@ template.replace(shared_config_volume_mounts())
@@ -48,9 +52,6 @@ spec:
             mountPath: /data/cloud_controller_ng
           - name: nginx-uploads
             mountPath: /tmp/uploads
-          #@ if/end data.values.uaa.serverCerts.secretName:
-          - name: uaa-certs
-            mountPath: /config/uaa/certs
           #@ if/end data.values.eirini.serverCerts.secretName:
           - name: eirini-certs
             mountPath: /config/eirini/certs
@@ -60,8 +61,7 @@ spec:
         - name: cf-api-local-worker
           image: #@ data.values.images.ccng
           imagePullPolicy: Always
-          command: ["/usr/local/bin/bundle"]
-          args: ["exec", "rake", "jobs:local"]
+          command: [ "/cnb/process/local-worker" ]
           env:
           - name: CLOUD_CONTROLLER_NG_CONFIG
             value: #@ ccng_config_mount_path
@@ -69,8 +69,10 @@ spec:
             value: #@ ccng_secrets_mount_path
           resources:
             requests:
+              cpu: 100m
               memory: 300Mi
             limits:
+              cpu: 500m
               memory: 1.2Gi
           volumeMounts:
           - #@ template.replace(shared_config_volume_mounts())
@@ -84,8 +86,6 @@ spec:
         - name: package-image-uploader
           image: #@ data.values.images.package_image_uploader
           imagePullPolicy: Always
-          securityContext:
-            runAsUser: 0
           readinessProbe:
             tcpSocket:
               port: 8080
@@ -113,6 +113,13 @@ spec:
             httpGet:
               port: 80
               path: "/healthz"
+          resources:
+            requests:
+              cpu: 100m
+              memory: 300Mi
+            limits:
+              cpu: 500m
+              memory: 1Gi
           volumeMounts:
           - name: nginx
             mountPath: /etc/nginx
@@ -128,6 +135,13 @@ spec:
           - containerPort: 9102
           image: #@ data.values.images.statsd_exporter
           imagePullPolicy: Always
+          resources:
+            requests:
+              cpu: 100m
+              memory: 300Mi
+            limits:
+              cpu: 500m
+              memory: 1Gi
       serviceAccountName: cf-api-server-service-account
       volumes:
       - #@ template.replace(shared_config_volumes())
@@ -138,10 +152,6 @@ spec:
           name: nginx
       - name: nginx-logs
         emptyDir: {}
-      #@ if/end data.values.uaa.serverCerts.secretName:
-      - name: uaa-certs
-        secret:
-          secretName: #@ data.values.uaa.serverCerts.secretName
       #@ if/end data.values.eirini.serverCerts.secretName:
       - name: eirini-certs
         secret:

--- a/config/capi/_ytt_lib/capi-k8s-release/templates/cc-kpack-registry-service-account.yml
+++ b/config/capi/_ytt_lib/capi-k8s-release/templates/cc-kpack-registry-service-account.yml
@@ -14,7 +14,7 @@ metadata:
   name: cc-kpack-registry-auth-secret
   namespace: #@ data.values.staging_namespace
   annotations:
-    build.pivotal.io/docker: #@ data.values.kpack.registry.hostname
+    kpack.io/docker: #@ data.values.kpack.registry.hostname
 type: kubernetes.io/basic-auth
 stringData:
   username: #@ data.values.kpack.registry.username
@@ -26,7 +26,7 @@ metadata:
   name: cc-package-registry-upload-secret
   namespace: #@ data.values.system_namespace
   annotations:
-    build.pivotal.io/docker: #@ data.values.kpack.registry.hostname
+    kpack.io/docker: #@ data.values.kpack.registry.hostname
 type: kubernetes.io/basic-auth
 stringData:
   username: #@ data.values.kpack.registry.username

--- a/config/capi/_ytt_lib/capi-k8s-release/templates/ccdb-migrate-job.yaml
+++ b/config/capi/_ytt_lib/capi-k8s-release/templates/ccdb-migrate-job.yaml
@@ -17,12 +17,7 @@ spec:
       - name: run-migrations
         image: #@ data.values.images.ccng
         imagePullPolicy: Always
-        command: ["/bin/bash", "-c"]
-        args:
-        - |
-          bundle exec rake db:wait_for_istio && \
-          bundle exec rake db:setup_database && \
-          bundle exec rake db:terminate_istio
+        command: [ "/cnb/process/migrate" ]
         env:
         - name: CLOUD_CONTROLLER_NG_CONFIG
           value: #@ ccng_config_mount_path

--- a/config/capi/_ytt_lib/capi-k8s-release/templates/ccng-config.lib.yml
+++ b/config/capi/_ytt_lib/capi-k8s-release/templates/ccng-config.lib.yml
@@ -17,7 +17,7 @@ fluent:
 internal_service_hostname: #@ "capi.{}.svc.cluster.local".format(data.values.system_namespace)
 internal_service_port: 9023
 
-pid_filename: /cloud_controller_ng/cloud_controller_ng.pid
+pid_filename: cloud_controller_ng.pid
 newrelic_enabled: false
 development_mode: false
 
@@ -55,6 +55,7 @@ internal_api:
 
 nginx:
   use_nginx: true
+  #! TODO: consume this from a variable since it's defined in the pod's mounts
   instance_socket: "/data/cloud_controller_ng/cloud_controller.sock"
 
 index: 0
@@ -82,7 +83,7 @@ directories:
 logging:
   file: /dev/stdout
   syslog: vcap.cloud_controller_ng
-  level: "info"
+  level: #@ data.values.cc.log_level
   max_retries: 1
 
 logcache:
@@ -130,7 +131,6 @@ uaa:
   internal_url: #@ "http://uaa.{}.svc.cluster.local:8080".format(data.values.system_namespace)
   resource_id: cloud_controller,cloud_controller_service_permissions
   client_timeout: 60
-  ca_file: /config/uaa/certs/uaa.crt
 
 routing_api:
   url: #@ "https://api.{}/routing".format(data.values.system_domain)
@@ -154,7 +154,7 @@ default_health_check_timeout: 60
 maximum_health_check_timeout: 180
 
 runtimes_file: "/dev/null"
-stacks_file: "/cloud_controller_ng/config/stacks.yml"
+stacks_file: config/stacks.yml
 
 shared_isolation_segment_name: shared
 

--- a/config/capi/_ytt_lib/capi-k8s-release/templates/cf-api-controllers-service-account.yml
+++ b/config/capi/_ytt_lib/capi-k8s-release/templates/cf-api-controllers-service-account.yml
@@ -49,12 +49,38 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
 ---
 apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: cf-api-controllers-service-account-periodicsyncs-admin
+subjects:
+  - kind: ServiceAccount
+    name: cf-api-controllers-service-account
+    namespace: #@ data.values.system_namespace
+roleRef:
+  kind: ClusterRole
+  name: "cf:periodicsyncs-admin"
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: cf-api-controllers-service-account-routes-admin
+subjects:
+  - kind: ServiceAccount
+    name: cf-api-controllers-service-account
+    namespace: #@ data.values.system_namespace
+roleRef:
+  kind: ClusterRole
+  name: "cf:routes-admin"
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: "cf:kpack-builds-informer"
 rules:
   - apiGroups:
-      - build.pivotal.io
+      - kpack.io
     resources:
       - builds
     verbs:
@@ -87,3 +113,30 @@ rules:
       - list
       - update
       - patch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  name: "cf:periodicsyncs-admin"
+rules:
+  - apiGroups:
+      - apps.cloudfoundry.org
+    resources:
+      - periodicsyncs
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - apps.cloudfoundry.org
+    resources:
+      - periodicsyncs/status
+    verbs:
+      - get
+      - patch
+      - update

--- a/config/capi/_ytt_lib/capi-k8s-release/templates/cf-api-server-service-account.yml
+++ b/config/capi/_ytt_lib/capi-k8s-release/templates/cf-api-server-service-account.yml
@@ -37,7 +37,7 @@ roleRef:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: cf-api-server-service-account-kpack-custombuilder-admin
+  name: cf-api-server-service-account-kpack-builder-admin
   namespace: #@ data.values.staging_namespace
 subjects:
   - kind: ServiceAccount
@@ -45,7 +45,7 @@ subjects:
     namespace: #@ data.values.system_namespace
 roleRef:
   kind: ClusterRole
-  name: "cf:kpack-custombuilder-admin"
+  name: "cf:kpack-builder-admin"
   apiGroup: rbac.authorization.k8s.io
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -62,6 +62,8 @@ rules:
       - get
       - update
       - delete
+      - list
+      - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -69,7 +71,7 @@ metadata:
   name: "cf:kpack-builds-admin"
 rules:
   - apiGroups:
-      - build.pivotal.io
+      - kpack.io
     resources:
       - images
     verbs:
@@ -81,13 +83,13 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: "cf:kpack-custombuilder-admin"
+  name: "cf:kpack-builder-admin"
 rules:
   - apiGroups:
-      - experimental.kpack.pivotal.io
+      - kpack.io
     resources:
-      - custombuilders
-      - custombuilders/status
+      - builders
+      - builders/status
     verbs:
       - get
       - create

--- a/config/capi/_ytt_lib/capi-k8s-release/templates/cf-api-worker-service-account.yml
+++ b/config/capi/_ytt_lib/capi-k8s-release/templates/cf-api-worker-service-account.yml
@@ -37,7 +37,7 @@ roleRef:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: cf-api-worker-service-account-kpack-custombuilder-admin
+  name: cf-api-worker-service-account-kpack-builder-admin
   namespace: #@ data.values.staging_namespace
 subjects:
   - kind: ServiceAccount
@@ -45,5 +45,5 @@ subjects:
     namespace: #@ data.values.system_namespace
 roleRef:
   kind: ClusterRole
-  name: "cf:kpack-custombuilder-admin"
+  name: "cf:kpack-builder-admin"
   apiGroup: rbac.authorization.k8s.io

--- a/config/capi/_ytt_lib/capi-k8s-release/templates/clock_deployment.yml
+++ b/config/capi/_ytt_lib/capi-k8s-release/templates/clock_deployment.yml
@@ -27,9 +27,7 @@ spec:
         - name: cf-api-clock
           image: #@ data.values.images.ccng
           imagePullPolicy: Always
-          workingDir: "/cloud_controller_ng"
-          command: ["/usr/local/bin/bundle"]
-          args: ["exec", "rake", "clock:start"]
+          command: [ "/cnb/process/clock" ]
           env:
           - name: CLOUD_CONTROLLER_NG_CONFIG
             value: #@ ccng_config_mount_path
@@ -37,8 +35,10 @@ spec:
             value: #@ ccng_secrets_mount_path
           resources:
             requests:
+              cpu: 300m
               memory: 300Mi
             limits:
+              cpu: 1000m
               memory: 1Gi
           readinessProbe:
             tcpSocket:

--- a/config/capi/_ytt_lib/capi-k8s-release/templates/controllers_deployment.yml
+++ b/config/capi/_ytt_lib/capi-k8s-release/templates/controllers_deployment.yml
@@ -35,8 +35,6 @@ spec:
           value: cf_api_controllers
         - name: CF_API_HOST
           value: #@ "http://capi.{}.svc.cluster.local".format(data.values.system_namespace)
-        - name: STAGING_NAMESPACE
-          value: #@ data.values.staging_namespace
         - name: WORKLOADS_NAMESPACE
           value: #@ data.values.workloads_namespace
         resources:
@@ -60,7 +58,7 @@ kind: ClusterRole
 metadata:
   name: cf-api-controllers
 rules:
-- apiGroups: ["build.pivotal.io"]
+- apiGroups: ["kpack.io"]
   resources: ["images", "builds", "builds/status", "images/status"]
   verbs: ["get", "watch", "list"]
 ---

--- a/config/capi/_ytt_lib/capi-k8s-release/templates/deployment_updater_deployment.yml
+++ b/config/capi/_ytt_lib/capi-k8s-release/templates/deployment_updater_deployment.yml
@@ -27,9 +27,7 @@ spec:
         - name: cf-api-deployment-updater
           image: #@ data.values.images.ccng
           imagePullPolicy: Always
-          workingDir: "/cloud_controller_ng"
-          command: ["/usr/local/bin/bundle"]
-          args: ["exec", "rake", "deployment_updater:start"]
+          command: [ "/cnb/process/deployment-updater" ]
           env:
           - name: CLOUD_CONTROLLER_NG_CONFIG
             value: #@ ccng_config_mount_path
@@ -37,8 +35,10 @@ spec:
             value: #@ ccng_secrets_mount_path
           resources:
             requests:
+              cpu: 300m
               memory: 300Mi
             limits:
+              cpu: 1000m
               memory: 1Gi
           readinessProbe:
             tcpSocket:

--- a/config/capi/_ytt_lib/capi-k8s-release/templates/nginx-configmap.yml
+++ b/config/capi/_ytt_lib/capi-k8s-release/templates/nginx-configmap.yml
@@ -9,6 +9,7 @@ metadata:
     kapp.k14s.io/versioned: ""
 data:
   nginx.conf: |
+    user cnb cnb;
     error_log stderr info;
 
     worker_processes auto;

--- a/config/capi/_ytt_lib/capi-k8s-release/templates/periodic-route-sync.yml
+++ b/config/capi/_ytt_lib/capi-k8s-release/templates/periodic-route-sync.yml
@@ -1,0 +1,10 @@
+#@ load("@ytt:data", "data")
+
+---
+apiVersion: apps.cloudfoundry.org/v1alpha1
+kind: PeriodicSync
+metadata:
+  name: cf-api-periodic-route-sync
+  namespace: #@ data.values.system_namespace
+spec:
+  period_seconds: 15

--- a/config/capi/_ytt_lib/capi-k8s-release/templates/periodic-sync-crd.yml
+++ b/config/capi/_ytt_lib/capi-k8s-release/templates/periodic-sync-crd.yml
@@ -1,0 +1,82 @@
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.2.5
+  creationTimestamp: null
+  name: periodicsyncs.apps.cloudfoundry.org
+spec:
+  group: apps.cloudfoundry.org
+  names:
+    kind: PeriodicSync
+    listKind: PeriodicSyncList
+    plural: periodicsyncs
+    singular: periodicsync
+  scope: Namespaced
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      description: PeriodicSync is the Schema for the periodicsyncs API
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: PeriodicSyncSpec defines the desired state of PeriodicSync
+          properties:
+            period_seconds:
+              format: int32
+              type: integer
+          required:
+            - period_seconds
+          type: object
+        status:
+          description: PeriodicSyncStatus defines the observed state of PeriodicSync
+          properties:
+            conditions:
+              description: 'INSERT ADDITIONAL STATUS FIELD - define observed state
+                of cluster Important: Run "make" to regenerate code after modifying
+                this file'
+              items:
+                description: 'Loosely following this KEP: https://github.com/kubernetes/enhancements/tree/master/keps/sig-api-machinery/1623-standardize-conditions
+                  Eventually we can update to use standard Kubernetes types'
+                properties:
+                  lastTransitionTime:
+                    format: date-time
+                    type: string
+                  message:
+                    type: string
+                  reason:
+                    type: string
+                  status:
+                    type: string
+                  type:
+                    type: string
+                required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                type: object
+              type: array
+          required:
+            - conditions
+          type: object
+      type: object
+  version: v1alpha1
+  versions:
+    - name: v1alpha1
+      served: true
+      storage: true

--- a/config/capi/_ytt_lib/capi-k8s-release/templates/worker_deployment.yml
+++ b/config/capi/_ytt_lib/capi-k8s-release/templates/worker_deployment.yml
@@ -23,9 +23,7 @@ spec:
         - name: cf-api-worker
           image: #@ data.values.images.ccng
           imagePullPolicy: Always
-          workingDir: "/cloud_controller_ng"
-          command: ["/usr/local/bin/bundle"]
-          args: ["exec", "rake", "jobs:generic"]
+          command: [ "/cnb/process/api-worker" ]
           env:
           - name: CLOUD_CONTROLLER_NG_CONFIG
             value: #@ ccng_config_mount_path
@@ -33,8 +31,10 @@ spec:
             value: #@ ccng_secrets_mount_path
           resources:
             requests:
+              cpu: 300m
               memory: 300Mi
             limits:
+              cpu: 1000m
               memory: 1Gi
           readinessProbe:
             tcpSocket:

--- a/config/capi/_ytt_lib/capi-k8s-release/values/_default.yml
+++ b/config/capi/_ytt_lib/capi-k8s-release/values/_default.yml
@@ -1,69 +1,5 @@
 #@data/values
 ---
-apiServer:
-  opi:
-    ca: |
-      -----BEGIN CERTIFICATE-----
-      MIIClDCCAXwCCQCU6a04MFuU6zANBgkqhkiG9w0BAQUFADAMMQowCAYDVQQDDAEq
-      MB4XDTE5MTIwOTIzMjYzM1oXDTIwMTIwODIzMjYzM1owDDEKMAgGA1UEAwwBKjCC
-      ASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBANGvyO+mnn2tpnILxu2DNlgw
-      KKQ+8iwqC07gAvwbGmkEGjifxlRO5sbK1Cel79LUO3McCm4rfy4Kkk7VyFUFxduL
-      kvHg25/DXlf2gzFx5hzQ4LzOFcX7/Qr+KXdCT2TWjn+ppKhOyt6QMfYvTuRZMQ+0
-      TTDOUm+fd06S2pvJonW0h7sIwIuT1BVooH/WQIHkmbu+iW/V1AHJtPwBnd/YOEwP
-      yijAs9mdfi6s7h0ysJJ3NWGIxSSR9H0fIdx3OKX+6Vzw+9Na/dlzVNZgJ+6tR4TU
-      RGcSojbzei8YdX9VQy0fjns0mavxrq/aezrQeX5sj3lH0iiMiKmXoEoE1ZvnF1sC
-      AwEAATANBgkqhkiG9w0BAQUFAAOCAQEAXeQ1dAnHXklorPBkc/TMwjZ7fRCG3twJ
-      giViAvsGrGrXtKGwAfWENlM+8kG99VGpQ5RZ+wWGXayObqATMKMmrUZ5LSlBGfQz
-      AgKiDYURoKe+IHC3dBw/7nNFIXfuVexWhULQj6kyg0XlwNLSk/3DaJrsvOjirymY
-      j0ubnTrEwgl+2Yam97VW4a1Q3VXbay6VhNrEetMUUHokFPz6Go1bxDs07/fYfVfJ
-      Qv9xehvYLNuXDjluVRXneVpnRmC6XDAMAgT90qfZvktKj3KwLIZCdBczH9Kflhsr
-      2Xru1Dw19HiJCfX+ZotYMNOhx92qTiL0ELlJjqeu8c0bdAo0tuYYew==
-      -----END CERTIFICATE-----
-    client_cert: |
-      -----BEGIN CERTIFICATE-----
-      MIIClDCCAXwCCQCU6a04MFuU6zANBgkqhkiG9w0BAQUFADAMMQowCAYDVQQDDAEq
-      MB4XDTE5MTIwOTIzMjYzM1oXDTIwMTIwODIzMjYzM1owDDEKMAgGA1UEAwwBKjCC
-      ASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBANGvyO+mnn2tpnILxu2DNlgw
-      KKQ+8iwqC07gAvwbGmkEGjifxlRO5sbK1Cel79LUO3McCm4rfy4Kkk7VyFUFxduL
-      kvHg25/DXlf2gzFx5hzQ4LzOFcX7/Qr+KXdCT2TWjn+ppKhOyt6QMfYvTuRZMQ+0
-      TTDOUm+fd06S2pvJonW0h7sIwIuT1BVooH/WQIHkmbu+iW/V1AHJtPwBnd/YOEwP
-      yijAs9mdfi6s7h0ysJJ3NWGIxSSR9H0fIdx3OKX+6Vzw+9Na/dlzVNZgJ+6tR4TU
-      RGcSojbzei8YdX9VQy0fjns0mavxrq/aezrQeX5sj3lH0iiMiKmXoEoE1ZvnF1sC
-      AwEAATANBgkqhkiG9w0BAQUFAAOCAQEAXeQ1dAnHXklorPBkc/TMwjZ7fRCG3twJ
-      giViAvsGrGrXtKGwAfWENlM+8kG99VGpQ5RZ+wWGXayObqATMKMmrUZ5LSlBGfQz
-      AgKiDYURoKe+IHC3dBw/7nNFIXfuVexWhULQj6kyg0XlwNLSk/3DaJrsvOjirymY
-      j0ubnTrEwgl+2Yam97VW4a1Q3VXbay6VhNrEetMUUHokFPz6Go1bxDs07/fYfVfJ
-      Qv9xehvYLNuXDjluVRXneVpnRmC6XDAMAgT90qfZvktKj3KwLIZCdBczH9Kflhsr
-      2Xru1Dw19HiJCfX+ZotYMNOhx92qTiL0ELlJjqeu8c0bdAo0tuYYew==
-      -----END CERTIFICATE-----
-    client_key: |
-      -----BEGIN RSA PRIVATE KEY-----
-      MIIEpQIBAAKCAQEA0a/I76aefa2mcgvG7YM2WDAopD7yLCoLTuAC/BsaaQQaOJ/G
-      VE7mxsrUJ6Xv0tQ7cxwKbit/LgqSTtXIVQXF24uS8eDbn8NeV/aDMXHmHNDgvM4V
-      xfv9Cv4pd0JPZNaOf6mkqE7K3pAx9i9O5FkxD7RNMM5Sb593TpLam8midbSHuwjA
-      i5PUFWigf9ZAgeSZu76Jb9XUAcm0/AGd39g4TA/KKMCz2Z1+LqzuHTKwknc1YYjF
-      JJH0fR8h3Hc4pf7pXPD701r92XNU1mAn7q1HhNREZxKiNvN6Lxh1f1VDLR+OezSZ
-      q/Gur9p7OtB5fmyPeUfSKIyIqZegSgTVm+cXWwIDAQABAoIBAQCutncIJ557PUso
-      T2PK1r9bL5VNdR03azjM2Z3jDXot8jse3xHTgYKMNMgc2QhAdJGsUbrnHNr1M93A
-      TiSDozG+wkcHvsGAFrrvM/kQI8UGUYxQBK7jrhijJi7KrbeVX6iP+nu1uSET3LWk
-      WLq1TROx8Bs5BVBurUItd/MqRxFUXDt6+1LPr59TvikYwchxhzSwokS4GCJ++uUR
-      J423+gLHWaDHBE06P6X1PbtcckEYHBMN56jo8de78UQNdxRUw2LXq2cIGTdx0KTs
-      pc35mu6jzkudaLYuBNrcs0dcIAaQw0rnpRlfVI8dmH3+uShbSdJej19zFugCZaOy
-      HzRkVG2xAoGBAOf1p77bogik4sV9/k9UwwkwpRmTDUT3sj15aNjRvUilgkOpP5B9
-      JkWG6BBenBdg/8iSy4sBah2pEj/oSUe53CYd9USJWcAafLpGWw0F0aud038zu+yJ
-      KcxvAjud/IDy3IuM395ohv0b/gMkuQLKaQxHl3A4boftp6KAo3iPvw0dAoGBAOdr
-      L1dtrjJM0gsEyvzj9d7HlMQUCwidu6xMWikOG0LBYFv+Ecs9k4IuB3QcV+H9IdLe
-      RbRAOlXZeXgXqc1stFJSon9he1mxFgUnu9hxrmx0fILzBBtVNJeRdUETHAG15dTt
-      OX0bKjE5qdbWSkmN7TBv/G7wzzMbThdPWBaDFyTXAoGAIfTqW5xXeiB5OiQZqI9m
-      BeBjKv1GAgSoySsO2D7MEOh5y2HpdkN76M25BzxyaVG/4CLtPSo12KW5kDV3FNL2
-      kXXtQ90/kEnQXIyUI7HoYdE29vYh2pyxy8WsdAHKxy3Gb39t/mca686/PsKPewMa
-      obuRRdJdC/UUh0uBotKYS1kCgYEAtgvwkwNaLIGYHkjn8ibWDSnN0q29vEpxD2qE
-      5pUNRudeiR+GGe7XsmnJPULqs4Fw8TQfe1unSE+rKZjb4BjqhXQyFqi142nWW7nV
-      IMDVKMY+CLlpeqL9m1o29jk1J/dS1LzFI7CR8WVeQP4UNGastxTxbMiNBrQtK1Mk
-      hZkcRMMCgYEAhvImIwfWMBb7vyZ2qUYz3d7JJRDF11ufGp3/5WN4TS0nHAJN43Tf
-      G+IH4ZZUCENYiFbGfygd+xLAQ1CmhUzaOjZVONbKugbMqHSISaH90Yzfd2qpKawD
-      0NvW20ZPCnvqegG8wOIGlqWwNBSARitdfWIHpGl/Rogp6+mYRw1It4I=
-      -----END RSA PRIVATE KEY-----
 app_domains: []
 blobstore:
   access_key_id: AKIAIOSFODNN7EXAMPLE
@@ -75,6 +11,8 @@ blobstore:
   region: ""
   resource_directory_key: cc-resources
   secret_access_key_secret_name:
+cc:
+  log_level: info
 ccdb:
   adapter: postgres
   database: cloud_controller
@@ -119,5 +57,3 @@ images:
   nginx:
   statsd_exporter:
   package_image_uploader:
-kbld:
-  destination:

--- a/config/capi/_ytt_lib/capi-k8s-release/values/images.yml
+++ b/config/capi/_ytt_lib/capi-k8s-release/values/images.yml
@@ -1,11 +1,9 @@
 #@data/values
 ---
 images:
-  ccng: cloudfoundry/cloud-controller-ng@sha256:cacb91272670f98a1135c0964719bca02befc75f063477afa5bb2d70a5c3b8e7
-  cf_api_controllers: cloudfoundry/cf-api-controllers@sha256:9cd6557f411c42b2bafe8487f63fae608f0dafd9f56c4268de8ec6fcd88ff7d9
+  ccng: gcr.io/cf-capi-arya/dev-ccng@sha256:fda89ac251d0b0aa6185b4b46d42a11113fafff4a6aa2fbc99c4227fc14f35b9
+  cf_api_controllers: gcr.io/cf-capi-arya/dev-controllers@sha256:7e63bb428b1bb713a5358c0feb67ae9d04feba216153570e68853257220d05a6
   cf_autodetect_builder: cloudfoundry/cnb:0.0.94-bionic@sha256:5b03a853e636b78c44e475bbc514e2b7b140cc41cca8ab907e9753431ae8c0b0
-  nginx: cloudfoundry/capi-nginx@sha256:980f50e190cbff72d23300bc422da23faa888271c2d07ac3abaa65af55a5316a
-  package_image_uploader: cloudfoundry/cf-api-package-image-uploader@sha256:aae727a0960d10ce644035dee7041f7e882c7c58a37992252002ce7c95d8804d
+  nginx: cloudfoundry/capi-nginx@sha256:25997cca011ed0761955754a68931f7b1694e487bffba73c6ac8dbcd084f5dee
+  package_image_uploader: gcr.io/cf-capi-arya/dev-package-image-uploader@sha256:1119b111ede474c1a89ef7c0ba917940e29761162593f71981a119e6b90d5a51
   statsd_exporter: oratos/statsd_exporter:v0.15.0@sha256:10a64dc4ad0a3e3fe88372f0481dea5c02595c38d168617836a99a649d3ac407
-kbld:
-  destination: null

--- a/config/kpack/_ytt_lib/kpack/release-0.1.2.yaml
+++ b/config/kpack/_ytt_lib/kpack/release-0.1.2.yaml
@@ -6,9 +6,9 @@ metadata:
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
-  name: builds.build.pivotal.io
+  name: builds.kpack.io
 spec:
-  group: build.pivotal.io
+  group: kpack.io
   version: v1alpha1
   names:
     kind: Build
@@ -35,17 +35,15 @@ spec:
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
-  name: builders.build.pivotal.io
+  name: builders.kpack.io
 spec:
-  group: build.pivotal.io
+  group: kpack.io
   version: v1alpha1
   names:
     kind: Builder
     singular: builder
     plural: builders
     shortNames:
-    - cnbbuilder
-    - cnbbuilders
     - bldr
     - bldrs
     categories:
@@ -64,9 +62,9 @@ spec:
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
-  name: clusterbuilders.build.pivotal.io
+  name: clusterbuilders.kpack.io
 spec:
-  group: build.pivotal.io
+  group: kpack.io
   version: v1alpha1
   names:
     kind: ClusterBuilder
@@ -74,6 +72,7 @@ spec:
     plural: clusterbuilders
     shortNames:
     - clstbldr
+    - clstbldrs
     categories:
     - kpack
   scope: Cluster
@@ -87,13 +86,34 @@ spec:
     type: string
     JSONPath: .status.conditions[?(@.type=="Ready")].status
 ---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: clusterstores.kpack.io
+spec:
+  group: kpack.io
+  version: v1alpha1
+  names:
+    kind: ClusterStore
+    singular: clusterstore
+    plural: clusterstores
+    categories:
+    - kpack
+  scope: Cluster
+  subresources:
+    status: {}
+  additionalPrinterColumns:
+  - name: Ready
+    type: string
+    JSONPath: .status.conditions[?(@.type=="Ready")].status
+---
 apiVersion: v1
 kind: ConfigMap
 metadata:
   name: build-init-image
   namespace: kpack
 data:
-  image: "gcr.io/cf-build-service-public/kpack/build-init@sha256:090bf83938b3a6e8559d566a816825035c3226a5b2b89710db3f2b9b8a0a218b"
+  image: gcr.io/cf-build-service-public/kpack/build-init@sha256:8136ff3a64517457b91f86bf66b8ffe13b986aaf3511887eda107e59dcb8c632
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -101,7 +121,7 @@ metadata:
   name: rebase-image
   namespace: kpack
 data:
-  image: "gcr.io/cf-build-service-public/kpack/rebase@sha256:68f116436c555fc655fb6cdf58a58b229dca6c64c46df730c01b0b2c995d24e3"
+  image: gcr.io/cf-build-service-public/kpack/rebase@sha256:70e1d8837773d623c67f9e9f09cddb58c77a30de46ebfe1d0090199c29dabc0d
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -109,7 +129,7 @@ metadata:
   name: lifecycle-image
   namespace: kpack
 data:
-  image: "gcr.io/cf-build-service-public/kpack/lifecycle@sha256:830f6026479a0b43bdc6ba3e942a80c7c5e49839e911ad5592c1e54933419d05"
+  image: gcr.io/cf-build-service-public/kpack/lifecycle@sha256:2b97f13bdf43d2f4e72b68f67dcb1b693c6bee10f76b709c09e46ae21ec265e8
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -117,7 +137,7 @@ metadata:
   name: completion-image
   namespace: kpack
 data:
-  image: "gcr.io/cf-build-service-public/kpack/completion@sha256:dd21b848f5ac7d1c844c780bb2b51596f5eadc300bee9bdc34cc912fa7d2ce9f"
+  image: gcr.io/cf-build-service-public/kpack/completion@sha256:1e83c4ccb56ad3e0fccbac74f91dfc404db280f8d3380cfa20c7d68fd0359235
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -133,12 +153,12 @@ spec:
     metadata:
       labels:
         app: kpack-controller
-        version: dev
+        version: 0.1.2-rc.1
     spec:
       serviceAccountName: controller
       containers:
       - name: controller
-        image: "gcr.io/cf-build-service-public/kpack/controller@sha256:350e74b06c196070d4b256a9ab358aeb981cb55369d6933b89072d7625ec240a"
+        image: gcr.io/cf-build-service-public/kpack/controller@sha256:6a7fbb4d34a5ed778e75edc2a14b671afcbccaed1a37a4662708b7a11559734c
         env:
         - name: CONFIG_LOGGING_NAME
           value: config-logging
@@ -183,7 +203,7 @@ metadata:
   name: kpack-controller-admin
 rules:
 - apiGroups:
-  - build.pivotal.io
+  - kpack.io
   resources:
   - builds
   - builds/status
@@ -195,6 +215,10 @@ rules:
   - builders/status
   - clusterbuilders
   - clusterbuilders/status
+  - clusterstores
+  - clusterstores/status
+  - clusterstacks
+  - clusterstacks/status
   - sourceresolvers
   - sourceresolvers/status
   verbs:
@@ -229,25 +253,6 @@ rules:
   - create
   - update
   - delete
-  - watch
-- apiGroups:
-  - experimental.kpack.pivotal.io
-  resources:
-  - custombuilders
-  - custombuilders/status
-  - customclusterbuilders
-  - customclusterbuilders/status
-  - stores
-  - stores/status
-  - stacks
-  - stacks/status
-  verbs:
-  - get
-  - list
-  - create
-  - update
-  - delete
-  - patch
   - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -295,61 +300,9 @@ roleRef:
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
-  name: custombuilders.experimental.kpack.pivotal.io
+  name: images.kpack.io
 spec:
-  group: experimental.kpack.pivotal.io
-  version: v1alpha1
-  names:
-    kind: CustomBuilder
-    singular: custombuilder
-    plural: custombuilders
-    shortNames:
-    - custmbldr
-    categories:
-    - kpack
-  scope: Namespaced
-  subresources:
-    status: {}
-  additionalPrinterColumns:
-  - name: LatestImage
-    type: string
-    JSONPath: .status.latestImage
-  - name: Ready
-    type: string
-    JSONPath: .status.conditions[?(@.type=="Ready")].status
----
-apiVersion: apiextensions.k8s.io/v1beta1
-kind: CustomResourceDefinition
-metadata:
-  name: customclusterbuilders.experimental.kpack.pivotal.io
-spec:
-  group: experimental.kpack.pivotal.io
-  version: v1alpha1
-  names:
-    kind: CustomClusterBuilder
-    singular: customclusterbuilder
-    plural: customclusterbuilders
-    shortNames:
-    - ccb
-    categories:
-    - kpack
-  scope: Cluster
-  subresources:
-    status: {}
-  additionalPrinterColumns:
-  - name: LatestImage
-    type: string
-    JSONPath: .status.latestImage
-  - name: Ready
-    type: string
-    JSONPath: .status.conditions[?(@.type=="Ready")].status
----
-apiVersion: apiextensions.k8s.io/v1beta1
-kind: CustomResourceDefinition
-metadata:
-  name: images.build.pivotal.io
-spec:
-  group: build.pivotal.io
+  group: kpack.io
   version: v1alpha1
   names:
     kind: Image
@@ -388,9 +341,9 @@ spec:
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
-  name: sourceresolvers.build.pivotal.io
+  name: sourceresolvers.kpack.io
 spec:
-  group: build.pivotal.io
+  group: kpack.io
   version: v1alpha1
   names:
     kind: SourceResolver
@@ -409,35 +362,14 @@ spec:
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
-  name: stacks.experimental.kpack.pivotal.io
+  name: clusterstacks.kpack.io
 spec:
-  group: experimental.kpack.pivotal.io
+  group: kpack.io
   version: v1alpha1
   names:
-    kind: Stack
-    singular: stack
-    plural: stacks
-    categories:
-    - kpack
-  scope: Cluster
-  subresources:
-    status: {}
-  additionalPrinterColumns:
-  - name: Ready
-    type: string
-    JSONPath: .status.conditions[?(@.type=="Ready")].status
----
-apiVersion: apiextensions.k8s.io/v1beta1
-kind: CustomResourceDefinition
-metadata:
-  name: stores.experimental.kpack.pivotal.io
-spec:
-  group: experimental.kpack.pivotal.io
-  version: v1alpha1
-  names:
-    kind: Store
-    singular: store
-    plural: stores
+    kind: ClusterStack
+    singular: clusterstack
+    plural: clusterstacks
     categories:
     - kpack
   scope: Cluster
@@ -451,7 +383,7 @@ spec:
 apiVersion: admissionregistration.k8s.io/v1beta1
 kind: MutatingWebhookConfiguration
 metadata:
-  name: defaults.webhook.kpack.pivotal.io
+  name: defaults.webhook.kpack.io
 webhooks:
 - admissionReviewVersions:
   - v1beta1
@@ -461,12 +393,12 @@ webhooks:
       namespace: kpack
   failurePolicy: Fail
   sideEffects: None
-  name: defaults.webhook.kpack.pivotal.io
+  name: defaults.webhook.kpack.io
 ---
 apiVersion: admissionregistration.k8s.io/v1beta1
 kind: ValidatingWebhookConfiguration
 metadata:
-  name: validation.webhook.kpack.pivotal.io
+  name: validation.webhook.kpack.io
 webhooks:
 - admissionReviewVersions:
   - v1beta1
@@ -476,7 +408,7 @@ webhooks:
       namespace: kpack
   failurePolicy: Fail
   sideEffects: None
-  name: validation.webhook.kpack.pivotal.io
+  name: validation.webhook.kpack.io
 ---
 apiVersion: v1
 kind: Secret
@@ -499,12 +431,12 @@ spec:
       labels:
         app: kpack-webhook
         role: webhook
-        version: dev
+        version: 0.1.2-rc.1
     spec:
       serviceAccountName: webhook
       containers:
       - name: webhook
-        image: "gcr.io/cf-build-service-public/kpack/webhook@sha256:8abb7c72856ee1276a9586dd687a31e0d2ae12d54c98432ee749cd1e33c0d331"
+        image: gcr.io/cf-build-service-public/kpack/webhook@sha256:c51a7508908baacc7253c74b9d9a4f7384a62882005c0d7aabe59f9d43904233
         ports:
         - name: https-webhook
           containerPort: 8443
@@ -581,7 +513,7 @@ rules:
   resources:
   - mutatingwebhookconfigurations
   resourceNames:
-  - defaults.webhook.kpack.pivotal.io
+  - defaults.webhook.kpack.io
   verbs:
   - update
 - apiGroups:
@@ -597,7 +529,7 @@ rules:
   resources:
   - validatingwebhookconfigurations
   resourceNames:
-  - validation.webhook.kpack.pivotal.io
+  - validation.webhook.kpack.io
   verbs:
   - update
 - apiGroups:

--- a/config/kpack/default-buildpacks.yml
+++ b/config/kpack/default-buildpacks.yml
@@ -2,8 +2,8 @@
 #@ load("/namespaces.star", "workloads_staging_namespace")
 
 ---
-apiVersion: experimental.kpack.pivotal.io/v1alpha1
-kind: Store
+apiVersion: kpack.io/v1alpha1
+kind: ClusterStore
 metadata:
   name: cf-buildpack-store
 spec:
@@ -18,8 +18,8 @@ spec:
   - image: gcr.io/paketo-buildpacks/procfile@sha256:e9f731b4cd3f8a13f2f70295713b0ef0970e02e03a530be467bf25703ee5e086
 
 ---
-apiVersion: experimental.kpack.pivotal.io/v1alpha1
-kind: Stack
+apiVersion: kpack.io/v1alpha1
+kind: ClusterStack
 metadata:
   name: cflinuxfs3-stack
 spec:
@@ -30,16 +30,20 @@ spec:
     image: "gcr.io/paketo-buildpacks/run@sha256:06a082106d349955e8b72d6f73310d701c74ac0a40aaf5cbe44662927d39f7c5"
 
 ---
-apiVersion: experimental.kpack.pivotal.io/v1alpha1
-kind: CustomBuilder
+apiVersion: kpack.io/v1alpha1
+kind: Builder
 metadata:
   name: cf-default-builder
   namespace: #@ workloads_staging_namespace()
 spec:
   tag: #@ "{}/cf-default-builder".format(data.values.app_registry.repository_prefix)
   serviceAccount: cc-kpack-registry-service-account
-  stack: cflinuxfs3-stack
-  store: cf-buildpack-store
+  stack:
+    name: cflinuxfs3-stack
+    kind: ClusterStack
+  store:
+    name: cf-buildpack-store
+    kind: ClusterStore
   order:
   - group:
     - id: paketo-community/ruby

--- a/config/kpack/kapp-order.yml
+++ b/config/kpack/kapp-order.yml
@@ -1,7 +1,7 @@
 #@ load("@ytt:overlay", "overlay")
 #@ load("@ytt:data", "data")
 
-#@overlay/match by=overlay.subset({"kind":"Store"})
+#@overlay/match by=overlay.subset({"kind":"ClusterStore"})
 ---
 metadata:
   #@overlay/match missing_ok=True
@@ -9,7 +9,7 @@ metadata:
     #@overlay/match missing_ok=True
     kapp.k14s.io/change-group.kpack-resources: "cf-for-k8s.cloudfoundry.org/kpack-resources"
 
-#@overlay/match by=overlay.subset({"kind":"Stack"})
+#@overlay/match by=overlay.subset({"kind":"ClusterStack"})
 ---
 metadata:
   #@overlay/match missing_ok=True
@@ -17,7 +17,7 @@ metadata:
     #@overlay/match missing_ok=True
     kapp.k14s.io/change-group.kpack-resources: "cf-for-k8s.cloudfoundry.org/kpack-resources"
 
-#@overlay/match by=overlay.subset({"kind":"CustomBuilder"})
+#@overlay/match by=overlay.subset({"kind":"Builder"})
 ---
 metadata:
   #@overlay/match missing_ok=True

--- a/config/kpack/kapp-wait-rules.yml
+++ b/config/kpack/kapp-wait-rules.yml
@@ -10,8 +10,8 @@ waitRules:
     status: "True"
     success: true
   resourceMatchers:
-  - apiVersionKindMatcher: {apiVersion: experimental.kpack.pivotal.io/v1alpha1, kind: Stack}
-  - apiVersionKindMatcher: {apiVersion: experimental.kpack.pivotal.io/v1alpha1, kind: Store}
+  - apiVersionKindMatcher: {apiVersion: kpack.io/v1alpha1, kind: ClusterStack}
+  - apiVersionKindMatcher: {apiVersion: kpack.io/v1alpha1, kind: ClusterStore}
 - supportsObservedGeneration: true
   conditionMatchers:
   - type: Ready
@@ -21,6 +21,6 @@ waitRules:
     status: "False"
     failure: true
   resourceMatchers:
-  - apiVersionKindMatcher: {apiVersion: experimental.kpack.pivotal.io/v1alpha1, kind: CustomBuilder}
+  - apiVersionKindMatcher: {apiVersion: kpack.io/v1alpha1, kind: Builder}
 
 

--- a/config/kpack/kpack.yml
+++ b/config/kpack/kpack.yml
@@ -46,7 +46,7 @@ spec:
 metadata:
   annotations:
     #@overlay/remove
-    build.pivotal.io/docker:
+    kpack.io/docker:
 type: kubernetes.io/dockerconfigjson
 #@overlay/match missing_ok=True
 data:

--- a/vendir.lock.yml
+++ b/vendir.lock.yml
@@ -2,8 +2,8 @@ apiVersion: vendir.k14s.io/v1alpha1
 directories:
 - contents:
   - git:
-      commitTitle: prevent access to internal cf-api endpoints...
-      sha: 282418aa63f4cb4e724087c414973e00538bf783
+      commitTitle: Temporarily use image we built ourselves...
+      sha: e3449f8ecfb6dc3b7b29bf0bbdfdc38e25f78373
     path: .
   path: config/capi/_ytt_lib/capi-k8s-release
 - contents:
@@ -29,13 +29,14 @@ directories:
     path: .
   path: config/uaa/_ytt_lib/uaa
 - contents:
+  - githubRelease:
+      url: https://api.github.com/repos/pivotal/kpack/releases/30225354
+    path: .
+  path: config/kpack/_ytt_lib/kpack
+- contents:
   - manual: {}
     path: eirini
   path: config/eirini/_ytt_lib
-- contents:
-  - manual: {}
-    path: kpack
-  path: config/kpack/_ytt_lib
 - contents:
   - manual: {}
     path: minio

--- a/vendir.yml
+++ b/vendir.yml
@@ -8,7 +8,7 @@ directories:
   - path: .
     git:
       url: https://github.com/cloudfoundry/capi-k8s-release
-      ref: secure-cf-api-internal-endpoints-174455375
+      ref: upgrade-kpack-0.1.2-174413920
     includePaths:
     - templates/**/*
     - values/**/*
@@ -44,16 +44,20 @@ directories:
       ref: v74.25.0
     includePaths:
     - k8s/templates/**/*
+- path: config/kpack/_ytt_lib/kpack
+  contents:
+  - path: .
+    githubRelease:
+      slug: pivotal/kpack
+      tag: v0.1.2
+      disableAutoChecksumValidation: true
+    includePaths:
+    - release-*.yaml
 # the components in this section below are handled by their corresponding build scripts
 # the manual param tells vendir to not override/touch the contents of these directories
 - path: config/eirini/_ytt_lib
   contents:
   - path: eirini
-    manual: {}
-
-- path: config/kpack/_ytt_lib
-  contents:
-  - path: kpack
     manual: {}
 
 - path: config/minio/_ytt_lib


### PR DESCRIPTION
## WHAT is this change about?
This bumps kpack to its latest stable version (0.1.2); however, this introduced breaking changes which required multiple changes to `capi-k8s-release` and its underlying source code (`cloud_controller_ng` + `cf-api-controllers`)

As a result, in order to minimize the amount of pipelines breaking on both our and RelInt's ends, we created a branch which introduces the changes needed to our k8s templates plus bumping to images we hand-crafted (instead of through automation) which contain the changes needed in our source to accommodate kpack's breaking changes. 

We have confirmed basic functionality continues to work (i.e. `cf push catnip`)

Maybe also worth mentioning this was forked off a branch you all made to bump kpack (`kpack-bump-0.1.1`); this required some additional changes beyond the `capi-k8s-release` stuff since kpack 0.1.1 is not stable per their release notes and some other small things. Also we accidentally force-pushed to that old branch we forked from, sorry!

## Does this PR introduce a change to `config/values.yml`?
No

## Acceptance Steps
Confirm there is no regression introduced via smoke tests and any other acceptance tests y'all have

## Tag your pair, your PM, and/or team
@cloudfoundry/cf-capi 


## Related Links
- Story in our backlog: https://www.pivotaltracker.com/n/projects/966314/stories/174413920
