### PR TITLE
bump to istio 1.7.1

### DIFF
--- a/build/istio/istioctl-values.yaml
+++ b/build/istio/istioctl-values.yaml
@@ -39,6 +39,7 @@ spec:
     sidecarInjectorWebhook:
       rewriteAppHTTPProbe: true
     meshConfig:
+      accessLogEncoding: 'JSON'
       enableAutoMtls: true
       accessLogFile: "/dev/stdout"
       accessLogFormat: >-
@@ -78,6 +79,4 @@ spec:
         }
     global:
       controlPlaneSecurityEnabled: true
-      proxy:
-        accessLogEncoding: 'JSON'
 

--- a/build/istio/values.yaml
+++ b/build/istio/values.yaml
@@ -5,7 +5,7 @@
 #! These values cannot be changed later when rendering cf-for-k8s templates.
 #! Values related to CF should NOT be in this file.
 
-istio_version: 1.6.4
+istio_version: 1.7.1
 
 fluentbit:
   image: gcr.io/cf-networking-images/cf-k8s-networking/fluentbit@sha256:9d0f364a682b1903b1230d836d2270f86f29b2904ea5b2b8ee3ea9132a9ab9d7

--- a/config/istio/istio-generated/xxx-generated-istio.yaml
+++ b/config/istio/istio-generated/xxx-generated-istio.yaml
@@ -1,10 +1,6840 @@
 ---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    helm.sh/resource-policy: keep
+  labels:
+    app: mixer
+    chart: istio
+    cloudfoundry.org/istio_version: 1.7.1
+    heritage: Tiller
+    istio: mixer-adapter
+    package: adapter
+    release: istio
+  name: adapters.config.istio.io
+spec:
+  group: config.istio.io
+  names:
+    categories:
+    - istio-io
+    - policy-istio-io
+    kind: adapter
+    plural: adapters
+    singular: adapter
+  scope: Namespaced
+  versions:
+  - name: v1alpha2
+    schema:
+      openAPIV3Schema:
+        properties:
+          spec:
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
+          status:
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    helm.sh/resource-policy: keep
+  labels:
+    app: mixer
+    chart: istio
+    cloudfoundry.org/istio_version: 1.7.1
+    heritage: Tiller
+    istio: core
+    package: istio.io.mixer
+    release: istio
+  name: attributemanifests.config.istio.io
+spec:
+  group: config.istio.io
+  names:
+    categories:
+    - istio-io
+    - policy-istio-io
+    kind: attributemanifest
+    listKind: attributemanifestList
+    plural: attributemanifests
+    singular: attributemanifest
+  scope: Namespaced
+  versions:
+  - name: v1alpha2
+    schema:
+      openAPIV3Schema:
+        properties:
+          spec:
+            description: 'Describes the rules used to configure Mixer''s policy and
+              telemetry features. See more details at: https://istio.io/docs/reference/config/policy-and-telemetry/istio.policy.v1beta1.html'
+            properties:
+              attributes:
+                additionalProperties:
+                  properties:
+                    description:
+                      description: A human-readable description of the attribute's
+                        purpose.
+                      format: string
+                      type: string
+                    valueType:
+                      description: The type of data carried by this attribute.
+                      enum:
+                      - VALUE_TYPE_UNSPECIFIED
+                      - STRING
+                      - INT64
+                      - DOUBLE
+                      - BOOL
+                      - TIMESTAMP
+                      - IP_ADDRESS
+                      - EMAIL_ADDRESS
+                      - URI
+                      - DNS_NAME
+                      - DURATION
+                      - STRING_MAP
+                      type: string
+                  type: object
+                description: The set of attributes this Istio component will be responsible
+                  for producing at runtime.
+                type: object
+              name:
+                description: Name of the component producing these attributes.
+                format: string
+                type: string
+              revision:
+                description: The revision of this document.
+                format: string
+                type: string
+            type: object
+          status:
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    helm.sh/resource-policy: keep
+  labels:
+    app: istio-pilot
+    chart: istio
+    cloudfoundry.org/istio_version: 1.7.1
+    heritage: Tiller
+    istio: security
+    release: istio
+  name: authorizationpolicies.security.istio.io
+spec:
+  group: security.istio.io
+  names:
+    categories:
+    - istio-io
+    - security-istio-io
+    kind: AuthorizationPolicy
+    listKind: AuthorizationPolicyList
+    plural: authorizationpolicies
+    singular: authorizationpolicy
+  scope: Namespaced
+  versions:
+  - name: v1beta1
+    schema:
+      openAPIV3Schema:
+        properties:
+          spec:
+            description: 'Configuration for access control on workloads. See more
+              details at: https://istio.io/docs/reference/config/security/authorization-policy.html'
+            properties:
+              action:
+                description: Optional.
+                enum:
+                - ALLOW
+                - DENY
+                - AUDIT
+                type: string
+              rules:
+                description: Optional.
+                items:
+                  properties:
+                    from:
+                      description: Optional.
+                      items:
+                        properties:
+                          source:
+                            description: Source specifies the source of a request.
+                            properties:
+                              ipBlocks:
+                                description: Optional.
+                                items:
+                                  format: string
+                                  type: string
+                                type: array
+                              namespaces:
+                                description: Optional.
+                                items:
+                                  format: string
+                                  type: string
+                                type: array
+                              notIpBlocks:
+                                description: Optional.
+                                items:
+                                  format: string
+                                  type: string
+                                type: array
+                              notNamespaces:
+                                description: Optional.
+                                items:
+                                  format: string
+                                  type: string
+                                type: array
+                              notPrincipals:
+                                description: Optional.
+                                items:
+                                  format: string
+                                  type: string
+                                type: array
+                              notRequestPrincipals:
+                                description: Optional.
+                                items:
+                                  format: string
+                                  type: string
+                                type: array
+                              principals:
+                                description: Optional.
+                                items:
+                                  format: string
+                                  type: string
+                                type: array
+                              requestPrincipals:
+                                description: Optional.
+                                items:
+                                  format: string
+                                  type: string
+                                type: array
+                            type: object
+                        type: object
+                      type: array
+                    to:
+                      description: Optional.
+                      items:
+                        properties:
+                          operation:
+                            description: Operation specifies the operation of a request.
+                            properties:
+                              hosts:
+                                description: Optional.
+                                items:
+                                  format: string
+                                  type: string
+                                type: array
+                              methods:
+                                description: Optional.
+                                items:
+                                  format: string
+                                  type: string
+                                type: array
+                              notHosts:
+                                description: Optional.
+                                items:
+                                  format: string
+                                  type: string
+                                type: array
+                              notMethods:
+                                description: Optional.
+                                items:
+                                  format: string
+                                  type: string
+                                type: array
+                              notPaths:
+                                description: Optional.
+                                items:
+                                  format: string
+                                  type: string
+                                type: array
+                              notPorts:
+                                description: Optional.
+                                items:
+                                  format: string
+                                  type: string
+                                type: array
+                              paths:
+                                description: Optional.
+                                items:
+                                  format: string
+                                  type: string
+                                type: array
+                              ports:
+                                description: Optional.
+                                items:
+                                  format: string
+                                  type: string
+                                type: array
+                            type: object
+                        type: object
+                      type: array
+                    when:
+                      description: Optional.
+                      items:
+                        properties:
+                          key:
+                            description: The name of an Istio attribute.
+                            format: string
+                            type: string
+                          notValues:
+                            description: Optional.
+                            items:
+                              format: string
+                              type: string
+                            type: array
+                          values:
+                            description: Optional.
+                            items:
+                              format: string
+                              type: string
+                            type: array
+                        type: object
+                      type: array
+                  type: object
+                type: array
+              selector:
+                description: Optional.
+                properties:
+                  matchLabels:
+                    additionalProperties:
+                      format: string
+                      type: string
+                    type: object
+                type: object
+            type: object
+          status:
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    helm.sh/resource-policy: keep
+  labels:
+    app: istio-pilot
+    chart: istio
+    cloudfoundry.org/istio_version: 1.7.1
+    heritage: Tiller
+    release: istio
+  name: destinationrules.networking.istio.io
+spec:
+  group: networking.istio.io
+  names:
+    categories:
+    - istio-io
+    - networking-istio-io
+    kind: DestinationRule
+    listKind: DestinationRuleList
+    plural: destinationrules
+    shortNames:
+    - dr
+    singular: destinationrule
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: The name of a service from the service registry
+      jsonPath: .spec.host
+      name: Host
+      type: string
+    - description: 'CreationTimestamp is a timestamp representing the server time
+        when this object was created. It is not guaranteed to be set in happens-before
+        order across separate operations. Clients may not set this value. It is represented
+        in RFC3339 form and is in UTC. Populated by the system. Read-only. Null for
+        lists. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata'
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha3
+    schema:
+      openAPIV3Schema:
+        properties:
+          spec:
+            description: 'Configuration affecting load balancing, outlier detection,
+              etc. See more details at: https://istio.io/docs/reference/config/networking/destination-rule.html'
+            properties:
+              exportTo:
+                description: A list of namespaces to which this destination rule is
+                  exported.
+                items:
+                  format: string
+                  type: string
+                type: array
+              host:
+                description: The name of a service from the service registry.
+                format: string
+                type: string
+              subsets:
+                items:
+                  properties:
+                    labels:
+                      additionalProperties:
+                        format: string
+                        type: string
+                      type: object
+                    name:
+                      description: Name of the subset.
+                      format: string
+                      type: string
+                    trafficPolicy:
+                      description: Traffic policies that apply to this subset.
+                      properties:
+                        connectionPool:
+                          properties:
+                            http:
+                              description: HTTP connection pool settings.
+                              properties:
+                                h2UpgradePolicy:
+                                  description: Specify if http1.1 connection should
+                                    be upgraded to http2 for the associated destination.
+                                  enum:
+                                  - DEFAULT
+                                  - DO_NOT_UPGRADE
+                                  - UPGRADE
+                                  type: string
+                                http1MaxPendingRequests:
+                                  description: Maximum number of pending HTTP requests
+                                    to a destination.
+                                  format: int32
+                                  type: integer
+                                http2MaxRequests:
+                                  description: Maximum number of requests to a backend.
+                                  format: int32
+                                  type: integer
+                                idleTimeout:
+                                  description: The idle timeout for upstream connection
+                                    pool connections.
+                                  type: string
+                                maxRequestsPerConnection:
+                                  description: Maximum number of requests per connection
+                                    to a backend.
+                                  format: int32
+                                  type: integer
+                                maxRetries:
+                                  format: int32
+                                  type: integer
+                              type: object
+                            tcp:
+                              description: Settings common to both HTTP and TCP upstream
+                                connections.
+                              properties:
+                                connectTimeout:
+                                  description: TCP connection timeout.
+                                  type: string
+                                maxConnections:
+                                  description: Maximum number of HTTP1 /TCP connections
+                                    to a destination host.
+                                  format: int32
+                                  type: integer
+                                tcpKeepalive:
+                                  description: If set then set SO_KEEPALIVE on the
+                                    socket to enable TCP Keepalives.
+                                  properties:
+                                    interval:
+                                      description: The time duration between keep-alive
+                                        probes.
+                                      type: string
+                                    probes:
+                                      type: integer
+                                    time:
+                                      type: string
+                                  type: object
+                              type: object
+                          type: object
+                        loadBalancer:
+                          description: Settings controlling the load balancer algorithms.
+                          oneOf:
+                          - not:
+                              anyOf:
+                              - required:
+                                - simple
+                              - properties:
+                                  consistentHash:
+                                    oneOf:
+                                    - not:
+                                        anyOf:
+                                        - required:
+                                          - httpHeaderName
+                                        - required:
+                                          - httpCookie
+                                        - required:
+                                          - useSourceIp
+                                        - required:
+                                          - httpQueryParameterName
+                                    - required:
+                                      - httpHeaderName
+                                    - required:
+                                      - httpCookie
+                                    - required:
+                                      - useSourceIp
+                                    - required:
+                                      - httpQueryParameterName
+                                required:
+                                - consistentHash
+                          - required:
+                            - simple
+                          - properties:
+                              consistentHash:
+                                oneOf:
+                                - not:
+                                    anyOf:
+                                    - required:
+                                      - httpHeaderName
+                                    - required:
+                                      - httpCookie
+                                    - required:
+                                      - useSourceIp
+                                    - required:
+                                      - httpQueryParameterName
+                                - required:
+                                  - httpHeaderName
+                                - required:
+                                  - httpCookie
+                                - required:
+                                  - useSourceIp
+                                - required:
+                                  - httpQueryParameterName
+                            required:
+                            - consistentHash
+                          properties:
+                            consistentHash:
+                              properties:
+                                httpCookie:
+                                  description: Hash based on HTTP cookie.
+                                  properties:
+                                    name:
+                                      description: Name of the cookie.
+                                      format: string
+                                      type: string
+                                    path:
+                                      description: Path to set for the cookie.
+                                      format: string
+                                      type: string
+                                    ttl:
+                                      description: Lifetime of the cookie.
+                                      type: string
+                                  type: object
+                                httpHeaderName:
+                                  description: Hash based on a specific HTTP header.
+                                  format: string
+                                  type: string
+                                httpQueryParameterName:
+                                  description: Hash based on a specific HTTP query
+                                    parameter.
+                                  format: string
+                                  type: string
+                                minimumRingSize:
+                                  type: integer
+                                useSourceIp:
+                                  description: Hash based on the source IP address.
+                                  type: boolean
+                              type: object
+                            localityLbSetting:
+                              properties:
+                                distribute:
+                                  description: 'Optional: only one of distribute or
+                                    failover can be set.'
+                                  items:
+                                    properties:
+                                      from:
+                                        description: Originating locality, '/' separated,
+                                          e.g.
+                                        format: string
+                                        type: string
+                                      to:
+                                        additionalProperties:
+                                          type: integer
+                                        description: Map of upstream localities to
+                                          traffic distribution weights.
+                                        type: object
+                                    type: object
+                                  type: array
+                                enabled:
+                                  description: enable locality load balancing, this
+                                    is DestinationRule-level and will override mesh
+                                    wide settings in entirety.
+                                  nullable: true
+                                  type: boolean
+                                failover:
+                                  description: 'Optional: only failover or distribute
+                                    can be set.'
+                                  items:
+                                    properties:
+                                      from:
+                                        description: Originating region.
+                                        format: string
+                                        type: string
+                                      to:
+                                        format: string
+                                        type: string
+                                    type: object
+                                  type: array
+                              type: object
+                            simple:
+                              enum:
+                              - ROUND_ROBIN
+                              - LEAST_CONN
+                              - RANDOM
+                              - PASSTHROUGH
+                              type: string
+                          type: object
+                        outlierDetection:
+                          properties:
+                            baseEjectionTime:
+                              description: Minimum ejection duration.
+                              type: string
+                            consecutive5xxErrors:
+                              description: Number of 5xx errors before a host is ejected
+                                from the connection pool.
+                              nullable: true
+                              type: integer
+                            consecutiveErrors:
+                              format: int32
+                              type: integer
+                            consecutiveGatewayErrors:
+                              description: Number of gateway errors before a host
+                                is ejected from the connection pool.
+                              nullable: true
+                              type: integer
+                            interval:
+                              description: Time interval between ejection sweep analysis.
+                              type: string
+                            maxEjectionPercent:
+                              format: int32
+                              type: integer
+                            minHealthPercent:
+                              format: int32
+                              type: integer
+                          type: object
+                        portLevelSettings:
+                          description: Traffic policies specific to individual ports.
+                          items:
+                            properties:
+                              connectionPool:
+                                properties:
+                                  http:
+                                    description: HTTP connection pool settings.
+                                    properties:
+                                      h2UpgradePolicy:
+                                        description: Specify if http1.1 connection
+                                          should be upgraded to http2 for the associated
+                                          destination.
+                                        enum:
+                                        - DEFAULT
+                                        - DO_NOT_UPGRADE
+                                        - UPGRADE
+                                        type: string
+                                      http1MaxPendingRequests:
+                                        description: Maximum number of pending HTTP
+                                          requests to a destination.
+                                        format: int32
+                                        type: integer
+                                      http2MaxRequests:
+                                        description: Maximum number of requests to
+                                          a backend.
+                                        format: int32
+                                        type: integer
+                                      idleTimeout:
+                                        description: The idle timeout for upstream
+                                          connection pool connections.
+                                        type: string
+                                      maxRequestsPerConnection:
+                                        description: Maximum number of requests per
+                                          connection to a backend.
+                                        format: int32
+                                        type: integer
+                                      maxRetries:
+                                        format: int32
+                                        type: integer
+                                    type: object
+                                  tcp:
+                                    description: Settings common to both HTTP and
+                                      TCP upstream connections.
+                                    properties:
+                                      connectTimeout:
+                                        description: TCP connection timeout.
+                                        type: string
+                                      maxConnections:
+                                        description: Maximum number of HTTP1 /TCP
+                                          connections to a destination host.
+                                        format: int32
+                                        type: integer
+                                      tcpKeepalive:
+                                        description: If set then set SO_KEEPALIVE
+                                          on the socket to enable TCP Keepalives.
+                                        properties:
+                                          interval:
+                                            description: The time duration between
+                                              keep-alive probes.
+                                            type: string
+                                          probes:
+                                            type: integer
+                                          time:
+                                            type: string
+                                        type: object
+                                    type: object
+                                type: object
+                              loadBalancer:
+                                description: Settings controlling the load balancer
+                                  algorithms.
+                                oneOf:
+                                - not:
+                                    anyOf:
+                                    - required:
+                                      - simple
+                                    - properties:
+                                        consistentHash:
+                                          oneOf:
+                                          - not:
+                                              anyOf:
+                                              - required:
+                                                - httpHeaderName
+                                              - required:
+                                                - httpCookie
+                                              - required:
+                                                - useSourceIp
+                                              - required:
+                                                - httpQueryParameterName
+                                          - required:
+                                            - httpHeaderName
+                                          - required:
+                                            - httpCookie
+                                          - required:
+                                            - useSourceIp
+                                          - required:
+                                            - httpQueryParameterName
+                                      required:
+                                      - consistentHash
+                                - required:
+                                  - simple
+                                - properties:
+                                    consistentHash:
+                                      oneOf:
+                                      - not:
+                                          anyOf:
+                                          - required:
+                                            - httpHeaderName
+                                          - required:
+                                            - httpCookie
+                                          - required:
+                                            - useSourceIp
+                                          - required:
+                                            - httpQueryParameterName
+                                      - required:
+                                        - httpHeaderName
+                                      - required:
+                                        - httpCookie
+                                      - required:
+                                        - useSourceIp
+                                      - required:
+                                        - httpQueryParameterName
+                                  required:
+                                  - consistentHash
+                                properties:
+                                  consistentHash:
+                                    properties:
+                                      httpCookie:
+                                        description: Hash based on HTTP cookie.
+                                        properties:
+                                          name:
+                                            description: Name of the cookie.
+                                            format: string
+                                            type: string
+                                          path:
+                                            description: Path to set for the cookie.
+                                            format: string
+                                            type: string
+                                          ttl:
+                                            description: Lifetime of the cookie.
+                                            type: string
+                                        type: object
+                                      httpHeaderName:
+                                        description: Hash based on a specific HTTP
+                                          header.
+                                        format: string
+                                        type: string
+                                      httpQueryParameterName:
+                                        description: Hash based on a specific HTTP
+                                          query parameter.
+                                        format: string
+                                        type: string
+                                      minimumRingSize:
+                                        type: integer
+                                      useSourceIp:
+                                        description: Hash based on the source IP address.
+                                        type: boolean
+                                    type: object
+                                  localityLbSetting:
+                                    properties:
+                                      distribute:
+                                        description: 'Optional: only one of distribute
+                                          or failover can be set.'
+                                        items:
+                                          properties:
+                                            from:
+                                              description: Originating locality, '/'
+                                                separated, e.g.
+                                              format: string
+                                              type: string
+                                            to:
+                                              additionalProperties:
+                                                type: integer
+                                              description: Map of upstream localities
+                                                to traffic distribution weights.
+                                              type: object
+                                          type: object
+                                        type: array
+                                      enabled:
+                                        description: enable locality load balancing,
+                                          this is DestinationRule-level and will override
+                                          mesh wide settings in entirety.
+                                        nullable: true
+                                        type: boolean
+                                      failover:
+                                        description: 'Optional: only failover or distribute
+                                          can be set.'
+                                        items:
+                                          properties:
+                                            from:
+                                              description: Originating region.
+                                              format: string
+                                              type: string
+                                            to:
+                                              format: string
+                                              type: string
+                                          type: object
+                                        type: array
+                                    type: object
+                                  simple:
+                                    enum:
+                                    - ROUND_ROBIN
+                                    - LEAST_CONN
+                                    - RANDOM
+                                    - PASSTHROUGH
+                                    type: string
+                                type: object
+                              outlierDetection:
+                                properties:
+                                  baseEjectionTime:
+                                    description: Minimum ejection duration.
+                                    type: string
+                                  consecutive5xxErrors:
+                                    description: Number of 5xx errors before a host
+                                      is ejected from the connection pool.
+                                    nullable: true
+                                    type: integer
+                                  consecutiveErrors:
+                                    format: int32
+                                    type: integer
+                                  consecutiveGatewayErrors:
+                                    description: Number of gateway errors before a
+                                      host is ejected from the connection pool.
+                                    nullable: true
+                                    type: integer
+                                  interval:
+                                    description: Time interval between ejection sweep
+                                      analysis.
+                                    type: string
+                                  maxEjectionPercent:
+                                    format: int32
+                                    type: integer
+                                  minHealthPercent:
+                                    format: int32
+                                    type: integer
+                                type: object
+                              port:
+                                properties:
+                                  number:
+                                    type: integer
+                                type: object
+                              tls:
+                                description: TLS related settings for connections
+                                  to the upstream service.
+                                properties:
+                                  caCertificates:
+                                    format: string
+                                    type: string
+                                  clientCertificate:
+                                    description: REQUIRED if mode is `MUTUAL`.
+                                    format: string
+                                    type: string
+                                  credentialName:
+                                    format: string
+                                    type: string
+                                  mode:
+                                    enum:
+                                    - DISABLE
+                                    - SIMPLE
+                                    - MUTUAL
+                                    - ISTIO_MUTUAL
+                                    type: string
+                                  privateKey:
+                                    description: REQUIRED if mode is `MUTUAL`.
+                                    format: string
+                                    type: string
+                                  sni:
+                                    description: SNI string to present to the server
+                                      during TLS handshake.
+                                    format: string
+                                    type: string
+                                  subjectAltNames:
+                                    items:
+                                      format: string
+                                      type: string
+                                    type: array
+                                type: object
+                            type: object
+                          type: array
+                        tls:
+                          description: TLS related settings for connections to the
+                            upstream service.
+                          properties:
+                            caCertificates:
+                              format: string
+                              type: string
+                            clientCertificate:
+                              description: REQUIRED if mode is `MUTUAL`.
+                              format: string
+                              type: string
+                            credentialName:
+                              format: string
+                              type: string
+                            mode:
+                              enum:
+                              - DISABLE
+                              - SIMPLE
+                              - MUTUAL
+                              - ISTIO_MUTUAL
+                              type: string
+                            privateKey:
+                              description: REQUIRED if mode is `MUTUAL`.
+                              format: string
+                              type: string
+                            sni:
+                              description: SNI string to present to the server during
+                                TLS handshake.
+                              format: string
+                              type: string
+                            subjectAltNames:
+                              items:
+                                format: string
+                                type: string
+                              type: array
+                          type: object
+                      type: object
+                  type: object
+                type: array
+              trafficPolicy:
+                properties:
+                  connectionPool:
+                    properties:
+                      http:
+                        description: HTTP connection pool settings.
+                        properties:
+                          h2UpgradePolicy:
+                            description: Specify if http1.1 connection should be upgraded
+                              to http2 for the associated destination.
+                            enum:
+                            - DEFAULT
+                            - DO_NOT_UPGRADE
+                            - UPGRADE
+                            type: string
+                          http1MaxPendingRequests:
+                            description: Maximum number of pending HTTP requests to
+                              a destination.
+                            format: int32
+                            type: integer
+                          http2MaxRequests:
+                            description: Maximum number of requests to a backend.
+                            format: int32
+                            type: integer
+                          idleTimeout:
+                            description: The idle timeout for upstream connection
+                              pool connections.
+                            type: string
+                          maxRequestsPerConnection:
+                            description: Maximum number of requests per connection
+                              to a backend.
+                            format: int32
+                            type: integer
+                          maxRetries:
+                            format: int32
+                            type: integer
+                        type: object
+                      tcp:
+                        description: Settings common to both HTTP and TCP upstream
+                          connections.
+                        properties:
+                          connectTimeout:
+                            description: TCP connection timeout.
+                            type: string
+                          maxConnections:
+                            description: Maximum number of HTTP1 /TCP connections
+                              to a destination host.
+                            format: int32
+                            type: integer
+                          tcpKeepalive:
+                            description: If set then set SO_KEEPALIVE on the socket
+                              to enable TCP Keepalives.
+                            properties:
+                              interval:
+                                description: The time duration between keep-alive
+                                  probes.
+                                type: string
+                              probes:
+                                type: integer
+                              time:
+                                type: string
+                            type: object
+                        type: object
+                    type: object
+                  loadBalancer:
+                    description: Settings controlling the load balancer algorithms.
+                    oneOf:
+                    - not:
+                        anyOf:
+                        - required:
+                          - simple
+                        - properties:
+                            consistentHash:
+                              oneOf:
+                              - not:
+                                  anyOf:
+                                  - required:
+                                    - httpHeaderName
+                                  - required:
+                                    - httpCookie
+                                  - required:
+                                    - useSourceIp
+                                  - required:
+                                    - httpQueryParameterName
+                              - required:
+                                - httpHeaderName
+                              - required:
+                                - httpCookie
+                              - required:
+                                - useSourceIp
+                              - required:
+                                - httpQueryParameterName
+                          required:
+                          - consistentHash
+                    - required:
+                      - simple
+                    - properties:
+                        consistentHash:
+                          oneOf:
+                          - not:
+                              anyOf:
+                              - required:
+                                - httpHeaderName
+                              - required:
+                                - httpCookie
+                              - required:
+                                - useSourceIp
+                              - required:
+                                - httpQueryParameterName
+                          - required:
+                            - httpHeaderName
+                          - required:
+                            - httpCookie
+                          - required:
+                            - useSourceIp
+                          - required:
+                            - httpQueryParameterName
+                      required:
+                      - consistentHash
+                    properties:
+                      consistentHash:
+                        properties:
+                          httpCookie:
+                            description: Hash based on HTTP cookie.
+                            properties:
+                              name:
+                                description: Name of the cookie.
+                                format: string
+                                type: string
+                              path:
+                                description: Path to set for the cookie.
+                                format: string
+                                type: string
+                              ttl:
+                                description: Lifetime of the cookie.
+                                type: string
+                            type: object
+                          httpHeaderName:
+                            description: Hash based on a specific HTTP header.
+                            format: string
+                            type: string
+                          httpQueryParameterName:
+                            description: Hash based on a specific HTTP query parameter.
+                            format: string
+                            type: string
+                          minimumRingSize:
+                            type: integer
+                          useSourceIp:
+                            description: Hash based on the source IP address.
+                            type: boolean
+                        type: object
+                      localityLbSetting:
+                        properties:
+                          distribute:
+                            description: 'Optional: only one of distribute or failover
+                              can be set.'
+                            items:
+                              properties:
+                                from:
+                                  description: Originating locality, '/' separated,
+                                    e.g.
+                                  format: string
+                                  type: string
+                                to:
+                                  additionalProperties:
+                                    type: integer
+                                  description: Map of upstream localities to traffic
+                                    distribution weights.
+                                  type: object
+                              type: object
+                            type: array
+                          enabled:
+                            description: enable locality load balancing, this is DestinationRule-level
+                              and will override mesh wide settings in entirety.
+                            nullable: true
+                            type: boolean
+                          failover:
+                            description: 'Optional: only failover or distribute can
+                              be set.'
+                            items:
+                              properties:
+                                from:
+                                  description: Originating region.
+                                  format: string
+                                  type: string
+                                to:
+                                  format: string
+                                  type: string
+                              type: object
+                            type: array
+                        type: object
+                      simple:
+                        enum:
+                        - ROUND_ROBIN
+                        - LEAST_CONN
+                        - RANDOM
+                        - PASSTHROUGH
+                        type: string
+                    type: object
+                  outlierDetection:
+                    properties:
+                      baseEjectionTime:
+                        description: Minimum ejection duration.
+                        type: string
+                      consecutive5xxErrors:
+                        description: Number of 5xx errors before a host is ejected
+                          from the connection pool.
+                        nullable: true
+                        type: integer
+                      consecutiveErrors:
+                        format: int32
+                        type: integer
+                      consecutiveGatewayErrors:
+                        description: Number of gateway errors before a host is ejected
+                          from the connection pool.
+                        nullable: true
+                        type: integer
+                      interval:
+                        description: Time interval between ejection sweep analysis.
+                        type: string
+                      maxEjectionPercent:
+                        format: int32
+                        type: integer
+                      minHealthPercent:
+                        format: int32
+                        type: integer
+                    type: object
+                  portLevelSettings:
+                    description: Traffic policies specific to individual ports.
+                    items:
+                      properties:
+                        connectionPool:
+                          properties:
+                            http:
+                              description: HTTP connection pool settings.
+                              properties:
+                                h2UpgradePolicy:
+                                  description: Specify if http1.1 connection should
+                                    be upgraded to http2 for the associated destination.
+                                  enum:
+                                  - DEFAULT
+                                  - DO_NOT_UPGRADE
+                                  - UPGRADE
+                                  type: string
+                                http1MaxPendingRequests:
+                                  description: Maximum number of pending HTTP requests
+                                    to a destination.
+                                  format: int32
+                                  type: integer
+                                http2MaxRequests:
+                                  description: Maximum number of requests to a backend.
+                                  format: int32
+                                  type: integer
+                                idleTimeout:
+                                  description: The idle timeout for upstream connection
+                                    pool connections.
+                                  type: string
+                                maxRequestsPerConnection:
+                                  description: Maximum number of requests per connection
+                                    to a backend.
+                                  format: int32
+                                  type: integer
+                                maxRetries:
+                                  format: int32
+                                  type: integer
+                              type: object
+                            tcp:
+                              description: Settings common to both HTTP and TCP upstream
+                                connections.
+                              properties:
+                                connectTimeout:
+                                  description: TCP connection timeout.
+                                  type: string
+                                maxConnections:
+                                  description: Maximum number of HTTP1 /TCP connections
+                                    to a destination host.
+                                  format: int32
+                                  type: integer
+                                tcpKeepalive:
+                                  description: If set then set SO_KEEPALIVE on the
+                                    socket to enable TCP Keepalives.
+                                  properties:
+                                    interval:
+                                      description: The time duration between keep-alive
+                                        probes.
+                                      type: string
+                                    probes:
+                                      type: integer
+                                    time:
+                                      type: string
+                                  type: object
+                              type: object
+                          type: object
+                        loadBalancer:
+                          description: Settings controlling the load balancer algorithms.
+                          oneOf:
+                          - not:
+                              anyOf:
+                              - required:
+                                - simple
+                              - properties:
+                                  consistentHash:
+                                    oneOf:
+                                    - not:
+                                        anyOf:
+                                        - required:
+                                          - httpHeaderName
+                                        - required:
+                                          - httpCookie
+                                        - required:
+                                          - useSourceIp
+                                        - required:
+                                          - httpQueryParameterName
+                                    - required:
+                                      - httpHeaderName
+                                    - required:
+                                      - httpCookie
+                                    - required:
+                                      - useSourceIp
+                                    - required:
+                                      - httpQueryParameterName
+                                required:
+                                - consistentHash
+                          - required:
+                            - simple
+                          - properties:
+                              consistentHash:
+                                oneOf:
+                                - not:
+                                    anyOf:
+                                    - required:
+                                      - httpHeaderName
+                                    - required:
+                                      - httpCookie
+                                    - required:
+                                      - useSourceIp
+                                    - required:
+                                      - httpQueryParameterName
+                                - required:
+                                  - httpHeaderName
+                                - required:
+                                  - httpCookie
+                                - required:
+                                  - useSourceIp
+                                - required:
+                                  - httpQueryParameterName
+                            required:
+                            - consistentHash
+                          properties:
+                            consistentHash:
+                              properties:
+                                httpCookie:
+                                  description: Hash based on HTTP cookie.
+                                  properties:
+                                    name:
+                                      description: Name of the cookie.
+                                      format: string
+                                      type: string
+                                    path:
+                                      description: Path to set for the cookie.
+                                      format: string
+                                      type: string
+                                    ttl:
+                                      description: Lifetime of the cookie.
+                                      type: string
+                                  type: object
+                                httpHeaderName:
+                                  description: Hash based on a specific HTTP header.
+                                  format: string
+                                  type: string
+                                httpQueryParameterName:
+                                  description: Hash based on a specific HTTP query
+                                    parameter.
+                                  format: string
+                                  type: string
+                                minimumRingSize:
+                                  type: integer
+                                useSourceIp:
+                                  description: Hash based on the source IP address.
+                                  type: boolean
+                              type: object
+                            localityLbSetting:
+                              properties:
+                                distribute:
+                                  description: 'Optional: only one of distribute or
+                                    failover can be set.'
+                                  items:
+                                    properties:
+                                      from:
+                                        description: Originating locality, '/' separated,
+                                          e.g.
+                                        format: string
+                                        type: string
+                                      to:
+                                        additionalProperties:
+                                          type: integer
+                                        description: Map of upstream localities to
+                                          traffic distribution weights.
+                                        type: object
+                                    type: object
+                                  type: array
+                                enabled:
+                                  description: enable locality load balancing, this
+                                    is DestinationRule-level and will override mesh
+                                    wide settings in entirety.
+                                  nullable: true
+                                  type: boolean
+                                failover:
+                                  description: 'Optional: only failover or distribute
+                                    can be set.'
+                                  items:
+                                    properties:
+                                      from:
+                                        description: Originating region.
+                                        format: string
+                                        type: string
+                                      to:
+                                        format: string
+                                        type: string
+                                    type: object
+                                  type: array
+                              type: object
+                            simple:
+                              enum:
+                              - ROUND_ROBIN
+                              - LEAST_CONN
+                              - RANDOM
+                              - PASSTHROUGH
+                              type: string
+                          type: object
+                        outlierDetection:
+                          properties:
+                            baseEjectionTime:
+                              description: Minimum ejection duration.
+                              type: string
+                            consecutive5xxErrors:
+                              description: Number of 5xx errors before a host is ejected
+                                from the connection pool.
+                              nullable: true
+                              type: integer
+                            consecutiveErrors:
+                              format: int32
+                              type: integer
+                            consecutiveGatewayErrors:
+                              description: Number of gateway errors before a host
+                                is ejected from the connection pool.
+                              nullable: true
+                              type: integer
+                            interval:
+                              description: Time interval between ejection sweep analysis.
+                              type: string
+                            maxEjectionPercent:
+                              format: int32
+                              type: integer
+                            minHealthPercent:
+                              format: int32
+                              type: integer
+                          type: object
+                        port:
+                          properties:
+                            number:
+                              type: integer
+                          type: object
+                        tls:
+                          description: TLS related settings for connections to the
+                            upstream service.
+                          properties:
+                            caCertificates:
+                              format: string
+                              type: string
+                            clientCertificate:
+                              description: REQUIRED if mode is `MUTUAL`.
+                              format: string
+                              type: string
+                            credentialName:
+                              format: string
+                              type: string
+                            mode:
+                              enum:
+                              - DISABLE
+                              - SIMPLE
+                              - MUTUAL
+                              - ISTIO_MUTUAL
+                              type: string
+                            privateKey:
+                              description: REQUIRED if mode is `MUTUAL`.
+                              format: string
+                              type: string
+                            sni:
+                              description: SNI string to present to the server during
+                                TLS handshake.
+                              format: string
+                              type: string
+                            subjectAltNames:
+                              items:
+                                format: string
+                                type: string
+                              type: array
+                          type: object
+                      type: object
+                    type: array
+                  tls:
+                    description: TLS related settings for connections to the upstream
+                      service.
+                    properties:
+                      caCertificates:
+                        format: string
+                        type: string
+                      clientCertificate:
+                        description: REQUIRED if mode is `MUTUAL`.
+                        format: string
+                        type: string
+                      credentialName:
+                        format: string
+                        type: string
+                      mode:
+                        enum:
+                        - DISABLE
+                        - SIMPLE
+                        - MUTUAL
+                        - ISTIO_MUTUAL
+                        type: string
+                      privateKey:
+                        description: REQUIRED if mode is `MUTUAL`.
+                        format: string
+                        type: string
+                      sni:
+                        description: SNI string to present to the server during TLS
+                          handshake.
+                        format: string
+                        type: string
+                      subjectAltNames:
+                        items:
+                          format: string
+                          type: string
+                        type: array
+                    type: object
+                type: object
+            type: object
+          status:
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+  - additionalPrinterColumns:
+    - description: The name of a service from the service registry
+      jsonPath: .spec.host
+      name: Host
+      type: string
+    - description: 'CreationTimestamp is a timestamp representing the server time
+        when this object was created. It is not guaranteed to be set in happens-before
+        order across separate operations. Clients may not set this value. It is represented
+        in RFC3339 form and is in UTC. Populated by the system. Read-only. Null for
+        lists. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata'
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        properties:
+          spec:
+            description: 'Configuration affecting load balancing, outlier detection,
+              etc. See more details at: https://istio.io/docs/reference/config/networking/destination-rule.html'
+            properties:
+              exportTo:
+                description: A list of namespaces to which this destination rule is
+                  exported.
+                items:
+                  format: string
+                  type: string
+                type: array
+              host:
+                description: The name of a service from the service registry.
+                format: string
+                type: string
+              subsets:
+                items:
+                  properties:
+                    labels:
+                      additionalProperties:
+                        format: string
+                        type: string
+                      type: object
+                    name:
+                      description: Name of the subset.
+                      format: string
+                      type: string
+                    trafficPolicy:
+                      description: Traffic policies that apply to this subset.
+                      properties:
+                        connectionPool:
+                          properties:
+                            http:
+                              description: HTTP connection pool settings.
+                              properties:
+                                h2UpgradePolicy:
+                                  description: Specify if http1.1 connection should
+                                    be upgraded to http2 for the associated destination.
+                                  enum:
+                                  - DEFAULT
+                                  - DO_NOT_UPGRADE
+                                  - UPGRADE
+                                  type: string
+                                http1MaxPendingRequests:
+                                  description: Maximum number of pending HTTP requests
+                                    to a destination.
+                                  format: int32
+                                  type: integer
+                                http2MaxRequests:
+                                  description: Maximum number of requests to a backend.
+                                  format: int32
+                                  type: integer
+                                idleTimeout:
+                                  description: The idle timeout for upstream connection
+                                    pool connections.
+                                  type: string
+                                maxRequestsPerConnection:
+                                  description: Maximum number of requests per connection
+                                    to a backend.
+                                  format: int32
+                                  type: integer
+                                maxRetries:
+                                  format: int32
+                                  type: integer
+                              type: object
+                            tcp:
+                              description: Settings common to both HTTP and TCP upstream
+                                connections.
+                              properties:
+                                connectTimeout:
+                                  description: TCP connection timeout.
+                                  type: string
+                                maxConnections:
+                                  description: Maximum number of HTTP1 /TCP connections
+                                    to a destination host.
+                                  format: int32
+                                  type: integer
+                                tcpKeepalive:
+                                  description: If set then set SO_KEEPALIVE on the
+                                    socket to enable TCP Keepalives.
+                                  properties:
+                                    interval:
+                                      description: The time duration between keep-alive
+                                        probes.
+                                      type: string
+                                    probes:
+                                      type: integer
+                                    time:
+                                      type: string
+                                  type: object
+                              type: object
+                          type: object
+                        loadBalancer:
+                          description: Settings controlling the load balancer algorithms.
+                          oneOf:
+                          - not:
+                              anyOf:
+                              - required:
+                                - simple
+                              - properties:
+                                  consistentHash:
+                                    oneOf:
+                                    - not:
+                                        anyOf:
+                                        - required:
+                                          - httpHeaderName
+                                        - required:
+                                          - httpCookie
+                                        - required:
+                                          - useSourceIp
+                                        - required:
+                                          - httpQueryParameterName
+                                    - required:
+                                      - httpHeaderName
+                                    - required:
+                                      - httpCookie
+                                    - required:
+                                      - useSourceIp
+                                    - required:
+                                      - httpQueryParameterName
+                                required:
+                                - consistentHash
+                          - required:
+                            - simple
+                          - properties:
+                              consistentHash:
+                                oneOf:
+                                - not:
+                                    anyOf:
+                                    - required:
+                                      - httpHeaderName
+                                    - required:
+                                      - httpCookie
+                                    - required:
+                                      - useSourceIp
+                                    - required:
+                                      - httpQueryParameterName
+                                - required:
+                                  - httpHeaderName
+                                - required:
+                                  - httpCookie
+                                - required:
+                                  - useSourceIp
+                                - required:
+                                  - httpQueryParameterName
+                            required:
+                            - consistentHash
+                          properties:
+                            consistentHash:
+                              properties:
+                                httpCookie:
+                                  description: Hash based on HTTP cookie.
+                                  properties:
+                                    name:
+                                      description: Name of the cookie.
+                                      format: string
+                                      type: string
+                                    path:
+                                      description: Path to set for the cookie.
+                                      format: string
+                                      type: string
+                                    ttl:
+                                      description: Lifetime of the cookie.
+                                      type: string
+                                  type: object
+                                httpHeaderName:
+                                  description: Hash based on a specific HTTP header.
+                                  format: string
+                                  type: string
+                                httpQueryParameterName:
+                                  description: Hash based on a specific HTTP query
+                                    parameter.
+                                  format: string
+                                  type: string
+                                minimumRingSize:
+                                  type: integer
+                                useSourceIp:
+                                  description: Hash based on the source IP address.
+                                  type: boolean
+                              type: object
+                            localityLbSetting:
+                              properties:
+                                distribute:
+                                  description: 'Optional: only one of distribute or
+                                    failover can be set.'
+                                  items:
+                                    properties:
+                                      from:
+                                        description: Originating locality, '/' separated,
+                                          e.g.
+                                        format: string
+                                        type: string
+                                      to:
+                                        additionalProperties:
+                                          type: integer
+                                        description: Map of upstream localities to
+                                          traffic distribution weights.
+                                        type: object
+                                    type: object
+                                  type: array
+                                enabled:
+                                  description: enable locality load balancing, this
+                                    is DestinationRule-level and will override mesh
+                                    wide settings in entirety.
+                                  nullable: true
+                                  type: boolean
+                                failover:
+                                  description: 'Optional: only failover or distribute
+                                    can be set.'
+                                  items:
+                                    properties:
+                                      from:
+                                        description: Originating region.
+                                        format: string
+                                        type: string
+                                      to:
+                                        format: string
+                                        type: string
+                                    type: object
+                                  type: array
+                              type: object
+                            simple:
+                              enum:
+                              - ROUND_ROBIN
+                              - LEAST_CONN
+                              - RANDOM
+                              - PASSTHROUGH
+                              type: string
+                          type: object
+                        outlierDetection:
+                          properties:
+                            baseEjectionTime:
+                              description: Minimum ejection duration.
+                              type: string
+                            consecutive5xxErrors:
+                              description: Number of 5xx errors before a host is ejected
+                                from the connection pool.
+                              nullable: true
+                              type: integer
+                            consecutiveErrors:
+                              format: int32
+                              type: integer
+                            consecutiveGatewayErrors:
+                              description: Number of gateway errors before a host
+                                is ejected from the connection pool.
+                              nullable: true
+                              type: integer
+                            interval:
+                              description: Time interval between ejection sweep analysis.
+                              type: string
+                            maxEjectionPercent:
+                              format: int32
+                              type: integer
+                            minHealthPercent:
+                              format: int32
+                              type: integer
+                          type: object
+                        portLevelSettings:
+                          description: Traffic policies specific to individual ports.
+                          items:
+                            properties:
+                              connectionPool:
+                                properties:
+                                  http:
+                                    description: HTTP connection pool settings.
+                                    properties:
+                                      h2UpgradePolicy:
+                                        description: Specify if http1.1 connection
+                                          should be upgraded to http2 for the associated
+                                          destination.
+                                        enum:
+                                        - DEFAULT
+                                        - DO_NOT_UPGRADE
+                                        - UPGRADE
+                                        type: string
+                                      http1MaxPendingRequests:
+                                        description: Maximum number of pending HTTP
+                                          requests to a destination.
+                                        format: int32
+                                        type: integer
+                                      http2MaxRequests:
+                                        description: Maximum number of requests to
+                                          a backend.
+                                        format: int32
+                                        type: integer
+                                      idleTimeout:
+                                        description: The idle timeout for upstream
+                                          connection pool connections.
+                                        type: string
+                                      maxRequestsPerConnection:
+                                        description: Maximum number of requests per
+                                          connection to a backend.
+                                        format: int32
+                                        type: integer
+                                      maxRetries:
+                                        format: int32
+                                        type: integer
+                                    type: object
+                                  tcp:
+                                    description: Settings common to both HTTP and
+                                      TCP upstream connections.
+                                    properties:
+                                      connectTimeout:
+                                        description: TCP connection timeout.
+                                        type: string
+                                      maxConnections:
+                                        description: Maximum number of HTTP1 /TCP
+                                          connections to a destination host.
+                                        format: int32
+                                        type: integer
+                                      tcpKeepalive:
+                                        description: If set then set SO_KEEPALIVE
+                                          on the socket to enable TCP Keepalives.
+                                        properties:
+                                          interval:
+                                            description: The time duration between
+                                              keep-alive probes.
+                                            type: string
+                                          probes:
+                                            type: integer
+                                          time:
+                                            type: string
+                                        type: object
+                                    type: object
+                                type: object
+                              loadBalancer:
+                                description: Settings controlling the load balancer
+                                  algorithms.
+                                oneOf:
+                                - not:
+                                    anyOf:
+                                    - required:
+                                      - simple
+                                    - properties:
+                                        consistentHash:
+                                          oneOf:
+                                          - not:
+                                              anyOf:
+                                              - required:
+                                                - httpHeaderName
+                                              - required:
+                                                - httpCookie
+                                              - required:
+                                                - useSourceIp
+                                              - required:
+                                                - httpQueryParameterName
+                                          - required:
+                                            - httpHeaderName
+                                          - required:
+                                            - httpCookie
+                                          - required:
+                                            - useSourceIp
+                                          - required:
+                                            - httpQueryParameterName
+                                      required:
+                                      - consistentHash
+                                - required:
+                                  - simple
+                                - properties:
+                                    consistentHash:
+                                      oneOf:
+                                      - not:
+                                          anyOf:
+                                          - required:
+                                            - httpHeaderName
+                                          - required:
+                                            - httpCookie
+                                          - required:
+                                            - useSourceIp
+                                          - required:
+                                            - httpQueryParameterName
+                                      - required:
+                                        - httpHeaderName
+                                      - required:
+                                        - httpCookie
+                                      - required:
+                                        - useSourceIp
+                                      - required:
+                                        - httpQueryParameterName
+                                  required:
+                                  - consistentHash
+                                properties:
+                                  consistentHash:
+                                    properties:
+                                      httpCookie:
+                                        description: Hash based on HTTP cookie.
+                                        properties:
+                                          name:
+                                            description: Name of the cookie.
+                                            format: string
+                                            type: string
+                                          path:
+                                            description: Path to set for the cookie.
+                                            format: string
+                                            type: string
+                                          ttl:
+                                            description: Lifetime of the cookie.
+                                            type: string
+                                        type: object
+                                      httpHeaderName:
+                                        description: Hash based on a specific HTTP
+                                          header.
+                                        format: string
+                                        type: string
+                                      httpQueryParameterName:
+                                        description: Hash based on a specific HTTP
+                                          query parameter.
+                                        format: string
+                                        type: string
+                                      minimumRingSize:
+                                        type: integer
+                                      useSourceIp:
+                                        description: Hash based on the source IP address.
+                                        type: boolean
+                                    type: object
+                                  localityLbSetting:
+                                    properties:
+                                      distribute:
+                                        description: 'Optional: only one of distribute
+                                          or failover can be set.'
+                                        items:
+                                          properties:
+                                            from:
+                                              description: Originating locality, '/'
+                                                separated, e.g.
+                                              format: string
+                                              type: string
+                                            to:
+                                              additionalProperties:
+                                                type: integer
+                                              description: Map of upstream localities
+                                                to traffic distribution weights.
+                                              type: object
+                                          type: object
+                                        type: array
+                                      enabled:
+                                        description: enable locality load balancing,
+                                          this is DestinationRule-level and will override
+                                          mesh wide settings in entirety.
+                                        nullable: true
+                                        type: boolean
+                                      failover:
+                                        description: 'Optional: only failover or distribute
+                                          can be set.'
+                                        items:
+                                          properties:
+                                            from:
+                                              description: Originating region.
+                                              format: string
+                                              type: string
+                                            to:
+                                              format: string
+                                              type: string
+                                          type: object
+                                        type: array
+                                    type: object
+                                  simple:
+                                    enum:
+                                    - ROUND_ROBIN
+                                    - LEAST_CONN
+                                    - RANDOM
+                                    - PASSTHROUGH
+                                    type: string
+                                type: object
+                              outlierDetection:
+                                properties:
+                                  baseEjectionTime:
+                                    description: Minimum ejection duration.
+                                    type: string
+                                  consecutive5xxErrors:
+                                    description: Number of 5xx errors before a host
+                                      is ejected from the connection pool.
+                                    nullable: true
+                                    type: integer
+                                  consecutiveErrors:
+                                    format: int32
+                                    type: integer
+                                  consecutiveGatewayErrors:
+                                    description: Number of gateway errors before a
+                                      host is ejected from the connection pool.
+                                    nullable: true
+                                    type: integer
+                                  interval:
+                                    description: Time interval between ejection sweep
+                                      analysis.
+                                    type: string
+                                  maxEjectionPercent:
+                                    format: int32
+                                    type: integer
+                                  minHealthPercent:
+                                    format: int32
+                                    type: integer
+                                type: object
+                              port:
+                                properties:
+                                  number:
+                                    type: integer
+                                type: object
+                              tls:
+                                description: TLS related settings for connections
+                                  to the upstream service.
+                                properties:
+                                  caCertificates:
+                                    format: string
+                                    type: string
+                                  clientCertificate:
+                                    description: REQUIRED if mode is `MUTUAL`.
+                                    format: string
+                                    type: string
+                                  credentialName:
+                                    format: string
+                                    type: string
+                                  mode:
+                                    enum:
+                                    - DISABLE
+                                    - SIMPLE
+                                    - MUTUAL
+                                    - ISTIO_MUTUAL
+                                    type: string
+                                  privateKey:
+                                    description: REQUIRED if mode is `MUTUAL`.
+                                    format: string
+                                    type: string
+                                  sni:
+                                    description: SNI string to present to the server
+                                      during TLS handshake.
+                                    format: string
+                                    type: string
+                                  subjectAltNames:
+                                    items:
+                                      format: string
+                                      type: string
+                                    type: array
+                                type: object
+                            type: object
+                          type: array
+                        tls:
+                          description: TLS related settings for connections to the
+                            upstream service.
+                          properties:
+                            caCertificates:
+                              format: string
+                              type: string
+                            clientCertificate:
+                              description: REQUIRED if mode is `MUTUAL`.
+                              format: string
+                              type: string
+                            credentialName:
+                              format: string
+                              type: string
+                            mode:
+                              enum:
+                              - DISABLE
+                              - SIMPLE
+                              - MUTUAL
+                              - ISTIO_MUTUAL
+                              type: string
+                            privateKey:
+                              description: REQUIRED if mode is `MUTUAL`.
+                              format: string
+                              type: string
+                            sni:
+                              description: SNI string to present to the server during
+                                TLS handshake.
+                              format: string
+                              type: string
+                            subjectAltNames:
+                              items:
+                                format: string
+                                type: string
+                              type: array
+                          type: object
+                      type: object
+                  type: object
+                type: array
+              trafficPolicy:
+                properties:
+                  connectionPool:
+                    properties:
+                      http:
+                        description: HTTP connection pool settings.
+                        properties:
+                          h2UpgradePolicy:
+                            description: Specify if http1.1 connection should be upgraded
+                              to http2 for the associated destination.
+                            enum:
+                            - DEFAULT
+                            - DO_NOT_UPGRADE
+                            - UPGRADE
+                            type: string
+                          http1MaxPendingRequests:
+                            description: Maximum number of pending HTTP requests to
+                              a destination.
+                            format: int32
+                            type: integer
+                          http2MaxRequests:
+                            description: Maximum number of requests to a backend.
+                            format: int32
+                            type: integer
+                          idleTimeout:
+                            description: The idle timeout for upstream connection
+                              pool connections.
+                            type: string
+                          maxRequestsPerConnection:
+                            description: Maximum number of requests per connection
+                              to a backend.
+                            format: int32
+                            type: integer
+                          maxRetries:
+                            format: int32
+                            type: integer
+                        type: object
+                      tcp:
+                        description: Settings common to both HTTP and TCP upstream
+                          connections.
+                        properties:
+                          connectTimeout:
+                            description: TCP connection timeout.
+                            type: string
+                          maxConnections:
+                            description: Maximum number of HTTP1 /TCP connections
+                              to a destination host.
+                            format: int32
+                            type: integer
+                          tcpKeepalive:
+                            description: If set then set SO_KEEPALIVE on the socket
+                              to enable TCP Keepalives.
+                            properties:
+                              interval:
+                                description: The time duration between keep-alive
+                                  probes.
+                                type: string
+                              probes:
+                                type: integer
+                              time:
+                                type: string
+                            type: object
+                        type: object
+                    type: object
+                  loadBalancer:
+                    description: Settings controlling the load balancer algorithms.
+                    oneOf:
+                    - not:
+                        anyOf:
+                        - required:
+                          - simple
+                        - properties:
+                            consistentHash:
+                              oneOf:
+                              - not:
+                                  anyOf:
+                                  - required:
+                                    - httpHeaderName
+                                  - required:
+                                    - httpCookie
+                                  - required:
+                                    - useSourceIp
+                                  - required:
+                                    - httpQueryParameterName
+                              - required:
+                                - httpHeaderName
+                              - required:
+                                - httpCookie
+                              - required:
+                                - useSourceIp
+                              - required:
+                                - httpQueryParameterName
+                          required:
+                          - consistentHash
+                    - required:
+                      - simple
+                    - properties:
+                        consistentHash:
+                          oneOf:
+                          - not:
+                              anyOf:
+                              - required:
+                                - httpHeaderName
+                              - required:
+                                - httpCookie
+                              - required:
+                                - useSourceIp
+                              - required:
+                                - httpQueryParameterName
+                          - required:
+                            - httpHeaderName
+                          - required:
+                            - httpCookie
+                          - required:
+                            - useSourceIp
+                          - required:
+                            - httpQueryParameterName
+                      required:
+                      - consistentHash
+                    properties:
+                      consistentHash:
+                        properties:
+                          httpCookie:
+                            description: Hash based on HTTP cookie.
+                            properties:
+                              name:
+                                description: Name of the cookie.
+                                format: string
+                                type: string
+                              path:
+                                description: Path to set for the cookie.
+                                format: string
+                                type: string
+                              ttl:
+                                description: Lifetime of the cookie.
+                                type: string
+                            type: object
+                          httpHeaderName:
+                            description: Hash based on a specific HTTP header.
+                            format: string
+                            type: string
+                          httpQueryParameterName:
+                            description: Hash based on a specific HTTP query parameter.
+                            format: string
+                            type: string
+                          minimumRingSize:
+                            type: integer
+                          useSourceIp:
+                            description: Hash based on the source IP address.
+                            type: boolean
+                        type: object
+                      localityLbSetting:
+                        properties:
+                          distribute:
+                            description: 'Optional: only one of distribute or failover
+                              can be set.'
+                            items:
+                              properties:
+                                from:
+                                  description: Originating locality, '/' separated,
+                                    e.g.
+                                  format: string
+                                  type: string
+                                to:
+                                  additionalProperties:
+                                    type: integer
+                                  description: Map of upstream localities to traffic
+                                    distribution weights.
+                                  type: object
+                              type: object
+                            type: array
+                          enabled:
+                            description: enable locality load balancing, this is DestinationRule-level
+                              and will override mesh wide settings in entirety.
+                            nullable: true
+                            type: boolean
+                          failover:
+                            description: 'Optional: only failover or distribute can
+                              be set.'
+                            items:
+                              properties:
+                                from:
+                                  description: Originating region.
+                                  format: string
+                                  type: string
+                                to:
+                                  format: string
+                                  type: string
+                              type: object
+                            type: array
+                        type: object
+                      simple:
+                        enum:
+                        - ROUND_ROBIN
+                        - LEAST_CONN
+                        - RANDOM
+                        - PASSTHROUGH
+                        type: string
+                    type: object
+                  outlierDetection:
+                    properties:
+                      baseEjectionTime:
+                        description: Minimum ejection duration.
+                        type: string
+                      consecutive5xxErrors:
+                        description: Number of 5xx errors before a host is ejected
+                          from the connection pool.
+                        nullable: true
+                        type: integer
+                      consecutiveErrors:
+                        format: int32
+                        type: integer
+                      consecutiveGatewayErrors:
+                        description: Number of gateway errors before a host is ejected
+                          from the connection pool.
+                        nullable: true
+                        type: integer
+                      interval:
+                        description: Time interval between ejection sweep analysis.
+                        type: string
+                      maxEjectionPercent:
+                        format: int32
+                        type: integer
+                      minHealthPercent:
+                        format: int32
+                        type: integer
+                    type: object
+                  portLevelSettings:
+                    description: Traffic policies specific to individual ports.
+                    items:
+                      properties:
+                        connectionPool:
+                          properties:
+                            http:
+                              description: HTTP connection pool settings.
+                              properties:
+                                h2UpgradePolicy:
+                                  description: Specify if http1.1 connection should
+                                    be upgraded to http2 for the associated destination.
+                                  enum:
+                                  - DEFAULT
+                                  - DO_NOT_UPGRADE
+                                  - UPGRADE
+                                  type: string
+                                http1MaxPendingRequests:
+                                  description: Maximum number of pending HTTP requests
+                                    to a destination.
+                                  format: int32
+                                  type: integer
+                                http2MaxRequests:
+                                  description: Maximum number of requests to a backend.
+                                  format: int32
+                                  type: integer
+                                idleTimeout:
+                                  description: The idle timeout for upstream connection
+                                    pool connections.
+                                  type: string
+                                maxRequestsPerConnection:
+                                  description: Maximum number of requests per connection
+                                    to a backend.
+                                  format: int32
+                                  type: integer
+                                maxRetries:
+                                  format: int32
+                                  type: integer
+                              type: object
+                            tcp:
+                              description: Settings common to both HTTP and TCP upstream
+                                connections.
+                              properties:
+                                connectTimeout:
+                                  description: TCP connection timeout.
+                                  type: string
+                                maxConnections:
+                                  description: Maximum number of HTTP1 /TCP connections
+                                    to a destination host.
+                                  format: int32
+                                  type: integer
+                                tcpKeepalive:
+                                  description: If set then set SO_KEEPALIVE on the
+                                    socket to enable TCP Keepalives.
+                                  properties:
+                                    interval:
+                                      description: The time duration between keep-alive
+                                        probes.
+                                      type: string
+                                    probes:
+                                      type: integer
+                                    time:
+                                      type: string
+                                  type: object
+                              type: object
+                          type: object
+                        loadBalancer:
+                          description: Settings controlling the load balancer algorithms.
+                          oneOf:
+                          - not:
+                              anyOf:
+                              - required:
+                                - simple
+                              - properties:
+                                  consistentHash:
+                                    oneOf:
+                                    - not:
+                                        anyOf:
+                                        - required:
+                                          - httpHeaderName
+                                        - required:
+                                          - httpCookie
+                                        - required:
+                                          - useSourceIp
+                                        - required:
+                                          - httpQueryParameterName
+                                    - required:
+                                      - httpHeaderName
+                                    - required:
+                                      - httpCookie
+                                    - required:
+                                      - useSourceIp
+                                    - required:
+                                      - httpQueryParameterName
+                                required:
+                                - consistentHash
+                          - required:
+                            - simple
+                          - properties:
+                              consistentHash:
+                                oneOf:
+                                - not:
+                                    anyOf:
+                                    - required:
+                                      - httpHeaderName
+                                    - required:
+                                      - httpCookie
+                                    - required:
+                                      - useSourceIp
+                                    - required:
+                                      - httpQueryParameterName
+                                - required:
+                                  - httpHeaderName
+                                - required:
+                                  - httpCookie
+                                - required:
+                                  - useSourceIp
+                                - required:
+                                  - httpQueryParameterName
+                            required:
+                            - consistentHash
+                          properties:
+                            consistentHash:
+                              properties:
+                                httpCookie:
+                                  description: Hash based on HTTP cookie.
+                                  properties:
+                                    name:
+                                      description: Name of the cookie.
+                                      format: string
+                                      type: string
+                                    path:
+                                      description: Path to set for the cookie.
+                                      format: string
+                                      type: string
+                                    ttl:
+                                      description: Lifetime of the cookie.
+                                      type: string
+                                  type: object
+                                httpHeaderName:
+                                  description: Hash based on a specific HTTP header.
+                                  format: string
+                                  type: string
+                                httpQueryParameterName:
+                                  description: Hash based on a specific HTTP query
+                                    parameter.
+                                  format: string
+                                  type: string
+                                minimumRingSize:
+                                  type: integer
+                                useSourceIp:
+                                  description: Hash based on the source IP address.
+                                  type: boolean
+                              type: object
+                            localityLbSetting:
+                              properties:
+                                distribute:
+                                  description: 'Optional: only one of distribute or
+                                    failover can be set.'
+                                  items:
+                                    properties:
+                                      from:
+                                        description: Originating locality, '/' separated,
+                                          e.g.
+                                        format: string
+                                        type: string
+                                      to:
+                                        additionalProperties:
+                                          type: integer
+                                        description: Map of upstream localities to
+                                          traffic distribution weights.
+                                        type: object
+                                    type: object
+                                  type: array
+                                enabled:
+                                  description: enable locality load balancing, this
+                                    is DestinationRule-level and will override mesh
+                                    wide settings in entirety.
+                                  nullable: true
+                                  type: boolean
+                                failover:
+                                  description: 'Optional: only failover or distribute
+                                    can be set.'
+                                  items:
+                                    properties:
+                                      from:
+                                        description: Originating region.
+                                        format: string
+                                        type: string
+                                      to:
+                                        format: string
+                                        type: string
+                                    type: object
+                                  type: array
+                              type: object
+                            simple:
+                              enum:
+                              - ROUND_ROBIN
+                              - LEAST_CONN
+                              - RANDOM
+                              - PASSTHROUGH
+                              type: string
+                          type: object
+                        outlierDetection:
+                          properties:
+                            baseEjectionTime:
+                              description: Minimum ejection duration.
+                              type: string
+                            consecutive5xxErrors:
+                              description: Number of 5xx errors before a host is ejected
+                                from the connection pool.
+                              nullable: true
+                              type: integer
+                            consecutiveErrors:
+                              format: int32
+                              type: integer
+                            consecutiveGatewayErrors:
+                              description: Number of gateway errors before a host
+                                is ejected from the connection pool.
+                              nullable: true
+                              type: integer
+                            interval:
+                              description: Time interval between ejection sweep analysis.
+                              type: string
+                            maxEjectionPercent:
+                              format: int32
+                              type: integer
+                            minHealthPercent:
+                              format: int32
+                              type: integer
+                          type: object
+                        port:
+                          properties:
+                            number:
+                              type: integer
+                          type: object
+                        tls:
+                          description: TLS related settings for connections to the
+                            upstream service.
+                          properties:
+                            caCertificates:
+                              format: string
+                              type: string
+                            clientCertificate:
+                              description: REQUIRED if mode is `MUTUAL`.
+                              format: string
+                              type: string
+                            credentialName:
+                              format: string
+                              type: string
+                            mode:
+                              enum:
+                              - DISABLE
+                              - SIMPLE
+                              - MUTUAL
+                              - ISTIO_MUTUAL
+                              type: string
+                            privateKey:
+                              description: REQUIRED if mode is `MUTUAL`.
+                              format: string
+                              type: string
+                            sni:
+                              description: SNI string to present to the server during
+                                TLS handshake.
+                              format: string
+                              type: string
+                            subjectAltNames:
+                              items:
+                                format: string
+                                type: string
+                              type: array
+                          type: object
+                      type: object
+                    type: array
+                  tls:
+                    description: TLS related settings for connections to the upstream
+                      service.
+                    properties:
+                      caCertificates:
+                        format: string
+                        type: string
+                      clientCertificate:
+                        description: REQUIRED if mode is `MUTUAL`.
+                        format: string
+                        type: string
+                      credentialName:
+                        format: string
+                        type: string
+                      mode:
+                        enum:
+                        - DISABLE
+                        - SIMPLE
+                        - MUTUAL
+                        - ISTIO_MUTUAL
+                        type: string
+                      privateKey:
+                        description: REQUIRED if mode is `MUTUAL`.
+                        format: string
+                        type: string
+                      sni:
+                        description: SNI string to present to the server during TLS
+                          handshake.
+                        format: string
+                        type: string
+                      subjectAltNames:
+                        items:
+                          format: string
+                          type: string
+                        type: array
+                    type: object
+                type: object
+            type: object
+          status:
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    helm.sh/resource-policy: keep
+  labels:
+    app: istio-pilot
+    chart: istio
+    cloudfoundry.org/istio_version: 1.7.1
+    heritage: Tiller
+    release: istio
+  name: envoyfilters.networking.istio.io
+spec:
+  group: networking.istio.io
+  names:
+    categories:
+    - istio-io
+    - networking-istio-io
+    kind: EnvoyFilter
+    listKind: EnvoyFilterList
+    plural: envoyfilters
+    singular: envoyfilter
+  scope: Namespaced
+  versions:
+  - name: v1alpha3
+    schema:
+      openAPIV3Schema:
+        properties:
+          spec:
+            description: 'Customizing Envoy configuration generated by Istio. See
+              more details at: https://istio.io/docs/reference/config/networking/envoy-filter.html'
+            properties:
+              configPatches:
+                description: One or more patches with match conditions.
+                items:
+                  properties:
+                    applyTo:
+                      enum:
+                      - INVALID
+                      - LISTENER
+                      - FILTER_CHAIN
+                      - NETWORK_FILTER
+                      - HTTP_FILTER
+                      - ROUTE_CONFIGURATION
+                      - VIRTUAL_HOST
+                      - HTTP_ROUTE
+                      - CLUSTER
+                      type: string
+                    match:
+                      description: Match on listener/route configuration/cluster.
+                      oneOf:
+                      - not:
+                          anyOf:
+                          - required:
+                            - listener
+                          - required:
+                            - routeConfiguration
+                          - required:
+                            - cluster
+                      - required:
+                        - listener
+                      - required:
+                        - routeConfiguration
+                      - required:
+                        - cluster
+                      properties:
+                        cluster:
+                          description: Match on envoy cluster attributes.
+                          properties:
+                            name:
+                              description: The exact name of the cluster to match.
+                              format: string
+                              type: string
+                            portNumber:
+                              description: The service port for which this cluster
+                                was generated.
+                              type: integer
+                            service:
+                              description: The fully qualified service name for this
+                                cluster.
+                              format: string
+                              type: string
+                            subset:
+                              description: The subset associated with the service.
+                              format: string
+                              type: string
+                          type: object
+                        context:
+                          description: The specific config generation context to match
+                            on.
+                          enum:
+                          - ANY
+                          - SIDECAR_INBOUND
+                          - SIDECAR_OUTBOUND
+                          - GATEWAY
+                          type: string
+                        listener:
+                          description: Match on envoy listener attributes.
+                          properties:
+                            filterChain:
+                              description: Match a specific filter chain in a listener.
+                              properties:
+                                applicationProtocols:
+                                  description: Applies only to sidecars.
+                                  format: string
+                                  type: string
+                                filter:
+                                  description: The name of a specific filter to apply
+                                    the patch to.
+                                  properties:
+                                    name:
+                                      description: The filter name to match on.
+                                      format: string
+                                      type: string
+                                    subFilter:
+                                      properties:
+                                        name:
+                                          description: The filter name to match on.
+                                          format: string
+                                          type: string
+                                      type: object
+                                  type: object
+                                name:
+                                  description: The name assigned to the filter chain.
+                                  format: string
+                                  type: string
+                                sni:
+                                  description: The SNI value used by a filter chain's
+                                    match condition.
+                                  format: string
+                                  type: string
+                                transportProtocol:
+                                  description: Applies only to SIDECAR_INBOUND context.
+                                  format: string
+                                  type: string
+                              type: object
+                            name:
+                              description: Match a specific listener by its name.
+                              format: string
+                              type: string
+                            portName:
+                              format: string
+                              type: string
+                            portNumber:
+                              type: integer
+                          type: object
+                        proxy:
+                          description: Match on properties associated with a proxy.
+                          properties:
+                            metadata:
+                              additionalProperties:
+                                format: string
+                                type: string
+                              type: object
+                            proxyVersion:
+                              format: string
+                              type: string
+                          type: object
+                        routeConfiguration:
+                          description: Match on envoy HTTP route configuration attributes.
+                          properties:
+                            gateway:
+                              format: string
+                              type: string
+                            name:
+                              description: Route configuration name to match on.
+                              format: string
+                              type: string
+                            portName:
+                              description: Applicable only for GATEWAY context.
+                              format: string
+                              type: string
+                            portNumber:
+                              type: integer
+                            vhost:
+                              properties:
+                                name:
+                                  format: string
+                                  type: string
+                                route:
+                                  description: Match a specific route within the virtual
+                                    host.
+                                  properties:
+                                    action:
+                                      description: Match a route with specific action
+                                        type.
+                                      enum:
+                                      - ANY
+                                      - ROUTE
+                                      - REDIRECT
+                                      - DIRECT_RESPONSE
+                                      type: string
+                                    name:
+                                      format: string
+                                      type: string
+                                  type: object
+                              type: object
+                          type: object
+                      type: object
+                    patch:
+                      description: The patch to apply along with the operation.
+                      properties:
+                        operation:
+                          description: Determines how the patch should be applied.
+                          enum:
+                          - INVALID
+                          - MERGE
+                          - ADD
+                          - REMOVE
+                          - INSERT_BEFORE
+                          - INSERT_AFTER
+                          - INSERT_FIRST
+                          type: string
+                        value:
+                          description: The JSON config of the object being patched.
+                          type: object
+                          x-kubernetes-preserve-unknown-fields: true
+                      type: object
+                  type: object
+                type: array
+              workloadSelector:
+                properties:
+                  labels:
+                    additionalProperties:
+                      format: string
+                      type: string
+                    type: object
+                type: object
+            type: object
+          status:
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    helm.sh/resource-policy: keep
+  labels:
+    app: istio-pilot
+    chart: istio
+    cloudfoundry.org/istio_version: 1.7.1
+    heritage: Tiller
+    release: istio
+  name: gateways.networking.istio.io
+spec:
+  group: networking.istio.io
+  names:
+    categories:
+    - istio-io
+    - networking-istio-io
+    kind: Gateway
+    listKind: GatewayList
+    plural: gateways
+    shortNames:
+    - gw
+    singular: gateway
+  scope: Namespaced
+  versions:
+  - name: v1alpha3
+    schema:
+      openAPIV3Schema:
+        properties:
+          spec:
+            description: 'Configuration affecting edge load balancer. See more details
+              at: https://istio.io/docs/reference/config/networking/gateway.html'
+            properties:
+              selector:
+                additionalProperties:
+                  format: string
+                  type: string
+                type: object
+              servers:
+                description: A list of server specifications.
+                items:
+                  properties:
+                    bind:
+                      format: string
+                      type: string
+                    defaultEndpoint:
+                      format: string
+                      type: string
+                    hosts:
+                      description: One or more hosts exposed by this gateway.
+                      items:
+                        format: string
+                        type: string
+                      type: array
+                    name:
+                      description: An optional name of the server, when set must be
+                        unique across all servers.
+                      format: string
+                      type: string
+                    port:
+                      properties:
+                        name:
+                          description: Label assigned to the port.
+                          format: string
+                          type: string
+                        number:
+                          description: A valid non-negative integer port number.
+                          type: integer
+                        protocol:
+                          description: The protocol exposed on the port.
+                          format: string
+                          type: string
+                        targetPort:
+                          type: integer
+                      type: object
+                    tls:
+                      description: Set of TLS related options that govern the server's
+                        behavior.
+                      properties:
+                        caCertificates:
+                          description: REQUIRED if mode is `MUTUAL`.
+                          format: string
+                          type: string
+                        cipherSuites:
+                          description: 'Optional: If specified, only support the specified
+                            cipher list.'
+                          items:
+                            format: string
+                            type: string
+                          type: array
+                        credentialName:
+                          format: string
+                          type: string
+                        httpsRedirect:
+                          type: boolean
+                        maxProtocolVersion:
+                          description: 'Optional: Maximum TLS protocol version.'
+                          enum:
+                          - TLS_AUTO
+                          - TLSV1_0
+                          - TLSV1_1
+                          - TLSV1_2
+                          - TLSV1_3
+                          type: string
+                        minProtocolVersion:
+                          description: 'Optional: Minimum TLS protocol version.'
+                          enum:
+                          - TLS_AUTO
+                          - TLSV1_0
+                          - TLSV1_1
+                          - TLSV1_2
+                          - TLSV1_3
+                          type: string
+                        mode:
+                          enum:
+                          - PASSTHROUGH
+                          - SIMPLE
+                          - MUTUAL
+                          - AUTO_PASSTHROUGH
+                          - ISTIO_MUTUAL
+                          type: string
+                        privateKey:
+                          description: REQUIRED if mode is `SIMPLE` or `MUTUAL`.
+                          format: string
+                          type: string
+                        serverCertificate:
+                          description: REQUIRED if mode is `SIMPLE` or `MUTUAL`.
+                          format: string
+                          type: string
+                        subjectAltNames:
+                          items:
+                            format: string
+                            type: string
+                          type: array
+                        verifyCertificateHash:
+                          items:
+                            format: string
+                            type: string
+                          type: array
+                        verifyCertificateSpki:
+                          items:
+                            format: string
+                            type: string
+                          type: array
+                      type: object
+                  type: object
+                type: array
+            type: object
+          status:
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+  - name: v1beta1
+    schema:
+      openAPIV3Schema:
+        properties:
+          spec:
+            description: 'Configuration affecting edge load balancer. See more details
+              at: https://istio.io/docs/reference/config/networking/gateway.html'
+            properties:
+              selector:
+                additionalProperties:
+                  format: string
+                  type: string
+                type: object
+              servers:
+                description: A list of server specifications.
+                items:
+                  properties:
+                    bind:
+                      format: string
+                      type: string
+                    defaultEndpoint:
+                      format: string
+                      type: string
+                    hosts:
+                      description: One or more hosts exposed by this gateway.
+                      items:
+                        format: string
+                        type: string
+                      type: array
+                    name:
+                      description: An optional name of the server, when set must be
+                        unique across all servers.
+                      format: string
+                      type: string
+                    port:
+                      properties:
+                        name:
+                          description: Label assigned to the port.
+                          format: string
+                          type: string
+                        number:
+                          description: A valid non-negative integer port number.
+                          type: integer
+                        protocol:
+                          description: The protocol exposed on the port.
+                          format: string
+                          type: string
+                        targetPort:
+                          type: integer
+                      type: object
+                    tls:
+                      description: Set of TLS related options that govern the server's
+                        behavior.
+                      properties:
+                        caCertificates:
+                          description: REQUIRED if mode is `MUTUAL`.
+                          format: string
+                          type: string
+                        cipherSuites:
+                          description: 'Optional: If specified, only support the specified
+                            cipher list.'
+                          items:
+                            format: string
+                            type: string
+                          type: array
+                        credentialName:
+                          format: string
+                          type: string
+                        httpsRedirect:
+                          type: boolean
+                        maxProtocolVersion:
+                          description: 'Optional: Maximum TLS protocol version.'
+                          enum:
+                          - TLS_AUTO
+                          - TLSV1_0
+                          - TLSV1_1
+                          - TLSV1_2
+                          - TLSV1_3
+                          type: string
+                        minProtocolVersion:
+                          description: 'Optional: Minimum TLS protocol version.'
+                          enum:
+                          - TLS_AUTO
+                          - TLSV1_0
+                          - TLSV1_1
+                          - TLSV1_2
+                          - TLSV1_3
+                          type: string
+                        mode:
+                          enum:
+                          - PASSTHROUGH
+                          - SIMPLE
+                          - MUTUAL
+                          - AUTO_PASSTHROUGH
+                          - ISTIO_MUTUAL
+                          type: string
+                        privateKey:
+                          description: REQUIRED if mode is `SIMPLE` or `MUTUAL`.
+                          format: string
+                          type: string
+                        serverCertificate:
+                          description: REQUIRED if mode is `SIMPLE` or `MUTUAL`.
+                          format: string
+                          type: string
+                        subjectAltNames:
+                          items:
+                            format: string
+                            type: string
+                          type: array
+                        verifyCertificateHash:
+                          items:
+                            format: string
+                            type: string
+                          type: array
+                        verifyCertificateSpki:
+                          items:
+                            format: string
+                            type: string
+                          type: array
+                      type: object
+                  type: object
+                type: array
+            type: object
+          status:
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    helm.sh/resource-policy: keep
+  labels:
+    app: mixer
+    chart: istio
+    cloudfoundry.org/istio_version: 1.7.1
+    heritage: Tiller
+    istio: mixer-handler
+    package: handler
+    release: istio
+  name: handlers.config.istio.io
+spec:
+  group: config.istio.io
+  names:
+    categories:
+    - istio-io
+    - policy-istio-io
+    kind: handler
+    listKind: handlerList
+    plural: handlers
+    singular: handler
+  scope: Namespaced
+  versions:
+  - name: v1alpha2
+    schema:
+      openAPIV3Schema:
+        properties:
+          spec:
+            description: Handler allows the operator to configure a specific adapter
+              implementation.
+            properties:
+              adapter:
+                description: The name of a specific adapter implementation.
+                format: string
+                type: string
+              compiledAdapter:
+                description: The name of the compiled in adapter this handler instantiates.
+                format: string
+                type: string
+              connection:
+                description: Information on how to connect to the out-of-process adapter.
+                properties:
+                  address:
+                    description: The address of the backend.
+                    format: string
+                    type: string
+                  authentication:
+                    description: Auth config for the connection to the backend.
+                    oneOf:
+                    - not:
+                        anyOf:
+                        - properties:
+                            tls:
+                              allOf:
+                              - oneOf:
+                                - not:
+                                    anyOf:
+                                    - required:
+                                      - tokenPath
+                                    - required:
+                                      - oauth
+                                - required:
+                                  - tokenPath
+                                - required:
+                                  - oauth
+                              - oneOf:
+                                - not:
+                                    anyOf:
+                                    - required:
+                                      - authHeader
+                                    - required:
+                                      - customHeader
+                                - required:
+                                  - authHeader
+                                - required:
+                                  - customHeader
+                          required:
+                          - tls
+                        - required:
+                          - mutual
+                    - properties:
+                        tls:
+                          allOf:
+                          - oneOf:
+                            - not:
+                                anyOf:
+                                - required:
+                                  - tokenPath
+                                - required:
+                                  - oauth
+                            - required:
+                              - tokenPath
+                            - required:
+                              - oauth
+                          - oneOf:
+                            - not:
+                                anyOf:
+                                - required:
+                                  - authHeader
+                                - required:
+                                  - customHeader
+                            - required:
+                              - authHeader
+                            - required:
+                              - customHeader
+                      required:
+                      - tls
+                    - required:
+                      - mutual
+                    properties:
+                      mutual:
+                        properties:
+                          caCertificates:
+                            format: string
+                            type: string
+                          clientCertificate:
+                            description: The path to the file holding client certificate
+                              for mutual TLS.
+                            format: string
+                            type: string
+                          privateKey:
+                            description: The path to the file holding the private
+                              key for mutual TLS.
+                            format: string
+                            type: string
+                          serverName:
+                            description: Used to configure mixer mutual TLS client
+                              to supply server name for SNI.
+                            format: string
+                            type: string
+                        type: object
+                      tls:
+                        properties:
+                          authHeader:
+                            description: Access token is passed as authorization header.
+                            enum:
+                            - PLAIN
+                            - BEARER
+                            type: string
+                          caCertificates:
+                            format: string
+                            type: string
+                          customHeader:
+                            description: Customized header key to hold access token,
+                              e.g.
+                            format: string
+                            type: string
+                          oauth:
+                            description: Oauth config to fetch access token from auth
+                              provider.
+                            properties:
+                              clientId:
+                                description: OAuth client id for mixer.
+                                format: string
+                                type: string
+                              clientSecret:
+                                description: The path to the file holding the client
+                                  secret for oauth.
+                                format: string
+                                type: string
+                              endpointParams:
+                                additionalProperties:
+                                  format: string
+                                  type: string
+                                description: Additional parameters for requests to
+                                  the token endpoint.
+                                type: object
+                              scopes:
+                                description: List of requested permissions.
+                                items:
+                                  format: string
+                                  type: string
+                                type: array
+                              tokenUrl:
+                                description: The Resource server's token endpoint
+                                  URL.
+                                format: string
+                                type: string
+                            type: object
+                          serverName:
+                            format: string
+                            type: string
+                          tokenPath:
+                            format: string
+                            type: string
+                        type: object
+                    type: object
+                  timeout:
+                    description: Timeout for remote calls to the backend.
+                    type: string
+                type: object
+              name:
+                description: Must be unique in the entire Mixer configuration.
+                format: string
+                type: string
+              params:
+                description: Depends on adapter implementation.
+                type: object
+                x-kubernetes-preserve-unknown-fields: true
+            type: object
+          status:
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    helm.sh/resource-policy: keep
+  labels:
+    app: istio-mixer
+    chart: istio
+    cloudfoundry.org/istio_version: 1.7.1
+    heritage: Tiller
+    release: istio
+  name: httpapispecbindings.config.istio.io
+spec:
+  group: config.istio.io
+  names:
+    categories:
+    - istio-io
+    - apim-istio-io
+    kind: HTTPAPISpecBinding
+    listKind: HTTPAPISpecBindingList
+    plural: httpapispecbindings
+    singular: httpapispecbinding
+  scope: Namespaced
+  versions:
+  - name: v1alpha2
+    schema:
+      openAPIV3Schema:
+        properties:
+          spec:
+            properties:
+              api_specs:
+                items:
+                  properties:
+                    name:
+                      description: The short name of the HTTPAPISpec.
+                      format: string
+                      type: string
+                    namespace:
+                      description: Optional namespace of the HTTPAPISpec.
+                      format: string
+                      type: string
+                  type: object
+                type: array
+              apiSpecs:
+                items:
+                  properties:
+                    name:
+                      description: The short name of the HTTPAPISpec.
+                      format: string
+                      type: string
+                    namespace:
+                      description: Optional namespace of the HTTPAPISpec.
+                      format: string
+                      type: string
+                  type: object
+                type: array
+              services:
+                description: One or more services to map the listed HTTPAPISpec onto.
+                items:
+                  properties:
+                    domain:
+                      description: Domain suffix used to construct the service FQDN
+                        in implementations that support such specification.
+                      format: string
+                      type: string
+                    labels:
+                      additionalProperties:
+                        format: string
+                        type: string
+                      description: Optional one or more labels that uniquely identify
+                        the service version.
+                      type: object
+                    name:
+                      description: The short name of the service such as "foo".
+                      format: string
+                      type: string
+                    namespace:
+                      description: Optional namespace of the service.
+                      format: string
+                      type: string
+                    service:
+                      description: The service FQDN.
+                      format: string
+                      type: string
+                  type: object
+                type: array
+            type: object
+          status:
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    helm.sh/resource-policy: keep
+  labels:
+    app: istio-mixer
+    chart: istio
+    cloudfoundry.org/istio_version: 1.7.1
+    heritage: Tiller
+    release: istio
+  name: httpapispecs.config.istio.io
+spec:
+  group: config.istio.io
+  names:
+    categories:
+    - istio-io
+    - apim-istio-io
+    kind: HTTPAPISpec
+    listKind: HTTPAPISpecList
+    plural: httpapispecs
+    singular: httpapispec
+  scope: Namespaced
+  versions:
+  - name: v1alpha2
+    schema:
+      openAPIV3Schema:
+        properties:
+          spec:
+            properties:
+              api_keys:
+                items:
+                  oneOf:
+                  - not:
+                      anyOf:
+                      - required:
+                        - query
+                      - required:
+                        - header
+                      - required:
+                        - cookie
+                  - required:
+                    - query
+                  - required:
+                    - header
+                  - required:
+                    - cookie
+                  properties:
+                    cookie:
+                      format: string
+                      type: string
+                    header:
+                      description: API key is sent in a request header.
+                      format: string
+                      type: string
+                    query:
+                      description: API Key is sent as a query parameter.
+                      format: string
+                      type: string
+                  type: object
+                type: array
+              apiKeys:
+                items:
+                  oneOf:
+                  - not:
+                      anyOf:
+                      - required:
+                        - query
+                      - required:
+                        - header
+                      - required:
+                        - cookie
+                  - required:
+                    - query
+                  - required:
+                    - header
+                  - required:
+                    - cookie
+                  properties:
+                    cookie:
+                      format: string
+                      type: string
+                    header:
+                      description: API key is sent in a request header.
+                      format: string
+                      type: string
+                    query:
+                      description: API Key is sent as a query parameter.
+                      format: string
+                      type: string
+                  type: object
+                type: array
+              attributes:
+                properties:
+                  attributes:
+                    additionalProperties:
+                      oneOf:
+                      - not:
+                          anyOf:
+                          - required:
+                            - stringValue
+                          - required:
+                            - int64Value
+                          - required:
+                            - doubleValue
+                          - required:
+                            - boolValue
+                          - required:
+                            - bytesValue
+                          - required:
+                            - timestampValue
+                          - required:
+                            - durationValue
+                          - required:
+                            - stringMapValue
+                      - required:
+                        - stringValue
+                      - required:
+                        - int64Value
+                      - required:
+                        - doubleValue
+                      - required:
+                        - boolValue
+                      - required:
+                        - bytesValue
+                      - required:
+                        - timestampValue
+                      - required:
+                        - durationValue
+                      - required:
+                        - stringMapValue
+                      properties:
+                        boolValue:
+                          type: boolean
+                        bytesValue:
+                          format: binary
+                          type: string
+                        doubleValue:
+                          format: double
+                          type: number
+                        durationValue:
+                          type: string
+                        int64Value:
+                          format: int64
+                          type: integer
+                        stringMapValue:
+                          properties:
+                            entries:
+                              additionalProperties:
+                                format: string
+                                type: string
+                              description: Holds a set of name/value pairs.
+                              type: object
+                          type: object
+                        stringValue:
+                          format: string
+                          type: string
+                        timestampValue:
+                          format: dateTime
+                          type: string
+                      type: object
+                    description: A map of attribute name to its value.
+                    type: object
+                type: object
+              patterns:
+                description: List of HTTP patterns to match.
+                items:
+                  oneOf:
+                  - not:
+                      anyOf:
+                      - required:
+                        - uriTemplate
+                      - required:
+                        - regex
+                  - required:
+                    - uriTemplate
+                  - required:
+                    - regex
+                  properties:
+                    attributes:
+                      properties:
+                        attributes:
+                          additionalProperties:
+                            oneOf:
+                            - not:
+                                anyOf:
+                                - required:
+                                  - stringValue
+                                - required:
+                                  - int64Value
+                                - required:
+                                  - doubleValue
+                                - required:
+                                  - boolValue
+                                - required:
+                                  - bytesValue
+                                - required:
+                                  - timestampValue
+                                - required:
+                                  - durationValue
+                                - required:
+                                  - stringMapValue
+                            - required:
+                              - stringValue
+                            - required:
+                              - int64Value
+                            - required:
+                              - doubleValue
+                            - required:
+                              - boolValue
+                            - required:
+                              - bytesValue
+                            - required:
+                              - timestampValue
+                            - required:
+                              - durationValue
+                            - required:
+                              - stringMapValue
+                            properties:
+                              boolValue:
+                                type: boolean
+                              bytesValue:
+                                format: binary
+                                type: string
+                              doubleValue:
+                                format: double
+                                type: number
+                              durationValue:
+                                type: string
+                              int64Value:
+                                format: int64
+                                type: integer
+                              stringMapValue:
+                                properties:
+                                  entries:
+                                    additionalProperties:
+                                      format: string
+                                      type: string
+                                    description: Holds a set of name/value pairs.
+                                    type: object
+                                type: object
+                              stringValue:
+                                format: string
+                                type: string
+                              timestampValue:
+                                format: dateTime
+                                type: string
+                            type: object
+                          description: A map of attribute name to its value.
+                          type: object
+                      type: object
+                    httpMethod:
+                      format: string
+                      type: string
+                    regex:
+                      format: string
+                      type: string
+                    uriTemplate:
+                      format: string
+                      type: string
+                  type: object
+                type: array
+            type: object
+          status:
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    helm.sh/resource-policy: keep
+  labels:
+    app: mixer
+    chart: istio
+    cloudfoundry.org/istio_version: 1.7.1
+    heritage: Tiller
+    istio: mixer-instance
+    package: instance
+    release: istio
+  name: instances.config.istio.io
+spec:
+  group: config.istio.io
+  names:
+    categories:
+    - istio-io
+    - policy-istio-io
+    kind: instance
+    listKind: instanceList
+    plural: instances
+    singular: instance
+  scope: Namespaced
+  versions:
+  - name: v1alpha2
+    schema:
+      openAPIV3Schema:
+        properties:
+          spec:
+            description: An Instance tells Mixer how to create instances for particular
+              template.
+            properties:
+              attributeBindings:
+                additionalProperties:
+                  format: string
+                  type: string
+                type: object
+              compiledTemplate:
+                description: The name of the compiled in template this instance creates
+                  instances for.
+                format: string
+                type: string
+              name:
+                format: string
+                type: string
+              params:
+                description: Depends on referenced template.
+                type: object
+                x-kubernetes-preserve-unknown-fields: true
+              template:
+                description: The name of the template this instance creates instances
+                  for.
+                format: string
+                type: string
+            type: object
+          status:
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  labels:
+    cloudfoundry.org/istio_version: 1.7.1
+    release: istio
+  name: istiooperators.install.istio.io
+spec:
+  group: install.istio.io
+  names:
+    kind: IstioOperator
+    plural: istiooperators
+    shortNames:
+    - iop
+    singular: istiooperator
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: Istio control plane revision
+      jsonPath: .spec.revision
+      name: Revision
+      type: string
+    - description: IOP current state
+      jsonPath: .status.status
+      name: Status
+      type: string
+    - description: 'CreationTimestamp is a timestamp representing the server time
+        when this object was created. It is not guaranteed to be set in happens-before
+        order across separate operations. Clients may not set this value. It is represented
+        in RFC3339 form and is in UTC. Populated by the system. Read-only. Null for
+        lists. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata'
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          spec:
+            description: 'Specification of the desired state of the istio control
+              plane resource. More info: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#spec-and-status'
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
+          status:
+            description: 'Status describes each of istio control plane component status
+              at the current time. 0 means NONE, 1 means UPDATING, 2 means HEALTHY,
+              3 means ERROR, 4 means RECONCILING. More info: https://github.com/istio/api/blob/master/operator/v1alpha1/istio.operator.v1alpha1.pb.html
+              & https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#spec-and-status'
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    helm.sh/resource-policy: keep
+  labels:
+    app: istio-pilot
+    chart: istio
+    cloudfoundry.org/istio_version: 1.7.1
+    heritage: Tiller
+    istio: security
+    release: istio
+  name: peerauthentications.security.istio.io
+spec:
+  group: security.istio.io
+  names:
+    categories:
+    - istio-io
+    - security-istio-io
+    kind: PeerAuthentication
+    listKind: PeerAuthenticationList
+    plural: peerauthentications
+    shortNames:
+    - pa
+    singular: peerauthentication
+  scope: Namespaced
+  versions:
+  - name: v1beta1
+    schema:
+      openAPIV3Schema:
+        properties:
+          spec:
+            description: PeerAuthentication defines how traffic will be tunneled (or
+              not) to the sidecar.
+            properties:
+              mtls:
+                description: Mutual TLS settings for workload.
+                properties:
+                  mode:
+                    description: Defines the mTLS mode used for peer authentication.
+                    enum:
+                    - UNSET
+                    - DISABLE
+                    - PERMISSIVE
+                    - STRICT
+                    type: string
+                type: object
+              portLevelMtls:
+                additionalProperties:
+                  properties:
+                    mode:
+                      description: Defines the mTLS mode used for peer authentication.
+                      enum:
+                      - UNSET
+                      - DISABLE
+                      - PERMISSIVE
+                      - STRICT
+                      type: string
+                  type: object
+                description: Port specific mutual TLS settings.
+                type: object
+              selector:
+                description: The selector determines the workloads to apply the ChannelAuthentication
+                  on.
+                properties:
+                  matchLabels:
+                    additionalProperties:
+                      format: string
+                      type: string
+                    type: object
+                type: object
+            type: object
+          status:
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    helm.sh/resource-policy: keep
+  labels:
+    app: istio-mixer
+    chart: istio
+    cloudfoundry.org/istio_version: 1.7.1
+    heritage: Tiller
+    release: istio
+  name: quotaspecbindings.config.istio.io
+spec:
+  group: config.istio.io
+  names:
+    categories:
+    - istio-io
+    - apim-istio-io
+    kind: QuotaSpecBinding
+    listKind: QuotaSpecBindingList
+    plural: quotaspecbindings
+    singular: quotaspecbinding
+  scope: Namespaced
+  versions:
+  - name: v1alpha2
+    schema:
+      openAPIV3Schema:
+        properties:
+          spec:
+            properties:
+              quotaSpecs:
+                items:
+                  properties:
+                    name:
+                      description: The short name of the QuotaSpec.
+                      format: string
+                      type: string
+                    namespace:
+                      description: Optional namespace of the QuotaSpec.
+                      format: string
+                      type: string
+                  type: object
+                type: array
+              services:
+                description: One or more services to map the listed QuotaSpec onto.
+                items:
+                  properties:
+                    domain:
+                      description: Domain suffix used to construct the service FQDN
+                        in implementations that support such specification.
+                      format: string
+                      type: string
+                    labels:
+                      additionalProperties:
+                        format: string
+                        type: string
+                      description: Optional one or more labels that uniquely identify
+                        the service version.
+                      type: object
+                    name:
+                      description: The short name of the service such as "foo".
+                      format: string
+                      type: string
+                    namespace:
+                      description: Optional namespace of the service.
+                      format: string
+                      type: string
+                    service:
+                      description: The service FQDN.
+                      format: string
+                      type: string
+                  type: object
+                type: array
+            type: object
+          status:
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    helm.sh/resource-policy: keep
+  labels:
+    app: istio-mixer
+    chart: istio
+    cloudfoundry.org/istio_version: 1.7.1
+    heritage: Tiller
+    release: istio
+  name: quotaspecs.config.istio.io
+spec:
+  group: config.istio.io
+  names:
+    categories:
+    - istio-io
+    - apim-istio-io
+    kind: QuotaSpec
+    listKind: QuotaSpecList
+    plural: quotaspecs
+    singular: quotaspec
+  scope: Namespaced
+  versions:
+  - name: v1alpha2
+    schema:
+      openAPIV3Schema:
+        properties:
+          spec:
+            description: Determines the quotas used for individual requests.
+            properties:
+              rules:
+                description: A list of Quota rules.
+                items:
+                  properties:
+                    match:
+                      description: If empty, match all request.
+                      items:
+                        properties:
+                          clause:
+                            additionalProperties:
+                              oneOf:
+                              - not:
+                                  anyOf:
+                                  - required:
+                                    - exact
+                                  - required:
+                                    - prefix
+                                  - required:
+                                    - regex
+                              - required:
+                                - exact
+                              - required:
+                                - prefix
+                              - required:
+                                - regex
+                              properties:
+                                exact:
+                                  format: string
+                                  type: string
+                                prefix:
+                                  format: string
+                                  type: string
+                                regex:
+                                  description: RE2 style regex-based match (https://github.com/google/re2/wiki/Syntax).
+                                  format: string
+                                  type: string
+                              type: object
+                            description: Map of attribute names to StringMatch type.
+                            type: object
+                        type: object
+                      type: array
+                    quotas:
+                      description: The list of quotas to charge.
+                      items:
+                        properties:
+                          charge:
+                            format: int32
+                            type: integer
+                          quota:
+                            format: string
+                            type: string
+                        type: object
+                      type: array
+                  type: object
+                type: array
+            type: object
+          status:
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    helm.sh/resource-policy: keep
+  labels:
+    app: istio-pilot
+    chart: istio
+    cloudfoundry.org/istio_version: 1.7.1
+    heritage: Tiller
+    istio: security
+    release: istio
+  name: requestauthentications.security.istio.io
+spec:
+  group: security.istio.io
+  names:
+    categories:
+    - istio-io
+    - security-istio-io
+    kind: RequestAuthentication
+    listKind: RequestAuthenticationList
+    plural: requestauthentications
+    shortNames:
+    - ra
+    singular: requestauthentication
+  scope: Namespaced
+  versions:
+  - name: v1beta1
+    schema:
+      openAPIV3Schema:
+        properties:
+          spec:
+            description: RequestAuthentication defines what request authentication
+              methods are supported by a workload.
+            properties:
+              jwtRules:
+                description: Define the list of JWTs that can be validated at the
+                  selected workloads' proxy.
+                items:
+                  properties:
+                    audiences:
+                      items:
+                        format: string
+                        type: string
+                      type: array
+                    forwardOriginalToken:
+                      description: If set to true, the orginal token will be kept
+                        for the ustream request.
+                      type: boolean
+                    fromHeaders:
+                      description: List of header locations from which JWT is expected.
+                      items:
+                        properties:
+                          name:
+                            description: The HTTP header name.
+                            format: string
+                            type: string
+                          prefix:
+                            description: The prefix that should be stripped before
+                              decoding the token.
+                            format: string
+                            type: string
+                        type: object
+                      type: array
+                    fromParams:
+                      description: List of query parameters from which JWT is expected.
+                      items:
+                        format: string
+                        type: string
+                      type: array
+                    issuer:
+                      description: Identifies the issuer that issued the JWT.
+                      format: string
+                      type: string
+                    jwks:
+                      description: JSON Web Key Set of public keys to validate signature
+                        of the JWT.
+                      format: string
+                      type: string
+                    jwks_uri:
+                      format: string
+                      type: string
+                    jwksUri:
+                      format: string
+                      type: string
+                    outputPayloadToHeader:
+                      format: string
+                      type: string
+                  type: object
+                type: array
+              selector:
+                description: The selector determines the workloads to apply the RequestAuthentication
+                  on.
+                properties:
+                  matchLabels:
+                    additionalProperties:
+                      format: string
+                      type: string
+                    type: object
+                type: object
+            type: object
+          status:
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    helm.sh/resource-policy: keep
+  labels:
+    app: mixer
+    chart: istio
+    cloudfoundry.org/istio_version: 1.7.1
+    heritage: Tiller
+    istio: core
+    package: istio.io.mixer
+    release: istio
+  name: rules.config.istio.io
+spec:
+  group: config.istio.io
+  names:
+    categories:
+    - istio-io
+    - policy-istio-io
+    kind: rule
+    listKind: ruleList
+    plural: rules
+    singular: rule
+  scope: Namespaced
+  versions:
+  - name: v1alpha2
+    schema:
+      openAPIV3Schema:
+        properties:
+          spec:
+            description: 'Describes the rules used to configure Mixer''s policy and
+              telemetry features. See more details at: https://istio.io/docs/reference/config/policy-and-telemetry/istio.policy.v1beta1.html'
+            properties:
+              actions:
+                description: The actions that will be executed when match evaluates
+                  to `true`.
+                items:
+                  properties:
+                    handler:
+                      description: Fully qualified name of the handler to invoke.
+                      format: string
+                      type: string
+                    instances:
+                      items:
+                        format: string
+                        type: string
+                      type: array
+                    name:
+                      description: A handle to refer to the results of the action.
+                      format: string
+                      type: string
+                  type: object
+                type: array
+              match:
+                description: Match is an attribute based predicate.
+                format: string
+                type: string
+              requestHeaderOperations:
+                items:
+                  properties:
+                    name:
+                      description: Header name literal value.
+                      format: string
+                      type: string
+                    operation:
+                      description: Header operation type.
+                      enum:
+                      - REPLACE
+                      - REMOVE
+                      - APPEND
+                      type: string
+                    values:
+                      description: Header value expressions.
+                      items:
+                        format: string
+                        type: string
+                      type: array
+                  type: object
+                type: array
+              responseHeaderOperations:
+                items:
+                  properties:
+                    name:
+                      description: Header name literal value.
+                      format: string
+                      type: string
+                    operation:
+                      description: Header operation type.
+                      enum:
+                      - REPLACE
+                      - REMOVE
+                      - APPEND
+                      type: string
+                    values:
+                      description: Header value expressions.
+                      items:
+                        format: string
+                        type: string
+                      type: array
+                  type: object
+                type: array
+              sampling:
+                properties:
+                  random:
+                    description: Provides filtering of actions based on random selection
+                      per request.
+                    properties:
+                      attributeExpression:
+                        description: Specifies an attribute expression to use to override
+                          the numerator in the `percent_sampled` field.
+                        format: string
+                        type: string
+                      percentSampled:
+                        description: The default sampling rate, expressed as a percentage.
+                        properties:
+                          denominator:
+                            description: Specifies the denominator.
+                            enum:
+                            - HUNDRED
+                            - TEN_THOUSAND
+                            type: string
+                          numerator:
+                            description: Specifies the numerator.
+                            type: integer
+                        type: object
+                      useIndependentRandomness:
+                        description: By default sampling will be based on the value
+                          of the request header `x-request-id`.
+                        type: boolean
+                    type: object
+                  rateLimit:
+                    properties:
+                      maxUnsampledEntries:
+                        description: Number of entries to allow during the `sampling_duration`
+                          before sampling is enforced.
+                        format: int64
+                        type: integer
+                      samplingDuration:
+                        description: Window in which to enforce the sampling rate.
+                        type: string
+                      samplingRate:
+                        description: The rate at which to sample entries once the
+                          unsampled limit has been reached.
+                        format: int64
+                        type: integer
+                    type: object
+                type: object
+            type: object
+          status:
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    helm.sh/resource-policy: keep
+  labels:
+    app: istio-pilot
+    chart: istio
+    cloudfoundry.org/istio_version: 1.7.1
+    heritage: Tiller
+    release: istio
+  name: serviceentries.networking.istio.io
+spec:
+  group: networking.istio.io
+  names:
+    categories:
+    - istio-io
+    - networking-istio-io
+    kind: ServiceEntry
+    listKind: ServiceEntryList
+    plural: serviceentries
+    shortNames:
+    - se
+    singular: serviceentry
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: The hosts associated with the ServiceEntry
+      jsonPath: .spec.hosts
+      name: Hosts
+      type: string
+    - description: Whether the service is external to the mesh or part of the mesh
+        (MESH_EXTERNAL or MESH_INTERNAL)
+      jsonPath: .spec.location
+      name: Location
+      type: string
+    - description: Service discovery mode for the hosts (NONE, STATIC, or DNS)
+      jsonPath: .spec.resolution
+      name: Resolution
+      type: string
+    - description: 'CreationTimestamp is a timestamp representing the server time
+        when this object was created. It is not guaranteed to be set in happens-before
+        order across separate operations. Clients may not set this value. It is represented
+        in RFC3339 form and is in UTC. Populated by the system. Read-only. Null for
+        lists. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata'
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha3
+    schema:
+      openAPIV3Schema:
+        properties:
+          spec:
+            description: 'Configuration affecting service registry. See more details
+              at: https://istio.io/docs/reference/config/networking/service-entry.html'
+            properties:
+              addresses:
+                description: The virtual IP addresses associated with the service.
+                items:
+                  format: string
+                  type: string
+                type: array
+              endpoints:
+                description: One or more endpoints associated with the service.
+                items:
+                  properties:
+                    address:
+                      format: string
+                      type: string
+                    labels:
+                      additionalProperties:
+                        format: string
+                        type: string
+                      description: One or more labels associated with the endpoint.
+                      type: object
+                    locality:
+                      description: The locality associated with the endpoint.
+                      format: string
+                      type: string
+                    network:
+                      format: string
+                      type: string
+                    ports:
+                      additionalProperties:
+                        type: integer
+                      description: Set of ports associated with the endpoint.
+                      type: object
+                    serviceAccount:
+                      format: string
+                      type: string
+                    weight:
+                      description: The load balancing weight associated with the endpoint.
+                      type: integer
+                  type: object
+                type: array
+              exportTo:
+                description: A list of namespaces to which this service is exported.
+                items:
+                  format: string
+                  type: string
+                type: array
+              hosts:
+                description: The hosts associated with the ServiceEntry.
+                items:
+                  format: string
+                  type: string
+                type: array
+              location:
+                enum:
+                - MESH_EXTERNAL
+                - MESH_INTERNAL
+                type: string
+              ports:
+                description: The ports associated with the external service.
+                items:
+                  properties:
+                    name:
+                      description: Label assigned to the port.
+                      format: string
+                      type: string
+                    number:
+                      description: A valid non-negative integer port number.
+                      type: integer
+                    protocol:
+                      description: The protocol exposed on the port.
+                      format: string
+                      type: string
+                    targetPort:
+                      type: integer
+                  type: object
+                type: array
+              resolution:
+                description: Service discovery mode for the hosts.
+                enum:
+                - NONE
+                - STATIC
+                - DNS
+                type: string
+              subjectAltNames:
+                items:
+                  format: string
+                  type: string
+                type: array
+              workloadSelector:
+                description: Applicable only for MESH_INTERNAL services.
+                properties:
+                  labels:
+                    additionalProperties:
+                      format: string
+                      type: string
+                    type: object
+                type: object
+            type: object
+          status:
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+  - additionalPrinterColumns:
+    - description: The hosts associated with the ServiceEntry
+      jsonPath: .spec.hosts
+      name: Hosts
+      type: string
+    - description: Whether the service is external to the mesh or part of the mesh
+        (MESH_EXTERNAL or MESH_INTERNAL)
+      jsonPath: .spec.location
+      name: Location
+      type: string
+    - description: Service discovery mode for the hosts (NONE, STATIC, or DNS)
+      jsonPath: .spec.resolution
+      name: Resolution
+      type: string
+    - description: 'CreationTimestamp is a timestamp representing the server time
+        when this object was created. It is not guaranteed to be set in happens-before
+        order across separate operations. Clients may not set this value. It is represented
+        in RFC3339 form and is in UTC. Populated by the system. Read-only. Null for
+        lists. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata'
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        properties:
+          spec:
+            description: 'Configuration affecting service registry. See more details
+              at: https://istio.io/docs/reference/config/networking/service-entry.html'
+            properties:
+              addresses:
+                description: The virtual IP addresses associated with the service.
+                items:
+                  format: string
+                  type: string
+                type: array
+              endpoints:
+                description: One or more endpoints associated with the service.
+                items:
+                  properties:
+                    address:
+                      format: string
+                      type: string
+                    labels:
+                      additionalProperties:
+                        format: string
+                        type: string
+                      description: One or more labels associated with the endpoint.
+                      type: object
+                    locality:
+                      description: The locality associated with the endpoint.
+                      format: string
+                      type: string
+                    network:
+                      format: string
+                      type: string
+                    ports:
+                      additionalProperties:
+                        type: integer
+                      description: Set of ports associated with the endpoint.
+                      type: object
+                    serviceAccount:
+                      format: string
+                      type: string
+                    weight:
+                      description: The load balancing weight associated with the endpoint.
+                      type: integer
+                  type: object
+                type: array
+              exportTo:
+                description: A list of namespaces to which this service is exported.
+                items:
+                  format: string
+                  type: string
+                type: array
+              hosts:
+                description: The hosts associated with the ServiceEntry.
+                items:
+                  format: string
+                  type: string
+                type: array
+              location:
+                enum:
+                - MESH_EXTERNAL
+                - MESH_INTERNAL
+                type: string
+              ports:
+                description: The ports associated with the external service.
+                items:
+                  properties:
+                    name:
+                      description: Label assigned to the port.
+                      format: string
+                      type: string
+                    number:
+                      description: A valid non-negative integer port number.
+                      type: integer
+                    protocol:
+                      description: The protocol exposed on the port.
+                      format: string
+                      type: string
+                    targetPort:
+                      type: integer
+                  type: object
+                type: array
+              resolution:
+                description: Service discovery mode for the hosts.
+                enum:
+                - NONE
+                - STATIC
+                - DNS
+                type: string
+              subjectAltNames:
+                items:
+                  format: string
+                  type: string
+                type: array
+              workloadSelector:
+                description: Applicable only for MESH_INTERNAL services.
+                properties:
+                  labels:
+                    additionalProperties:
+                      format: string
+                      type: string
+                    type: object
+                type: object
+            type: object
+          status:
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    helm.sh/resource-policy: keep
+  labels:
+    app: istio-pilot
+    chart: istio
+    cloudfoundry.org/istio_version: 1.7.1
+    heritage: Tiller
+    release: istio
+  name: sidecars.networking.istio.io
+spec:
+  group: networking.istio.io
+  names:
+    categories:
+    - istio-io
+    - networking-istio-io
+    kind: Sidecar
+    listKind: SidecarList
+    plural: sidecars
+    singular: sidecar
+  scope: Namespaced
+  versions:
+  - name: v1alpha3
+    schema:
+      openAPIV3Schema:
+        properties:
+          spec:
+            description: 'Configuration affecting network reachability of a sidecar.
+              See more details at: https://istio.io/docs/reference/config/networking/sidecar.html'
+            properties:
+              egress:
+                items:
+                  properties:
+                    bind:
+                      format: string
+                      type: string
+                    captureMode:
+                      enum:
+                      - DEFAULT
+                      - IPTABLES
+                      - NONE
+                      type: string
+                    hosts:
+                      items:
+                        format: string
+                        type: string
+                      type: array
+                    port:
+                      description: The port associated with the listener.
+                      properties:
+                        name:
+                          description: Label assigned to the port.
+                          format: string
+                          type: string
+                        number:
+                          description: A valid non-negative integer port number.
+                          type: integer
+                        protocol:
+                          description: The protocol exposed on the port.
+                          format: string
+                          type: string
+                        targetPort:
+                          type: integer
+                      type: object
+                  type: object
+                type: array
+              ingress:
+                items:
+                  properties:
+                    bind:
+                      description: The IP to which the listener should be bound.
+                      format: string
+                      type: string
+                    captureMode:
+                      enum:
+                      - DEFAULT
+                      - IPTABLES
+                      - NONE
+                      type: string
+                    defaultEndpoint:
+                      format: string
+                      type: string
+                    port:
+                      description: The port associated with the listener.
+                      properties:
+                        name:
+                          description: Label assigned to the port.
+                          format: string
+                          type: string
+                        number:
+                          description: A valid non-negative integer port number.
+                          type: integer
+                        protocol:
+                          description: The protocol exposed on the port.
+                          format: string
+                          type: string
+                        targetPort:
+                          type: integer
+                      type: object
+                  type: object
+                type: array
+              outboundTrafficPolicy:
+                description: Configuration for the outbound traffic policy.
+                properties:
+                  egressProxy:
+                    properties:
+                      host:
+                        description: The name of a service from the service registry.
+                        format: string
+                        type: string
+                      port:
+                        description: Specifies the port on the host that is being
+                          addressed.
+                        properties:
+                          number:
+                            type: integer
+                        type: object
+                      subset:
+                        description: The name of a subset within the service.
+                        format: string
+                        type: string
+                    type: object
+                  mode:
+                    enum:
+                    - REGISTRY_ONLY
+                    - ALLOW_ANY
+                    type: string
+                type: object
+              workloadSelector:
+                properties:
+                  labels:
+                    additionalProperties:
+                      format: string
+                      type: string
+                    type: object
+                type: object
+            type: object
+          status:
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+  - name: v1beta1
+    schema:
+      openAPIV3Schema:
+        properties:
+          spec:
+            description: 'Configuration affecting network reachability of a sidecar.
+              See more details at: https://istio.io/docs/reference/config/networking/sidecar.html'
+            properties:
+              egress:
+                items:
+                  properties:
+                    bind:
+                      format: string
+                      type: string
+                    captureMode:
+                      enum:
+                      - DEFAULT
+                      - IPTABLES
+                      - NONE
+                      type: string
+                    hosts:
+                      items:
+                        format: string
+                        type: string
+                      type: array
+                    port:
+                      description: The port associated with the listener.
+                      properties:
+                        name:
+                          description: Label assigned to the port.
+                          format: string
+                          type: string
+                        number:
+                          description: A valid non-negative integer port number.
+                          type: integer
+                        protocol:
+                          description: The protocol exposed on the port.
+                          format: string
+                          type: string
+                        targetPort:
+                          type: integer
+                      type: object
+                  type: object
+                type: array
+              ingress:
+                items:
+                  properties:
+                    bind:
+                      description: The IP to which the listener should be bound.
+                      format: string
+                      type: string
+                    captureMode:
+                      enum:
+                      - DEFAULT
+                      - IPTABLES
+                      - NONE
+                      type: string
+                    defaultEndpoint:
+                      format: string
+                      type: string
+                    port:
+                      description: The port associated with the listener.
+                      properties:
+                        name:
+                          description: Label assigned to the port.
+                          format: string
+                          type: string
+                        number:
+                          description: A valid non-negative integer port number.
+                          type: integer
+                        protocol:
+                          description: The protocol exposed on the port.
+                          format: string
+                          type: string
+                        targetPort:
+                          type: integer
+                      type: object
+                  type: object
+                type: array
+              outboundTrafficPolicy:
+                description: Configuration for the outbound traffic policy.
+                properties:
+                  egressProxy:
+                    properties:
+                      host:
+                        description: The name of a service from the service registry.
+                        format: string
+                        type: string
+                      port:
+                        description: Specifies the port on the host that is being
+                          addressed.
+                        properties:
+                          number:
+                            type: integer
+                        type: object
+                      subset:
+                        description: The name of a subset within the service.
+                        format: string
+                        type: string
+                    type: object
+                  mode:
+                    enum:
+                    - REGISTRY_ONLY
+                    - ALLOW_ANY
+                    type: string
+                type: object
+              workloadSelector:
+                properties:
+                  labels:
+                    additionalProperties:
+                      format: string
+                      type: string
+                    type: object
+                type: object
+            type: object
+          status:
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    helm.sh/resource-policy: keep
+  labels:
+    app: mixer
+    chart: istio
+    cloudfoundry.org/istio_version: 1.7.1
+    heritage: Tiller
+    istio: mixer-template
+    package: template
+    release: istio
+  name: templates.config.istio.io
+spec:
+  group: config.istio.io
+  names:
+    categories:
+    - istio-io
+    - policy-istio-io
+    kind: template
+    plural: templates
+    singular: template
+  scope: Namespaced
+  versions:
+  - name: v1alpha2
+    schema:
+      openAPIV3Schema:
+        properties:
+          spec:
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
+          status:
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    helm.sh/resource-policy: keep
+  labels:
+    app: istio-pilot
+    chart: istio
+    cloudfoundry.org/istio_version: 1.7.1
+    heritage: Tiller
+    release: istio
+  name: virtualservices.networking.istio.io
+spec:
+  group: networking.istio.io
+  names:
+    categories:
+    - istio-io
+    - networking-istio-io
+    kind: VirtualService
+    listKind: VirtualServiceList
+    plural: virtualservices
+    shortNames:
+    - vs
+    singular: virtualservice
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: The names of gateways and sidecars that should apply these routes
+      jsonPath: .spec.gateways
+      name: Gateways
+      type: string
+    - description: The destination hosts to which traffic is being sent
+      jsonPath: .spec.hosts
+      name: Hosts
+      type: string
+    - description: 'CreationTimestamp is a timestamp representing the server time
+        when this object was created. It is not guaranteed to be set in happens-before
+        order across separate operations. Clients may not set this value. It is represented
+        in RFC3339 form and is in UTC. Populated by the system. Read-only. Null for
+        lists. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata'
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha3
+    schema:
+      openAPIV3Schema:
+        properties:
+          spec:
+            description: 'Configuration affecting label/content routing, sni routing,
+              etc. See more details at: https://istio.io/docs/reference/config/networking/virtual-service.html'
+            properties:
+              exportTo:
+                description: A list of namespaces to which this virtual service is
+                  exported.
+                items:
+                  format: string
+                  type: string
+                type: array
+              gateways:
+                description: The names of gateways and sidecars that should apply
+                  these routes.
+                items:
+                  format: string
+                  type: string
+                type: array
+              hosts:
+                description: The destination hosts to which traffic is being sent.
+                items:
+                  format: string
+                  type: string
+                type: array
+              http:
+                description: An ordered list of route rules for HTTP traffic.
+                items:
+                  properties:
+                    corsPolicy:
+                      description: Cross-Origin Resource Sharing policy (CORS).
+                      properties:
+                        allowCredentials:
+                          nullable: true
+                          type: boolean
+                        allowHeaders:
+                          items:
+                            format: string
+                            type: string
+                          type: array
+                        allowMethods:
+                          description: List of HTTP methods allowed to access the
+                            resource.
+                          items:
+                            format: string
+                            type: string
+                          type: array
+                        allowOrigin:
+                          description: The list of origins that are allowed to perform
+                            CORS requests.
+                          items:
+                            format: string
+                            type: string
+                          type: array
+                        allowOrigins:
+                          description: String patterns that match allowed origins.
+                          items:
+                            oneOf:
+                            - not:
+                                anyOf:
+                                - required:
+                                  - exact
+                                - required:
+                                  - prefix
+                                - required:
+                                  - regex
+                            - required:
+                              - exact
+                            - required:
+                              - prefix
+                            - required:
+                              - regex
+                            properties:
+                              exact:
+                                format: string
+                                type: string
+                              prefix:
+                                format: string
+                                type: string
+                              regex:
+                                description: RE2 style regex-based match (https://github.com/google/re2/wiki/Syntax).
+                                format: string
+                                type: string
+                            type: object
+                          type: array
+                        exposeHeaders:
+                          items:
+                            format: string
+                            type: string
+                          type: array
+                        maxAge:
+                          type: string
+                      type: object
+                    delegate:
+                      properties:
+                        name:
+                          description: Name specifies the name of the delegate VirtualService.
+                          format: string
+                          type: string
+                        namespace:
+                          description: Namespace specifies the namespace where the
+                            delegate VirtualService resides.
+                          format: string
+                          type: string
+                      type: object
+                    fault:
+                      description: Fault injection policy to apply on HTTP traffic
+                        at the client side.
+                      properties:
+                        abort:
+                          oneOf:
+                          - not:
+                              anyOf:
+                              - required:
+                                - httpStatus
+                              - required:
+                                - grpcStatus
+                              - required:
+                                - http2Error
+                          - required:
+                            - httpStatus
+                          - required:
+                            - grpcStatus
+                          - required:
+                            - http2Error
+                          properties:
+                            grpcStatus:
+                              format: string
+                              type: string
+                            http2Error:
+                              format: string
+                              type: string
+                            httpStatus:
+                              description: HTTP status code to use to abort the Http
+                                request.
+                              format: int32
+                              type: integer
+                            percentage:
+                              description: Percentage of requests to be aborted with
+                                the error code provided.
+                              properties:
+                                value:
+                                  format: double
+                                  type: number
+                              type: object
+                          type: object
+                        delay:
+                          oneOf:
+                          - not:
+                              anyOf:
+                              - required:
+                                - fixedDelay
+                              - required:
+                                - exponentialDelay
+                          - required:
+                            - fixedDelay
+                          - required:
+                            - exponentialDelay
+                          properties:
+                            exponentialDelay:
+                              type: string
+                            fixedDelay:
+                              description: Add a fixed delay before forwarding the
+                                request.
+                              type: string
+                            percent:
+                              description: Percentage of requests on which the delay
+                                will be injected (0-100).
+                              format: int32
+                              type: integer
+                            percentage:
+                              description: Percentage of requests on which the delay
+                                will be injected.
+                              properties:
+                                value:
+                                  format: double
+                                  type: number
+                              type: object
+                          type: object
+                      type: object
+                    headers:
+                      properties:
+                        request:
+                          properties:
+                            add:
+                              additionalProperties:
+                                format: string
+                                type: string
+                              type: object
+                            remove:
+                              items:
+                                format: string
+                                type: string
+                              type: array
+                            set:
+                              additionalProperties:
+                                format: string
+                                type: string
+                              type: object
+                          type: object
+                        response:
+                          properties:
+                            add:
+                              additionalProperties:
+                                format: string
+                                type: string
+                              type: object
+                            remove:
+                              items:
+                                format: string
+                                type: string
+                              type: array
+                            set:
+                              additionalProperties:
+                                format: string
+                                type: string
+                              type: object
+                          type: object
+                      type: object
+                    match:
+                      items:
+                        properties:
+                          authority:
+                            oneOf:
+                            - not:
+                                anyOf:
+                                - required:
+                                  - exact
+                                - required:
+                                  - prefix
+                                - required:
+                                  - regex
+                            - required:
+                              - exact
+                            - required:
+                              - prefix
+                            - required:
+                              - regex
+                            properties:
+                              exact:
+                                format: string
+                                type: string
+                              prefix:
+                                format: string
+                                type: string
+                              regex:
+                                description: RE2 style regex-based match (https://github.com/google/re2/wiki/Syntax).
+                                format: string
+                                type: string
+                            type: object
+                          gateways:
+                            description: Names of gateways where the rule should be
+                              applied.
+                            items:
+                              format: string
+                              type: string
+                            type: array
+                          headers:
+                            additionalProperties:
+                              oneOf:
+                              - not:
+                                  anyOf:
+                                  - required:
+                                    - exact
+                                  - required:
+                                    - prefix
+                                  - required:
+                                    - regex
+                              - required:
+                                - exact
+                              - required:
+                                - prefix
+                              - required:
+                                - regex
+                              properties:
+                                exact:
+                                  format: string
+                                  type: string
+                                prefix:
+                                  format: string
+                                  type: string
+                                regex:
+                                  description: RE2 style regex-based match (https://github.com/google/re2/wiki/Syntax).
+                                  format: string
+                                  type: string
+                              type: object
+                            type: object
+                          ignoreUriCase:
+                            description: Flag to specify whether the URI matching
+                              should be case-insensitive.
+                            type: boolean
+                          method:
+                            oneOf:
+                            - not:
+                                anyOf:
+                                - required:
+                                  - exact
+                                - required:
+                                  - prefix
+                                - required:
+                                  - regex
+                            - required:
+                              - exact
+                            - required:
+                              - prefix
+                            - required:
+                              - regex
+                            properties:
+                              exact:
+                                format: string
+                                type: string
+                              prefix:
+                                format: string
+                                type: string
+                              regex:
+                                description: RE2 style regex-based match (https://github.com/google/re2/wiki/Syntax).
+                                format: string
+                                type: string
+                            type: object
+                          name:
+                            description: The name assigned to a match.
+                            format: string
+                            type: string
+                          port:
+                            description: Specifies the ports on the host that is being
+                              addressed.
+                            type: integer
+                          queryParams:
+                            additionalProperties:
+                              oneOf:
+                              - not:
+                                  anyOf:
+                                  - required:
+                                    - exact
+                                  - required:
+                                    - prefix
+                                  - required:
+                                    - regex
+                              - required:
+                                - exact
+                              - required:
+                                - prefix
+                              - required:
+                                - regex
+                              properties:
+                                exact:
+                                  format: string
+                                  type: string
+                                prefix:
+                                  format: string
+                                  type: string
+                                regex:
+                                  description: RE2 style regex-based match (https://github.com/google/re2/wiki/Syntax).
+                                  format: string
+                                  type: string
+                              type: object
+                            description: Query parameters for matching.
+                            type: object
+                          scheme:
+                            oneOf:
+                            - not:
+                                anyOf:
+                                - required:
+                                  - exact
+                                - required:
+                                  - prefix
+                                - required:
+                                  - regex
+                            - required:
+                              - exact
+                            - required:
+                              - prefix
+                            - required:
+                              - regex
+                            properties:
+                              exact:
+                                format: string
+                                type: string
+                              prefix:
+                                format: string
+                                type: string
+                              regex:
+                                description: RE2 style regex-based match (https://github.com/google/re2/wiki/Syntax).
+                                format: string
+                                type: string
+                            type: object
+                          sourceLabels:
+                            additionalProperties:
+                              format: string
+                              type: string
+                            type: object
+                          sourceNamespace:
+                            description: Source namespace constraining the applicability
+                              of a rule to workloads in that namespace.
+                            format: string
+                            type: string
+                          uri:
+                            oneOf:
+                            - not:
+                                anyOf:
+                                - required:
+                                  - exact
+                                - required:
+                                  - prefix
+                                - required:
+                                  - regex
+                            - required:
+                              - exact
+                            - required:
+                              - prefix
+                            - required:
+                              - regex
+                            properties:
+                              exact:
+                                format: string
+                                type: string
+                              prefix:
+                                format: string
+                                type: string
+                              regex:
+                                description: RE2 style regex-based match (https://github.com/google/re2/wiki/Syntax).
+                                format: string
+                                type: string
+                            type: object
+                          withoutHeaders:
+                            additionalProperties:
+                              oneOf:
+                              - not:
+                                  anyOf:
+                                  - required:
+                                    - exact
+                                  - required:
+                                    - prefix
+                                  - required:
+                                    - regex
+                              - required:
+                                - exact
+                              - required:
+                                - prefix
+                              - required:
+                                - regex
+                              properties:
+                                exact:
+                                  format: string
+                                  type: string
+                                prefix:
+                                  format: string
+                                  type: string
+                                regex:
+                                  description: RE2 style regex-based match (https://github.com/google/re2/wiki/Syntax).
+                                  format: string
+                                  type: string
+                              type: object
+                            description: withoutHeader has the same syntax with the
+                              header, but has opposite meaning.
+                            type: object
+                        type: object
+                      type: array
+                    mirror:
+                      properties:
+                        host:
+                          description: The name of a service from the service registry.
+                          format: string
+                          type: string
+                        port:
+                          description: Specifies the port on the host that is being
+                            addressed.
+                          properties:
+                            number:
+                              type: integer
+                          type: object
+                        subset:
+                          description: The name of a subset within the service.
+                          format: string
+                          type: string
+                      type: object
+                    mirror_percent:
+                      description: Percentage of the traffic to be mirrored by the
+                        `mirror` field.
+                      nullable: true
+                      type: integer
+                    mirrorPercent:
+                      description: Percentage of the traffic to be mirrored by the
+                        `mirror` field.
+                      nullable: true
+                      type: integer
+                    mirrorPercentage:
+                      description: Percentage of the traffic to be mirrored by the
+                        `mirror` field.
+                      properties:
+                        value:
+                          format: double
+                          type: number
+                      type: object
+                    name:
+                      description: The name assigned to the route for debugging purposes.
+                      format: string
+                      type: string
+                    redirect:
+                      description: A HTTP rule can either redirect or forward (default)
+                        traffic.
+                      properties:
+                        authority:
+                          format: string
+                          type: string
+                        redirectCode:
+                          type: integer
+                        uri:
+                          format: string
+                          type: string
+                      type: object
+                    retries:
+                      description: Retry policy for HTTP requests.
+                      properties:
+                        attempts:
+                          description: Number of retries for a given request.
+                          format: int32
+                          type: integer
+                        perTryTimeout:
+                          description: Timeout per retry attempt for a given request.
+                          type: string
+                        retryOn:
+                          description: Specifies the conditions under which retry
+                            takes place.
+                          format: string
+                          type: string
+                        retryRemoteLocalities:
+                          description: Flag to specify whether the retries should
+                            retry to other localities.
+                          nullable: true
+                          type: boolean
+                      type: object
+                    rewrite:
+                      description: Rewrite HTTP URIs and Authority headers.
+                      properties:
+                        authority:
+                          description: rewrite the Authority/Host header with this
+                            value.
+                          format: string
+                          type: string
+                        uri:
+                          format: string
+                          type: string
+                      type: object
+                    route:
+                      description: A HTTP rule can either redirect or forward (default)
+                        traffic.
+                      items:
+                        properties:
+                          destination:
+                            properties:
+                              host:
+                                description: The name of a service from the service
+                                  registry.
+                                format: string
+                                type: string
+                              port:
+                                description: Specifies the port on the host that is
+                                  being addressed.
+                                properties:
+                                  number:
+                                    type: integer
+                                type: object
+                              subset:
+                                description: The name of a subset within the service.
+                                format: string
+                                type: string
+                            type: object
+                          headers:
+                            properties:
+                              request:
+                                properties:
+                                  add:
+                                    additionalProperties:
+                                      format: string
+                                      type: string
+                                    type: object
+                                  remove:
+                                    items:
+                                      format: string
+                                      type: string
+                                    type: array
+                                  set:
+                                    additionalProperties:
+                                      format: string
+                                      type: string
+                                    type: object
+                                type: object
+                              response:
+                                properties:
+                                  add:
+                                    additionalProperties:
+                                      format: string
+                                      type: string
+                                    type: object
+                                  remove:
+                                    items:
+                                      format: string
+                                      type: string
+                                    type: array
+                                  set:
+                                    additionalProperties:
+                                      format: string
+                                      type: string
+                                    type: object
+                                type: object
+                            type: object
+                          weight:
+                            format: int32
+                            type: integer
+                        type: object
+                      type: array
+                    timeout:
+                      description: Timeout for HTTP requests, default is disabled.
+                      type: string
+                  type: object
+                type: array
+              tcp:
+                description: An ordered list of route rules for opaque TCP traffic.
+                items:
+                  properties:
+                    match:
+                      items:
+                        properties:
+                          destinationSubnets:
+                            description: IPv4 or IPv6 ip addresses of destination
+                              with optional subnet.
+                            items:
+                              format: string
+                              type: string
+                            type: array
+                          gateways:
+                            description: Names of gateways where the rule should be
+                              applied.
+                            items:
+                              format: string
+                              type: string
+                            type: array
+                          port:
+                            description: Specifies the port on the host that is being
+                              addressed.
+                            type: integer
+                          sourceLabels:
+                            additionalProperties:
+                              format: string
+                              type: string
+                            type: object
+                          sourceNamespace:
+                            description: Source namespace constraining the applicability
+                              of a rule to workloads in that namespace.
+                            format: string
+                            type: string
+                          sourceSubnet:
+                            description: IPv4 or IPv6 ip address of source with optional
+                              subnet.
+                            format: string
+                            type: string
+                        type: object
+                      type: array
+                    route:
+                      description: The destination to which the connection should
+                        be forwarded to.
+                      items:
+                        properties:
+                          destination:
+                            properties:
+                              host:
+                                description: The name of a service from the service
+                                  registry.
+                                format: string
+                                type: string
+                              port:
+                                description: Specifies the port on the host that is
+                                  being addressed.
+                                properties:
+                                  number:
+                                    type: integer
+                                type: object
+                              subset:
+                                description: The name of a subset within the service.
+                                format: string
+                                type: string
+                            type: object
+                          weight:
+                            format: int32
+                            type: integer
+                        type: object
+                      type: array
+                  type: object
+                type: array
+              tls:
+                items:
+                  properties:
+                    match:
+                      items:
+                        properties:
+                          destinationSubnets:
+                            description: IPv4 or IPv6 ip addresses of destination
+                              with optional subnet.
+                            items:
+                              format: string
+                              type: string
+                            type: array
+                          gateways:
+                            description: Names of gateways where the rule should be
+                              applied.
+                            items:
+                              format: string
+                              type: string
+                            type: array
+                          port:
+                            description: Specifies the port on the host that is being
+                              addressed.
+                            type: integer
+                          sniHosts:
+                            description: SNI (server name indicator) to match on.
+                            items:
+                              format: string
+                              type: string
+                            type: array
+                          sourceLabels:
+                            additionalProperties:
+                              format: string
+                              type: string
+                            type: object
+                          sourceNamespace:
+                            description: Source namespace constraining the applicability
+                              of a rule to workloads in that namespace.
+                            format: string
+                            type: string
+                        type: object
+                      type: array
+                    route:
+                      description: The destination to which the connection should
+                        be forwarded to.
+                      items:
+                        properties:
+                          destination:
+                            properties:
+                              host:
+                                description: The name of a service from the service
+                                  registry.
+                                format: string
+                                type: string
+                              port:
+                                description: Specifies the port on the host that is
+                                  being addressed.
+                                properties:
+                                  number:
+                                    type: integer
+                                type: object
+                              subset:
+                                description: The name of a subset within the service.
+                                format: string
+                                type: string
+                            type: object
+                          weight:
+                            format: int32
+                            type: integer
+                        type: object
+                      type: array
+                  type: object
+                type: array
+            type: object
+          status:
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+  - additionalPrinterColumns:
+    - description: The names of gateways and sidecars that should apply these routes
+      jsonPath: .spec.gateways
+      name: Gateways
+      type: string
+    - description: The destination hosts to which traffic is being sent
+      jsonPath: .spec.hosts
+      name: Hosts
+      type: string
+    - description: 'CreationTimestamp is a timestamp representing the server time
+        when this object was created. It is not guaranteed to be set in happens-before
+        order across separate operations. Clients may not set this value. It is represented
+        in RFC3339 form and is in UTC. Populated by the system. Read-only. Null for
+        lists. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata'
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        properties:
+          spec:
+            description: 'Configuration affecting label/content routing, sni routing,
+              etc. See more details at: https://istio.io/docs/reference/config/networking/virtual-service.html'
+            properties:
+              exportTo:
+                description: A list of namespaces to which this virtual service is
+                  exported.
+                items:
+                  format: string
+                  type: string
+                type: array
+              gateways:
+                description: The names of gateways and sidecars that should apply
+                  these routes.
+                items:
+                  format: string
+                  type: string
+                type: array
+              hosts:
+                description: The destination hosts to which traffic is being sent.
+                items:
+                  format: string
+                  type: string
+                type: array
+              http:
+                description: An ordered list of route rules for HTTP traffic.
+                items:
+                  properties:
+                    corsPolicy:
+                      description: Cross-Origin Resource Sharing policy (CORS).
+                      properties:
+                        allowCredentials:
+                          nullable: true
+                          type: boolean
+                        allowHeaders:
+                          items:
+                            format: string
+                            type: string
+                          type: array
+                        allowMethods:
+                          description: List of HTTP methods allowed to access the
+                            resource.
+                          items:
+                            format: string
+                            type: string
+                          type: array
+                        allowOrigin:
+                          description: The list of origins that are allowed to perform
+                            CORS requests.
+                          items:
+                            format: string
+                            type: string
+                          type: array
+                        allowOrigins:
+                          description: String patterns that match allowed origins.
+                          items:
+                            oneOf:
+                            - not:
+                                anyOf:
+                                - required:
+                                  - exact
+                                - required:
+                                  - prefix
+                                - required:
+                                  - regex
+                            - required:
+                              - exact
+                            - required:
+                              - prefix
+                            - required:
+                              - regex
+                            properties:
+                              exact:
+                                format: string
+                                type: string
+                              prefix:
+                                format: string
+                                type: string
+                              regex:
+                                description: RE2 style regex-based match (https://github.com/google/re2/wiki/Syntax).
+                                format: string
+                                type: string
+                            type: object
+                          type: array
+                        exposeHeaders:
+                          items:
+                            format: string
+                            type: string
+                          type: array
+                        maxAge:
+                          type: string
+                      type: object
+                    delegate:
+                      properties:
+                        name:
+                          description: Name specifies the name of the delegate VirtualService.
+                          format: string
+                          type: string
+                        namespace:
+                          description: Namespace specifies the namespace where the
+                            delegate VirtualService resides.
+                          format: string
+                          type: string
+                      type: object
+                    fault:
+                      description: Fault injection policy to apply on HTTP traffic
+                        at the client side.
+                      properties:
+                        abort:
+                          oneOf:
+                          - not:
+                              anyOf:
+                              - required:
+                                - httpStatus
+                              - required:
+                                - grpcStatus
+                              - required:
+                                - http2Error
+                          - required:
+                            - httpStatus
+                          - required:
+                            - grpcStatus
+                          - required:
+                            - http2Error
+                          properties:
+                            grpcStatus:
+                              format: string
+                              type: string
+                            http2Error:
+                              format: string
+                              type: string
+                            httpStatus:
+                              description: HTTP status code to use to abort the Http
+                                request.
+                              format: int32
+                              type: integer
+                            percentage:
+                              description: Percentage of requests to be aborted with
+                                the error code provided.
+                              properties:
+                                value:
+                                  format: double
+                                  type: number
+                              type: object
+                          type: object
+                        delay:
+                          oneOf:
+                          - not:
+                              anyOf:
+                              - required:
+                                - fixedDelay
+                              - required:
+                                - exponentialDelay
+                          - required:
+                            - fixedDelay
+                          - required:
+                            - exponentialDelay
+                          properties:
+                            exponentialDelay:
+                              type: string
+                            fixedDelay:
+                              description: Add a fixed delay before forwarding the
+                                request.
+                              type: string
+                            percent:
+                              description: Percentage of requests on which the delay
+                                will be injected (0-100).
+                              format: int32
+                              type: integer
+                            percentage:
+                              description: Percentage of requests on which the delay
+                                will be injected.
+                              properties:
+                                value:
+                                  format: double
+                                  type: number
+                              type: object
+                          type: object
+                      type: object
+                    headers:
+                      properties:
+                        request:
+                          properties:
+                            add:
+                              additionalProperties:
+                                format: string
+                                type: string
+                              type: object
+                            remove:
+                              items:
+                                format: string
+                                type: string
+                              type: array
+                            set:
+                              additionalProperties:
+                                format: string
+                                type: string
+                              type: object
+                          type: object
+                        response:
+                          properties:
+                            add:
+                              additionalProperties:
+                                format: string
+                                type: string
+                              type: object
+                            remove:
+                              items:
+                                format: string
+                                type: string
+                              type: array
+                            set:
+                              additionalProperties:
+                                format: string
+                                type: string
+                              type: object
+                          type: object
+                      type: object
+                    match:
+                      items:
+                        properties:
+                          authority:
+                            oneOf:
+                            - not:
+                                anyOf:
+                                - required:
+                                  - exact
+                                - required:
+                                  - prefix
+                                - required:
+                                  - regex
+                            - required:
+                              - exact
+                            - required:
+                              - prefix
+                            - required:
+                              - regex
+                            properties:
+                              exact:
+                                format: string
+                                type: string
+                              prefix:
+                                format: string
+                                type: string
+                              regex:
+                                description: RE2 style regex-based match (https://github.com/google/re2/wiki/Syntax).
+                                format: string
+                                type: string
+                            type: object
+                          gateways:
+                            description: Names of gateways where the rule should be
+                              applied.
+                            items:
+                              format: string
+                              type: string
+                            type: array
+                          headers:
+                            additionalProperties:
+                              oneOf:
+                              - not:
+                                  anyOf:
+                                  - required:
+                                    - exact
+                                  - required:
+                                    - prefix
+                                  - required:
+                                    - regex
+                              - required:
+                                - exact
+                              - required:
+                                - prefix
+                              - required:
+                                - regex
+                              properties:
+                                exact:
+                                  format: string
+                                  type: string
+                                prefix:
+                                  format: string
+                                  type: string
+                                regex:
+                                  description: RE2 style regex-based match (https://github.com/google/re2/wiki/Syntax).
+                                  format: string
+                                  type: string
+                              type: object
+                            type: object
+                          ignoreUriCase:
+                            description: Flag to specify whether the URI matching
+                              should be case-insensitive.
+                            type: boolean
+                          method:
+                            oneOf:
+                            - not:
+                                anyOf:
+                                - required:
+                                  - exact
+                                - required:
+                                  - prefix
+                                - required:
+                                  - regex
+                            - required:
+                              - exact
+                            - required:
+                              - prefix
+                            - required:
+                              - regex
+                            properties:
+                              exact:
+                                format: string
+                                type: string
+                              prefix:
+                                format: string
+                                type: string
+                              regex:
+                                description: RE2 style regex-based match (https://github.com/google/re2/wiki/Syntax).
+                                format: string
+                                type: string
+                            type: object
+                          name:
+                            description: The name assigned to a match.
+                            format: string
+                            type: string
+                          port:
+                            description: Specifies the ports on the host that is being
+                              addressed.
+                            type: integer
+                          queryParams:
+                            additionalProperties:
+                              oneOf:
+                              - not:
+                                  anyOf:
+                                  - required:
+                                    - exact
+                                  - required:
+                                    - prefix
+                                  - required:
+                                    - regex
+                              - required:
+                                - exact
+                              - required:
+                                - prefix
+                              - required:
+                                - regex
+                              properties:
+                                exact:
+                                  format: string
+                                  type: string
+                                prefix:
+                                  format: string
+                                  type: string
+                                regex:
+                                  description: RE2 style regex-based match (https://github.com/google/re2/wiki/Syntax).
+                                  format: string
+                                  type: string
+                              type: object
+                            description: Query parameters for matching.
+                            type: object
+                          scheme:
+                            oneOf:
+                            - not:
+                                anyOf:
+                                - required:
+                                  - exact
+                                - required:
+                                  - prefix
+                                - required:
+                                  - regex
+                            - required:
+                              - exact
+                            - required:
+                              - prefix
+                            - required:
+                              - regex
+                            properties:
+                              exact:
+                                format: string
+                                type: string
+                              prefix:
+                                format: string
+                                type: string
+                              regex:
+                                description: RE2 style regex-based match (https://github.com/google/re2/wiki/Syntax).
+                                format: string
+                                type: string
+                            type: object
+                          sourceLabels:
+                            additionalProperties:
+                              format: string
+                              type: string
+                            type: object
+                          sourceNamespace:
+                            description: Source namespace constraining the applicability
+                              of a rule to workloads in that namespace.
+                            format: string
+                            type: string
+                          uri:
+                            oneOf:
+                            - not:
+                                anyOf:
+                                - required:
+                                  - exact
+                                - required:
+                                  - prefix
+                                - required:
+                                  - regex
+                            - required:
+                              - exact
+                            - required:
+                              - prefix
+                            - required:
+                              - regex
+                            properties:
+                              exact:
+                                format: string
+                                type: string
+                              prefix:
+                                format: string
+                                type: string
+                              regex:
+                                description: RE2 style regex-based match (https://github.com/google/re2/wiki/Syntax).
+                                format: string
+                                type: string
+                            type: object
+                          withoutHeaders:
+                            additionalProperties:
+                              oneOf:
+                              - not:
+                                  anyOf:
+                                  - required:
+                                    - exact
+                                  - required:
+                                    - prefix
+                                  - required:
+                                    - regex
+                              - required:
+                                - exact
+                              - required:
+                                - prefix
+                              - required:
+                                - regex
+                              properties:
+                                exact:
+                                  format: string
+                                  type: string
+                                prefix:
+                                  format: string
+                                  type: string
+                                regex:
+                                  description: RE2 style regex-based match (https://github.com/google/re2/wiki/Syntax).
+                                  format: string
+                                  type: string
+                              type: object
+                            description: withoutHeader has the same syntax with the
+                              header, but has opposite meaning.
+                            type: object
+                        type: object
+                      type: array
+                    mirror:
+                      properties:
+                        host:
+                          description: The name of a service from the service registry.
+                          format: string
+                          type: string
+                        port:
+                          description: Specifies the port on the host that is being
+                            addressed.
+                          properties:
+                            number:
+                              type: integer
+                          type: object
+                        subset:
+                          description: The name of a subset within the service.
+                          format: string
+                          type: string
+                      type: object
+                    mirror_percent:
+                      description: Percentage of the traffic to be mirrored by the
+                        `mirror` field.
+                      nullable: true
+                      type: integer
+                    mirrorPercent:
+                      description: Percentage of the traffic to be mirrored by the
+                        `mirror` field.
+                      nullable: true
+                      type: integer
+                    mirrorPercentage:
+                      description: Percentage of the traffic to be mirrored by the
+                        `mirror` field.
+                      properties:
+                        value:
+                          format: double
+                          type: number
+                      type: object
+                    name:
+                      description: The name assigned to the route for debugging purposes.
+                      format: string
+                      type: string
+                    redirect:
+                      description: A HTTP rule can either redirect or forward (default)
+                        traffic.
+                      properties:
+                        authority:
+                          format: string
+                          type: string
+                        redirectCode:
+                          type: integer
+                        uri:
+                          format: string
+                          type: string
+                      type: object
+                    retries:
+                      description: Retry policy for HTTP requests.
+                      properties:
+                        attempts:
+                          description: Number of retries for a given request.
+                          format: int32
+                          type: integer
+                        perTryTimeout:
+                          description: Timeout per retry attempt for a given request.
+                          type: string
+                        retryOn:
+                          description: Specifies the conditions under which retry
+                            takes place.
+                          format: string
+                          type: string
+                        retryRemoteLocalities:
+                          description: Flag to specify whether the retries should
+                            retry to other localities.
+                          nullable: true
+                          type: boolean
+                      type: object
+                    rewrite:
+                      description: Rewrite HTTP URIs and Authority headers.
+                      properties:
+                        authority:
+                          description: rewrite the Authority/Host header with this
+                            value.
+                          format: string
+                          type: string
+                        uri:
+                          format: string
+                          type: string
+                      type: object
+                    route:
+                      description: A HTTP rule can either redirect or forward (default)
+                        traffic.
+                      items:
+                        properties:
+                          destination:
+                            properties:
+                              host:
+                                description: The name of a service from the service
+                                  registry.
+                                format: string
+                                type: string
+                              port:
+                                description: Specifies the port on the host that is
+                                  being addressed.
+                                properties:
+                                  number:
+                                    type: integer
+                                type: object
+                              subset:
+                                description: The name of a subset within the service.
+                                format: string
+                                type: string
+                            type: object
+                          headers:
+                            properties:
+                              request:
+                                properties:
+                                  add:
+                                    additionalProperties:
+                                      format: string
+                                      type: string
+                                    type: object
+                                  remove:
+                                    items:
+                                      format: string
+                                      type: string
+                                    type: array
+                                  set:
+                                    additionalProperties:
+                                      format: string
+                                      type: string
+                                    type: object
+                                type: object
+                              response:
+                                properties:
+                                  add:
+                                    additionalProperties:
+                                      format: string
+                                      type: string
+                                    type: object
+                                  remove:
+                                    items:
+                                      format: string
+                                      type: string
+                                    type: array
+                                  set:
+                                    additionalProperties:
+                                      format: string
+                                      type: string
+                                    type: object
+                                type: object
+                            type: object
+                          weight:
+                            format: int32
+                            type: integer
+                        type: object
+                      type: array
+                    timeout:
+                      description: Timeout for HTTP requests, default is disabled.
+                      type: string
+                  type: object
+                type: array
+              tcp:
+                description: An ordered list of route rules for opaque TCP traffic.
+                items:
+                  properties:
+                    match:
+                      items:
+                        properties:
+                          destinationSubnets:
+                            description: IPv4 or IPv6 ip addresses of destination
+                              with optional subnet.
+                            items:
+                              format: string
+                              type: string
+                            type: array
+                          gateways:
+                            description: Names of gateways where the rule should be
+                              applied.
+                            items:
+                              format: string
+                              type: string
+                            type: array
+                          port:
+                            description: Specifies the port on the host that is being
+                              addressed.
+                            type: integer
+                          sourceLabels:
+                            additionalProperties:
+                              format: string
+                              type: string
+                            type: object
+                          sourceNamespace:
+                            description: Source namespace constraining the applicability
+                              of a rule to workloads in that namespace.
+                            format: string
+                            type: string
+                          sourceSubnet:
+                            description: IPv4 or IPv6 ip address of source with optional
+                              subnet.
+                            format: string
+                            type: string
+                        type: object
+                      type: array
+                    route:
+                      description: The destination to which the connection should
+                        be forwarded to.
+                      items:
+                        properties:
+                          destination:
+                            properties:
+                              host:
+                                description: The name of a service from the service
+                                  registry.
+                                format: string
+                                type: string
+                              port:
+                                description: Specifies the port on the host that is
+                                  being addressed.
+                                properties:
+                                  number:
+                                    type: integer
+                                type: object
+                              subset:
+                                description: The name of a subset within the service.
+                                format: string
+                                type: string
+                            type: object
+                          weight:
+                            format: int32
+                            type: integer
+                        type: object
+                      type: array
+                  type: object
+                type: array
+              tls:
+                items:
+                  properties:
+                    match:
+                      items:
+                        properties:
+                          destinationSubnets:
+                            description: IPv4 or IPv6 ip addresses of destination
+                              with optional subnet.
+                            items:
+                              format: string
+                              type: string
+                            type: array
+                          gateways:
+                            description: Names of gateways where the rule should be
+                              applied.
+                            items:
+                              format: string
+                              type: string
+                            type: array
+                          port:
+                            description: Specifies the port on the host that is being
+                              addressed.
+                            type: integer
+                          sniHosts:
+                            description: SNI (server name indicator) to match on.
+                            items:
+                              format: string
+                              type: string
+                            type: array
+                          sourceLabels:
+                            additionalProperties:
+                              format: string
+                              type: string
+                            type: object
+                          sourceNamespace:
+                            description: Source namespace constraining the applicability
+                              of a rule to workloads in that namespace.
+                            format: string
+                            type: string
+                        type: object
+                      type: array
+                    route:
+                      description: The destination to which the connection should
+                        be forwarded to.
+                      items:
+                        properties:
+                          destination:
+                            properties:
+                              host:
+                                description: The name of a service from the service
+                                  registry.
+                                format: string
+                                type: string
+                              port:
+                                description: Specifies the port on the host that is
+                                  being addressed.
+                                properties:
+                                  number:
+                                    type: integer
+                                type: object
+                              subset:
+                                description: The name of a subset within the service.
+                                format: string
+                                type: string
+                            type: object
+                          weight:
+                            format: int32
+                            type: integer
+                        type: object
+                      type: array
+                  type: object
+                type: array
+            type: object
+          status:
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    helm.sh/resource-policy: keep
+  labels:
+    app: istio-pilot
+    chart: istio
+    cloudfoundry.org/istio_version: 1.7.1
+    heritage: Tiller
+    release: istio
+  name: workloadentries.networking.istio.io
+spec:
+  group: networking.istio.io
+  names:
+    categories:
+    - istio-io
+    - networking-istio-io
+    kind: WorkloadEntry
+    listKind: WorkloadEntryList
+    plural: workloadentries
+    shortNames:
+    - we
+    singular: workloadentry
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: 'CreationTimestamp is a timestamp representing the server time
+        when this object was created. It is not guaranteed to be set in happens-before
+        order across separate operations. Clients may not set this value. It is represented
+        in RFC3339 form and is in UTC. Populated by the system. Read-only. Null for
+        lists. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata'
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - description: Address associated with the network endpoint.
+      jsonPath: .spec.address
+      name: Address
+      type: string
+    name: v1alpha3
+    schema:
+      openAPIV3Schema:
+        properties:
+          spec:
+            description: 'Configuration affecting VMs onboarded into the mesh. See
+              more details at: https://istio.io/docs/reference/config/networking/workload-entry.html'
+            properties:
+              address:
+                format: string
+                type: string
+              labels:
+                additionalProperties:
+                  format: string
+                  type: string
+                description: One or more labels associated with the endpoint.
+                type: object
+              locality:
+                description: The locality associated with the endpoint.
+                format: string
+                type: string
+              network:
+                format: string
+                type: string
+              ports:
+                additionalProperties:
+                  type: integer
+                description: Set of ports associated with the endpoint.
+                type: object
+              serviceAccount:
+                format: string
+                type: string
+              weight:
+                description: The load balancing weight associated with the endpoint.
+                type: integer
+            type: object
+          status:
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+  - additionalPrinterColumns:
+    - description: 'CreationTimestamp is a timestamp representing the server time
+        when this object was created. It is not guaranteed to be set in happens-before
+        order across separate operations. Clients may not set this value. It is represented
+        in RFC3339 form and is in UTC. Populated by the system. Read-only. Null for
+        lists. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata'
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - description: Address associated with the network endpoint.
+      jsonPath: .spec.address
+      name: Address
+      type: string
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        properties:
+          spec:
+            description: 'Configuration affecting VMs onboarded into the mesh. See
+              more details at: https://istio.io/docs/reference/config/networking/workload-entry.html'
+            properties:
+              address:
+                format: string
+                type: string
+              labels:
+                additionalProperties:
+                  format: string
+                  type: string
+                description: One or more labels associated with the endpoint.
+                type: object
+              locality:
+                description: The locality associated with the endpoint.
+                format: string
+                type: string
+              network:
+                format: string
+                type: string
+              ports:
+                additionalProperties:
+                  type: integer
+                description: Set of ports associated with the endpoint.
+                type: object
+              serviceAccount:
+                format: string
+                type: string
+              weight:
+                description: The load balancing weight associated with the endpoint.
+                type: integer
+            type: object
+          status:
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app: istio-ingressgateway
+    cloudfoundry.org/istio_version: 1.7.1
+    istio: ingressgateway
+    release: istio
+  name: istio-ingressgateway-service-account
+  namespace: istio-system
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app: istio-reader
+    cloudfoundry.org/istio_version: 1.7.1
+    release: istio
+  name: istio-reader-service-account
+  namespace: istio-system
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app: istiod
+    cloudfoundry.org/istio_version: 1.7.1
+    release: istio
+  name: istiod-service-account
+  namespace: istio-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app: istio-reader
+    cloudfoundry.org/istio_version: 1.7.1
+    release: istio
+  name: istio-reader-istio-system
+rules:
+- apiGroups:
+  - config.istio.io
+  - security.istio.io
+  - networking.istio.io
+  - authentication.istio.io
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - endpoints
+  - pods
+  - services
+  - nodes
+  - replicationcontrollers
+  - namespaces
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apps
+  resources:
+  - replicasets
+  verbs:
+  - get
+  - list
+  - watch
+---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
     app: istiod
-    cloudfoundry.org/istio_version: 1.6.4
+    cloudfoundry.org/istio_version: 1.7.1
     release: istio
   name: istiod-istio-system
 rules:
@@ -27,14 +6857,7 @@ rules:
   - watch
   - update
 - apiGroups:
-  - networking.istio.io
-  resources:
-  - gateways
-  verbs:
-  - create
-- apiGroups:
   - config.istio.io
-  - rbac.istio.io
   - security.istio.io
   - networking.istio.io
   - authentication.istio.io
@@ -48,15 +6871,6 @@ rules:
   - apiextensions.k8s.io
   resources:
   - customresourcedefinitions
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - extensions
-  - apps
-  resources:
-  - deployments
   verbs:
   - get
   - list
@@ -133,82 +6947,28 @@ rules:
   verbs:
   - create
 - apiGroups:
+  - networking.x-k8s.io
+  resources:
+  - '*'
+  verbs:
+  - get
+  - watch
+  - list
+- apiGroups:
   - ""
   resources:
   - secrets
   verbs:
-  - create
   - get
   - watch
   - list
-  - update
-  - delete
-- apiGroups:
-  - ""
-  resources:
-  - serviceaccounts
-  verbs:
-  - get
-  - watch
-  - list
-- apiGroups:
-  - networking.x.k8s.io
-  resources:
-  - '*'
-  verbs:
-  - get
-  - watch
-  - list
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  labels:
-    app: istio-reader
-    cloudfoundry.org/istio_version: 1.6.4
-    release: istio
-  name: istio-reader-istio-system
-rules:
-- apiGroups:
-  - config.istio.io
-  - rbac.istio.io
-  - security.istio.io
-  - networking.istio.io
-  - authentication.istio.io
-  resources:
-  - '*'
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - ""
-  resources:
-  - endpoints
-  - pods
-  - services
-  - nodes
-  - replicationcontrollers
-  - namespaces
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - apps
-  resources:
-  - replicasets
-  verbs:
-  - get
-  - list
-  - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
     app: istio-reader
-    cloudfoundry.org/istio_version: 1.6.4
+    cloudfoundry.org/istio_version: 1.7.1
     release: istio
   name: istio-reader-istio-system
 roleRef:
@@ -225,7 +6985,7 @@ kind: ClusterRoleBinding
 metadata:
   labels:
     app: pilot
-    cloudfoundry.org/istio_version: 1.6.4
+    cloudfoundry.org/istio_version: 1.7.1
     release: istio
   name: istiod-pilot-istio-system
 roleRef:
@@ -237,37 +6997,20 @@ subjects:
   name: istiod-service-account
   namespace: istio-system
 ---
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  labels:
-    app: istio-reader
-    cloudfoundry.org/istio_version: 1.6.4
-    release: istio
-  name: istio-reader-service-account
-  namespace: istio-system
----
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  labels:
-    app: istiod
-    cloudfoundry.org/istio_version: 1.6.4
-    release: istio
-  name: istiod-service-account
-  namespace: istio-system
----
 apiVersion: admissionregistration.k8s.io/v1beta1
 kind: ValidatingWebhookConfiguration
 metadata:
   labels:
     app: istiod
-    cloudfoundry.org/istio_version: 1.6.4
+    cloudfoundry.org/istio_version: 1.7.1
     istio: istiod
     release: istio
   name: istiod-istio-system
 webhooks:
-- clientConfig:
+- admissionReviewVersions:
+  - v1beta1
+  - v1
+  clientConfig:
     caBundle: ""
     service:
       name: istiod
@@ -278,7 +7021,6 @@ webhooks:
   rules:
   - apiGroups:
     - config.istio.io
-    - rbac.istio.io
     - security.istio.io
     - authentication.istio.io
     - networking.istio.io
@@ -291,5441 +7033,679 @@ webhooks:
     - '*'
   sideEffects: None
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
-kind: CustomResourceDefinition
-metadata:
-  annotations:
-    helm.sh/resource-policy: keep
-  labels:
-    app: istio-mixer
-    chart: istio
-    cloudfoundry.org/istio_version: 1.6.4
-    heritage: Tiller
-    release: istio
-  name: httpapispecs.config.istio.io
-spec:
-  group: config.istio.io
-  names:
-    categories:
-    - istio-io
-    - apim-istio-io
-    kind: HTTPAPISpec
-    listKind: HTTPAPISpecList
-    plural: httpapispecs
-    singular: httpapispec
-  preserveUnknownFields: false
-  scope: Namespaced
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      properties:
-        spec:
-          properties:
-            api_keys:
-              items:
-                oneOf:
-                - not:
-                    anyOf:
-                    - required:
-                      - query
-                    - required:
-                      - header
-                    - required:
-                      - cookie
-                - required:
-                  - query
-                - required:
-                  - header
-                - required:
-                  - cookie
-                properties:
-                  cookie:
-                    format: string
-                    type: string
-                  header:
-                    description: API key is sent in a request header.
-                    format: string
-                    type: string
-                  query:
-                    description: API Key is sent as a query parameter.
-                    format: string
-                    type: string
-                type: object
-              type: array
-            apiKeys:
-              items:
-                oneOf:
-                - not:
-                    anyOf:
-                    - required:
-                      - query
-                    - required:
-                      - header
-                    - required:
-                      - cookie
-                - required:
-                  - query
-                - required:
-                  - header
-                - required:
-                  - cookie
-                properties:
-                  cookie:
-                    format: string
-                    type: string
-                  header:
-                    description: API key is sent in a request header.
-                    format: string
-                    type: string
-                  query:
-                    description: API Key is sent as a query parameter.
-                    format: string
-                    type: string
-                type: object
-              type: array
-            attributes:
-              properties:
-                attributes:
-                  additionalProperties:
-                    oneOf:
-                    - not:
-                        anyOf:
-                        - required:
-                          - stringValue
-                        - required:
-                          - int64Value
-                        - required:
-                          - doubleValue
-                        - required:
-                          - boolValue
-                        - required:
-                          - bytesValue
-                        - required:
-                          - timestampValue
-                        - required:
-                          - durationValue
-                        - required:
-                          - stringMapValue
-                    - required:
-                      - stringValue
-                    - required:
-                      - int64Value
-                    - required:
-                      - doubleValue
-                    - required:
-                      - boolValue
-                    - required:
-                      - bytesValue
-                    - required:
-                      - timestampValue
-                    - required:
-                      - durationValue
-                    - required:
-                      - stringMapValue
-                    properties:
-                      boolValue:
-                        type: boolean
-                      bytesValue:
-                        format: binary
-                        type: string
-                      doubleValue:
-                        format: double
-                        type: number
-                      durationValue:
-                        type: string
-                      int64Value:
-                        format: int64
-                        type: integer
-                      stringMapValue:
-                        properties:
-                          entries:
-                            additionalProperties:
-                              format: string
-                              type: string
-                            description: Holds a set of name/value pairs.
-                            type: object
-                        type: object
-                      stringValue:
-                        format: string
-                        type: string
-                      timestampValue:
-                        format: dateTime
-                        type: string
-                    type: object
-                  description: A map of attribute name to its value.
-                  type: object
-              type: object
-            patterns:
-              description: List of HTTP patterns to match.
-              items:
-                oneOf:
-                - not:
-                    anyOf:
-                    - required:
-                      - uriTemplate
-                    - required:
-                      - regex
-                - required:
-                  - uriTemplate
-                - required:
-                  - regex
-                properties:
-                  attributes:
-                    properties:
-                      attributes:
-                        additionalProperties:
-                          oneOf:
-                          - not:
-                              anyOf:
-                              - required:
-                                - stringValue
-                              - required:
-                                - int64Value
-                              - required:
-                                - doubleValue
-                              - required:
-                                - boolValue
-                              - required:
-                                - bytesValue
-                              - required:
-                                - timestampValue
-                              - required:
-                                - durationValue
-                              - required:
-                                - stringMapValue
-                          - required:
-                            - stringValue
-                          - required:
-                            - int64Value
-                          - required:
-                            - doubleValue
-                          - required:
-                            - boolValue
-                          - required:
-                            - bytesValue
-                          - required:
-                            - timestampValue
-                          - required:
-                            - durationValue
-                          - required:
-                            - stringMapValue
-                          properties:
-                            boolValue:
-                              type: boolean
-                            bytesValue:
-                              format: binary
-                              type: string
-                            doubleValue:
-                              format: double
-                              type: number
-                            durationValue:
-                              type: string
-                            int64Value:
-                              format: int64
-                              type: integer
-                            stringMapValue:
-                              properties:
-                                entries:
-                                  additionalProperties:
-                                    format: string
-                                    type: string
-                                  description: Holds a set of name/value pairs.
-                                  type: object
-                              type: object
-                            stringValue:
-                              format: string
-                              type: string
-                            timestampValue:
-                              format: dateTime
-                              type: string
-                          type: object
-                        description: A map of attribute name to its value.
-                        type: object
-                    type: object
-                  httpMethod:
-                    format: string
-                    type: string
-                  regex:
-                    format: string
-                    type: string
-                  uriTemplate:
-                    format: string
-                    type: string
-                type: object
-              type: array
-          type: object
-        status:
-          type: object
-          x-kubernetes-preserve-unknown-fields: true
-      type: object
-  versions:
-  - name: v1alpha2
-    served: true
-    storage: true
----
-apiVersion: apiextensions.k8s.io/v1beta1
-kind: CustomResourceDefinition
-metadata:
-  annotations:
-    helm.sh/resource-policy: keep
-  labels:
-    app: istio-mixer
-    chart: istio
-    cloudfoundry.org/istio_version: 1.6.4
-    heritage: Tiller
-    release: istio
-  name: httpapispecbindings.config.istio.io
-spec:
-  group: config.istio.io
-  names:
-    categories:
-    - istio-io
-    - apim-istio-io
-    kind: HTTPAPISpecBinding
-    listKind: HTTPAPISpecBindingList
-    plural: httpapispecbindings
-    singular: httpapispecbinding
-  preserveUnknownFields: false
-  scope: Namespaced
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      properties:
-        spec:
-          properties:
-            api_specs:
-              items:
-                properties:
-                  name:
-                    description: The short name of the HTTPAPISpec.
-                    format: string
-                    type: string
-                  namespace:
-                    description: Optional namespace of the HTTPAPISpec.
-                    format: string
-                    type: string
-                type: object
-              type: array
-            apiSpecs:
-              items:
-                properties:
-                  name:
-                    description: The short name of the HTTPAPISpec.
-                    format: string
-                    type: string
-                  namespace:
-                    description: Optional namespace of the HTTPAPISpec.
-                    format: string
-                    type: string
-                type: object
-              type: array
-            services:
-              description: One or more services to map the listed HTTPAPISpec onto.
-              items:
-                properties:
-                  domain:
-                    description: Domain suffix used to construct the service FQDN
-                      in implementations that support such specification.
-                    format: string
-                    type: string
-                  labels:
-                    additionalProperties:
-                      format: string
-                      type: string
-                    description: Optional one or more labels that uniquely identify
-                      the service version.
-                    type: object
-                  name:
-                    description: The short name of the service such as "foo".
-                    format: string
-                    type: string
-                  namespace:
-                    description: Optional namespace of the service.
-                    format: string
-                    type: string
-                  service:
-                    description: The service FQDN.
-                    format: string
-                    type: string
-                type: object
-              type: array
-          type: object
-        status:
-          type: object
-          x-kubernetes-preserve-unknown-fields: true
-      type: object
-  versions:
-  - name: v1alpha2
-    served: true
-    storage: true
----
-apiVersion: apiextensions.k8s.io/v1beta1
-kind: CustomResourceDefinition
-metadata:
-  annotations:
-    helm.sh/resource-policy: keep
-  labels:
-    app: istio-mixer
-    chart: istio
-    cloudfoundry.org/istio_version: 1.6.4
-    heritage: Tiller
-    release: istio
-  name: quotaspecs.config.istio.io
-spec:
-  group: config.istio.io
-  names:
-    categories:
-    - istio-io
-    - apim-istio-io
-    kind: QuotaSpec
-    listKind: QuotaSpecList
-    plural: quotaspecs
-    singular: quotaspec
-  preserveUnknownFields: false
-  scope: Namespaced
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      properties:
-        spec:
-          description: Determines the quotas used for individual requests.
-          properties:
-            rules:
-              description: A list of Quota rules.
-              items:
-                properties:
-                  match:
-                    description: If empty, match all request.
-                    items:
-                      properties:
-                        clause:
-                          additionalProperties:
-                            oneOf:
-                            - not:
-                                anyOf:
-                                - required:
-                                  - exact
-                                - required:
-                                  - prefix
-                                - required:
-                                  - regex
-                            - required:
-                              - exact
-                            - required:
-                              - prefix
-                            - required:
-                              - regex
-                            properties:
-                              exact:
-                                format: string
-                                type: string
-                              prefix:
-                                format: string
-                                type: string
-                              regex:
-                                description: RE2 style regex-based match (https://github.com/google/re2/wiki/Syntax).
-                                format: string
-                                type: string
-                            type: object
-                          description: Map of attribute names to StringMatch type.
-                          type: object
-                      type: object
-                    type: array
-                  quotas:
-                    description: The list of quotas to charge.
-                    items:
-                      properties:
-                        charge:
-                          format: int32
-                          type: integer
-                        quota:
-                          format: string
-                          type: string
-                      type: object
-                    type: array
-                type: object
-              type: array
-          type: object
-        status:
-          type: object
-          x-kubernetes-preserve-unknown-fields: true
-      type: object
-  versions:
-  - name: v1alpha2
-    served: true
-    storage: true
----
-apiVersion: apiextensions.k8s.io/v1beta1
-kind: CustomResourceDefinition
-metadata:
-  annotations:
-    helm.sh/resource-policy: keep
-  labels:
-    app: istio-mixer
-    chart: istio
-    cloudfoundry.org/istio_version: 1.6.4
-    heritage: Tiller
-    release: istio
-  name: quotaspecbindings.config.istio.io
-spec:
-  group: config.istio.io
-  names:
-    categories:
-    - istio-io
-    - apim-istio-io
-    kind: QuotaSpecBinding
-    listKind: QuotaSpecBindingList
-    plural: quotaspecbindings
-    singular: quotaspecbinding
-  preserveUnknownFields: false
-  scope: Namespaced
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      properties:
-        spec:
-          properties:
-            quotaSpecs:
-              items:
-                properties:
-                  name:
-                    description: The short name of the QuotaSpec.
-                    format: string
-                    type: string
-                  namespace:
-                    description: Optional namespace of the QuotaSpec.
-                    format: string
-                    type: string
-                type: object
-              type: array
-            services:
-              description: One or more services to map the listed QuotaSpec onto.
-              items:
-                properties:
-                  domain:
-                    description: Domain suffix used to construct the service FQDN
-                      in implementations that support such specification.
-                    format: string
-                    type: string
-                  labels:
-                    additionalProperties:
-                      format: string
-                      type: string
-                    description: Optional one or more labels that uniquely identify
-                      the service version.
-                    type: object
-                  name:
-                    description: The short name of the service such as "foo".
-                    format: string
-                    type: string
-                  namespace:
-                    description: Optional namespace of the service.
-                    format: string
-                    type: string
-                  service:
-                    description: The service FQDN.
-                    format: string
-                    type: string
-                type: object
-              type: array
-          type: object
-        status:
-          type: object
-          x-kubernetes-preserve-unknown-fields: true
-      type: object
-  versions:
-  - name: v1alpha2
-    served: true
-    storage: true
----
-apiVersion: apiextensions.k8s.io/v1beta1
-kind: CustomResourceDefinition
-metadata:
-  annotations:
-    helm.sh/resource-policy: keep
-  labels:
-    app: istio-pilot
-    chart: istio
-    cloudfoundry.org/istio_version: 1.6.4
-    heritage: Tiller
-    release: istio
-  name: destinationrules.networking.istio.io
-spec:
-  additionalPrinterColumns:
-  - JSONPath: .spec.host
-    description: The name of a service from the service registry
-    name: Host
-    type: string
-  - JSONPath: .metadata.creationTimestamp
-    description: 'CreationTimestamp is a timestamp representing the server time when
-      this object was created. It is not guaranteed to be set in happens-before order
-      across separate operations. Clients may not set this value. It is represented
-      in RFC3339 form and is in UTC. Populated by the system. Read-only. Null for
-      lists. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata'
-    name: Age
-    type: date
-  group: networking.istio.io
-  names:
-    categories:
-    - istio-io
-    - networking-istio-io
-    kind: DestinationRule
-    listKind: DestinationRuleList
-    plural: destinationrules
-    shortNames:
-    - dr
-    singular: destinationrule
-  preserveUnknownFields: false
-  scope: Namespaced
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      properties:
-        spec:
-          description: 'Configuration affecting load balancing, outlier detection,
-            etc. See more details at: https://istio.io/docs/reference/config/networking/destination-rule.html'
-          properties:
-            exportTo:
-              description: A list of namespaces to which this destination rule is
-                exported.
-              items:
-                format: string
-                type: string
-              type: array
-            host:
-              description: The name of a service from the service registry.
-              format: string
-              type: string
-            subsets:
-              items:
-                properties:
-                  labels:
-                    additionalProperties:
-                      format: string
-                      type: string
-                    type: object
-                  name:
-                    description: Name of the subset.
-                    format: string
-                    type: string
-                  trafficPolicy:
-                    description: Traffic policies that apply to this subset.
-                    properties:
-                      connectionPool:
-                        properties:
-                          http:
-                            description: HTTP connection pool settings.
-                            properties:
-                              h2UpgradePolicy:
-                                description: Specify if http1.1 connection should
-                                  be upgraded to http2 for the associated destination.
-                                enum:
-                                - DEFAULT
-                                - DO_NOT_UPGRADE
-                                - UPGRADE
-                                type: string
-                              http1MaxPendingRequests:
-                                description: Maximum number of pending HTTP requests
-                                  to a destination.
-                                format: int32
-                                type: integer
-                              http2MaxRequests:
-                                description: Maximum number of requests to a backend.
-                                format: int32
-                                type: integer
-                              idleTimeout:
-                                description: The idle timeout for upstream connection
-                                  pool connections.
-                                type: string
-                              maxRequestsPerConnection:
-                                description: Maximum number of requests per connection
-                                  to a backend.
-                                format: int32
-                                type: integer
-                              maxRetries:
-                                format: int32
-                                type: integer
-                            type: object
-                          tcp:
-                            description: Settings common to both HTTP and TCP upstream
-                              connections.
-                            properties:
-                              connectTimeout:
-                                description: TCP connection timeout.
-                                type: string
-                              maxConnections:
-                                description: Maximum number of HTTP1 /TCP connections
-                                  to a destination host.
-                                format: int32
-                                type: integer
-                              tcpKeepalive:
-                                description: If set then set SO_KEEPALIVE on the socket
-                                  to enable TCP Keepalives.
-                                properties:
-                                  interval:
-                                    description: The time duration between keep-alive
-                                      probes.
-                                    type: string
-                                  probes:
-                                    type: integer
-                                  time:
-                                    type: string
-                                type: object
-                            type: object
-                        type: object
-                      loadBalancer:
-                        description: Settings controlling the load balancer algorithms.
-                        oneOf:
-                        - not:
-                            anyOf:
-                            - required:
-                              - simple
-                            - properties:
-                                consistentHash:
-                                  oneOf:
-                                  - not:
-                                      anyOf:
-                                      - required:
-                                        - httpHeaderName
-                                      - required:
-                                        - httpCookie
-                                      - required:
-                                        - useSourceIp
-                                      - required:
-                                        - httpQueryParameterName
-                                  - required:
-                                    - httpHeaderName
-                                  - required:
-                                    - httpCookie
-                                  - required:
-                                    - useSourceIp
-                                  - required:
-                                    - httpQueryParameterName
-                              required:
-                              - consistentHash
-                        - required:
-                          - simple
-                        - properties:
-                            consistentHash:
-                              oneOf:
-                              - not:
-                                  anyOf:
-                                  - required:
-                                    - httpHeaderName
-                                  - required:
-                                    - httpCookie
-                                  - required:
-                                    - useSourceIp
-                                  - required:
-                                    - httpQueryParameterName
-                              - required:
-                                - httpHeaderName
-                              - required:
-                                - httpCookie
-                              - required:
-                                - useSourceIp
-                              - required:
-                                - httpQueryParameterName
-                          required:
-                          - consistentHash
-                        properties:
-                          consistentHash:
-                            properties:
-                              httpCookie:
-                                description: Hash based on HTTP cookie.
-                                properties:
-                                  name:
-                                    description: Name of the cookie.
-                                    format: string
-                                    type: string
-                                  path:
-                                    description: Path to set for the cookie.
-                                    format: string
-                                    type: string
-                                  ttl:
-                                    description: Lifetime of the cookie.
-                                    type: string
-                                type: object
-                              httpHeaderName:
-                                description: Hash based on a specific HTTP header.
-                                format: string
-                                type: string
-                              httpQueryParameterName:
-                                description: Hash based on a specific HTTP query parameter.
-                                format: string
-                                type: string
-                              minimumRingSize:
-                                type: integer
-                              useSourceIp:
-                                description: Hash based on the source IP address.
-                                type: boolean
-                            type: object
-                          localityLbSetting:
-                            properties:
-                              distribute:
-                                description: 'Optional: only one of distribute or
-                                  failover can be set.'
-                                items:
-                                  properties:
-                                    from:
-                                      description: Originating locality, '/' separated,
-                                        e.g.
-                                      format: string
-                                      type: string
-                                    to:
-                                      additionalProperties:
-                                        type: integer
-                                      description: Map of upstream localities to traffic
-                                        distribution weights.
-                                      type: object
-                                  type: object
-                                type: array
-                              enabled:
-                                description: enable locality load balancing, this
-                                  is DestinationRule-level and will override mesh
-                                  wide settings in entirety.
-                                type: boolean
-                              failover:
-                                description: 'Optional: only failover or distribute
-                                  can be set.'
-                                items:
-                                  properties:
-                                    from:
-                                      description: Originating region.
-                                      format: string
-                                      type: string
-                                    to:
-                                      format: string
-                                      type: string
-                                  type: object
-                                type: array
-                            type: object
-                          simple:
-                            enum:
-                            - ROUND_ROBIN
-                            - LEAST_CONN
-                            - RANDOM
-                            - PASSTHROUGH
-                            type: string
-                        type: object
-                      outlierDetection:
-                        properties:
-                          baseEjectionTime:
-                            description: Minimum ejection duration.
-                            type: string
-                          consecutive5xxErrors:
-                            description: Number of 5xx errors before a host is ejected
-                              from the connection pool.
-                            type: integer
-                          consecutiveErrors:
-                            format: int32
-                            type: integer
-                          consecutiveGatewayErrors:
-                            description: Number of gateway errors before a host is
-                              ejected from the connection pool.
-                            type: integer
-                          interval:
-                            description: Time interval between ejection sweep analysis.
-                            type: string
-                          maxEjectionPercent:
-                            format: int32
-                            type: integer
-                          minHealthPercent:
-                            format: int32
-                            type: integer
-                        type: object
-                      portLevelSettings:
-                        description: Traffic policies specific to individual ports.
-                        items:
-                          properties:
-                            connectionPool:
-                              properties:
-                                http:
-                                  description: HTTP connection pool settings.
-                                  properties:
-                                    h2UpgradePolicy:
-                                      description: Specify if http1.1 connection should
-                                        be upgraded to http2 for the associated destination.
-                                      enum:
-                                      - DEFAULT
-                                      - DO_NOT_UPGRADE
-                                      - UPGRADE
-                                      type: string
-                                    http1MaxPendingRequests:
-                                      description: Maximum number of pending HTTP
-                                        requests to a destination.
-                                      format: int32
-                                      type: integer
-                                    http2MaxRequests:
-                                      description: Maximum number of requests to a
-                                        backend.
-                                      format: int32
-                                      type: integer
-                                    idleTimeout:
-                                      description: The idle timeout for upstream connection
-                                        pool connections.
-                                      type: string
-                                    maxRequestsPerConnection:
-                                      description: Maximum number of requests per
-                                        connection to a backend.
-                                      format: int32
-                                      type: integer
-                                    maxRetries:
-                                      format: int32
-                                      type: integer
-                                  type: object
-                                tcp:
-                                  description: Settings common to both HTTP and TCP
-                                    upstream connections.
-                                  properties:
-                                    connectTimeout:
-                                      description: TCP connection timeout.
-                                      type: string
-                                    maxConnections:
-                                      description: Maximum number of HTTP1 /TCP connections
-                                        to a destination host.
-                                      format: int32
-                                      type: integer
-                                    tcpKeepalive:
-                                      description: If set then set SO_KEEPALIVE on
-                                        the socket to enable TCP Keepalives.
-                                      properties:
-                                        interval:
-                                          description: The time duration between keep-alive
-                                            probes.
-                                          type: string
-                                        probes:
-                                          type: integer
-                                        time:
-                                          type: string
-                                      type: object
-                                  type: object
-                              type: object
-                            loadBalancer:
-                              description: Settings controlling the load balancer
-                                algorithms.
-                              oneOf:
-                              - not:
-                                  anyOf:
-                                  - required:
-                                    - simple
-                                  - properties:
-                                      consistentHash:
-                                        oneOf:
-                                        - not:
-                                            anyOf:
-                                            - required:
-                                              - httpHeaderName
-                                            - required:
-                                              - httpCookie
-                                            - required:
-                                              - useSourceIp
-                                            - required:
-                                              - httpQueryParameterName
-                                        - required:
-                                          - httpHeaderName
-                                        - required:
-                                          - httpCookie
-                                        - required:
-                                          - useSourceIp
-                                        - required:
-                                          - httpQueryParameterName
-                                    required:
-                                    - consistentHash
-                              - required:
-                                - simple
-                              - properties:
-                                  consistentHash:
-                                    oneOf:
-                                    - not:
-                                        anyOf:
-                                        - required:
-                                          - httpHeaderName
-                                        - required:
-                                          - httpCookie
-                                        - required:
-                                          - useSourceIp
-                                        - required:
-                                          - httpQueryParameterName
-                                    - required:
-                                      - httpHeaderName
-                                    - required:
-                                      - httpCookie
-                                    - required:
-                                      - useSourceIp
-                                    - required:
-                                      - httpQueryParameterName
-                                required:
-                                - consistentHash
-                              properties:
-                                consistentHash:
-                                  properties:
-                                    httpCookie:
-                                      description: Hash based on HTTP cookie.
-                                      properties:
-                                        name:
-                                          description: Name of the cookie.
-                                          format: string
-                                          type: string
-                                        path:
-                                          description: Path to set for the cookie.
-                                          format: string
-                                          type: string
-                                        ttl:
-                                          description: Lifetime of the cookie.
-                                          type: string
-                                      type: object
-                                    httpHeaderName:
-                                      description: Hash based on a specific HTTP header.
-                                      format: string
-                                      type: string
-                                    httpQueryParameterName:
-                                      description: Hash based on a specific HTTP query
-                                        parameter.
-                                      format: string
-                                      type: string
-                                    minimumRingSize:
-                                      type: integer
-                                    useSourceIp:
-                                      description: Hash based on the source IP address.
-                                      type: boolean
-                                  type: object
-                                localityLbSetting:
-                                  properties:
-                                    distribute:
-                                      description: 'Optional: only one of distribute
-                                        or failover can be set.'
-                                      items:
-                                        properties:
-                                          from:
-                                            description: Originating locality, '/'
-                                              separated, e.g.
-                                            format: string
-                                            type: string
-                                          to:
-                                            additionalProperties:
-                                              type: integer
-                                            description: Map of upstream localities
-                                              to traffic distribution weights.
-                                            type: object
-                                        type: object
-                                      type: array
-                                    enabled:
-                                      description: enable locality load balancing,
-                                        this is DestinationRule-level and will override
-                                        mesh wide settings in entirety.
-                                      type: boolean
-                                    failover:
-                                      description: 'Optional: only failover or distribute
-                                        can be set.'
-                                      items:
-                                        properties:
-                                          from:
-                                            description: Originating region.
-                                            format: string
-                                            type: string
-                                          to:
-                                            format: string
-                                            type: string
-                                        type: object
-                                      type: array
-                                  type: object
-                                simple:
-                                  enum:
-                                  - ROUND_ROBIN
-                                  - LEAST_CONN
-                                  - RANDOM
-                                  - PASSTHROUGH
-                                  type: string
-                              type: object
-                            outlierDetection:
-                              properties:
-                                baseEjectionTime:
-                                  description: Minimum ejection duration.
-                                  type: string
-                                consecutive5xxErrors:
-                                  description: Number of 5xx errors before a host
-                                    is ejected from the connection pool.
-                                  type: integer
-                                consecutiveErrors:
-                                  format: int32
-                                  type: integer
-                                consecutiveGatewayErrors:
-                                  description: Number of gateway errors before a host
-                                    is ejected from the connection pool.
-                                  type: integer
-                                interval:
-                                  description: Time interval between ejection sweep
-                                    analysis.
-                                  type: string
-                                maxEjectionPercent:
-                                  format: int32
-                                  type: integer
-                                minHealthPercent:
-                                  format: int32
-                                  type: integer
-                              type: object
-                            port:
-                              properties:
-                                number:
-                                  type: integer
-                              type: object
-                            tls:
-                              description: TLS related settings for connections to
-                                the upstream service.
-                              properties:
-                                caCertificates:
-                                  format: string
-                                  type: string
-                                clientCertificate:
-                                  description: REQUIRED if mode is `MUTUAL`.
-                                  format: string
-                                  type: string
-                                mode:
-                                  enum:
-                                  - DISABLE
-                                  - SIMPLE
-                                  - MUTUAL
-                                  - ISTIO_MUTUAL
-                                  type: string
-                                privateKey:
-                                  description: REQUIRED if mode is `MUTUAL`.
-                                  format: string
-                                  type: string
-                                sni:
-                                  description: SNI string to present to the server
-                                    during TLS handshake.
-                                  format: string
-                                  type: string
-                                subjectAltNames:
-                                  items:
-                                    format: string
-                                    type: string
-                                  type: array
-                              type: object
-                          type: object
-                        type: array
-                      tls:
-                        description: TLS related settings for connections to the upstream
-                          service.
-                        properties:
-                          caCertificates:
-                            format: string
-                            type: string
-                          clientCertificate:
-                            description: REQUIRED if mode is `MUTUAL`.
-                            format: string
-                            type: string
-                          mode:
-                            enum:
-                            - DISABLE
-                            - SIMPLE
-                            - MUTUAL
-                            - ISTIO_MUTUAL
-                            type: string
-                          privateKey:
-                            description: REQUIRED if mode is `MUTUAL`.
-                            format: string
-                            type: string
-                          sni:
-                            description: SNI string to present to the server during
-                              TLS handshake.
-                            format: string
-                            type: string
-                          subjectAltNames:
-                            items:
-                              format: string
-                              type: string
-                            type: array
-                        type: object
-                    type: object
-                type: object
-              type: array
-            trafficPolicy:
-              properties:
-                connectionPool:
-                  properties:
-                    http:
-                      description: HTTP connection pool settings.
-                      properties:
-                        h2UpgradePolicy:
-                          description: Specify if http1.1 connection should be upgraded
-                            to http2 for the associated destination.
-                          enum:
-                          - DEFAULT
-                          - DO_NOT_UPGRADE
-                          - UPGRADE
-                          type: string
-                        http1MaxPendingRequests:
-                          description: Maximum number of pending HTTP requests to
-                            a destination.
-                          format: int32
-                          type: integer
-                        http2MaxRequests:
-                          description: Maximum number of requests to a backend.
-                          format: int32
-                          type: integer
-                        idleTimeout:
-                          description: The idle timeout for upstream connection pool
-                            connections.
-                          type: string
-                        maxRequestsPerConnection:
-                          description: Maximum number of requests per connection to
-                            a backend.
-                          format: int32
-                          type: integer
-                        maxRetries:
-                          format: int32
-                          type: integer
-                      type: object
-                    tcp:
-                      description: Settings common to both HTTP and TCP upstream connections.
-                      properties:
-                        connectTimeout:
-                          description: TCP connection timeout.
-                          type: string
-                        maxConnections:
-                          description: Maximum number of HTTP1 /TCP connections to
-                            a destination host.
-                          format: int32
-                          type: integer
-                        tcpKeepalive:
-                          description: If set then set SO_KEEPALIVE on the socket
-                            to enable TCP Keepalives.
-                          properties:
-                            interval:
-                              description: The time duration between keep-alive probes.
-                              type: string
-                            probes:
-                              type: integer
-                            time:
-                              type: string
-                          type: object
-                      type: object
-                  type: object
-                loadBalancer:
-                  description: Settings controlling the load balancer algorithms.
-                  oneOf:
-                  - not:
-                      anyOf:
-                      - required:
-                        - simple
-                      - properties:
-                          consistentHash:
-                            oneOf:
-                            - not:
-                                anyOf:
-                                - required:
-                                  - httpHeaderName
-                                - required:
-                                  - httpCookie
-                                - required:
-                                  - useSourceIp
-                                - required:
-                                  - httpQueryParameterName
-                            - required:
-                              - httpHeaderName
-                            - required:
-                              - httpCookie
-                            - required:
-                              - useSourceIp
-                            - required:
-                              - httpQueryParameterName
-                        required:
-                        - consistentHash
-                  - required:
-                    - simple
-                  - properties:
-                      consistentHash:
-                        oneOf:
-                        - not:
-                            anyOf:
-                            - required:
-                              - httpHeaderName
-                            - required:
-                              - httpCookie
-                            - required:
-                              - useSourceIp
-                            - required:
-                              - httpQueryParameterName
-                        - required:
-                          - httpHeaderName
-                        - required:
-                          - httpCookie
-                        - required:
-                          - useSourceIp
-                        - required:
-                          - httpQueryParameterName
-                    required:
-                    - consistentHash
-                  properties:
-                    consistentHash:
-                      properties:
-                        httpCookie:
-                          description: Hash based on HTTP cookie.
-                          properties:
-                            name:
-                              description: Name of the cookie.
-                              format: string
-                              type: string
-                            path:
-                              description: Path to set for the cookie.
-                              format: string
-                              type: string
-                            ttl:
-                              description: Lifetime of the cookie.
-                              type: string
-                          type: object
-                        httpHeaderName:
-                          description: Hash based on a specific HTTP header.
-                          format: string
-                          type: string
-                        httpQueryParameterName:
-                          description: Hash based on a specific HTTP query parameter.
-                          format: string
-                          type: string
-                        minimumRingSize:
-                          type: integer
-                        useSourceIp:
-                          description: Hash based on the source IP address.
-                          type: boolean
-                      type: object
-                    localityLbSetting:
-                      properties:
-                        distribute:
-                          description: 'Optional: only one of distribute or failover
-                            can be set.'
-                          items:
-                            properties:
-                              from:
-                                description: Originating locality, '/' separated,
-                                  e.g.
-                                format: string
-                                type: string
-                              to:
-                                additionalProperties:
-                                  type: integer
-                                description: Map of upstream localities to traffic
-                                  distribution weights.
-                                type: object
-                            type: object
-                          type: array
-                        enabled:
-                          description: enable locality load balancing, this is DestinationRule-level
-                            and will override mesh wide settings in entirety.
-                          type: boolean
-                        failover:
-                          description: 'Optional: only failover or distribute can
-                            be set.'
-                          items:
-                            properties:
-                              from:
-                                description: Originating region.
-                                format: string
-                                type: string
-                              to:
-                                format: string
-                                type: string
-                            type: object
-                          type: array
-                      type: object
-                    simple:
-                      enum:
-                      - ROUND_ROBIN
-                      - LEAST_CONN
-                      - RANDOM
-                      - PASSTHROUGH
-                      type: string
-                  type: object
-                outlierDetection:
-                  properties:
-                    baseEjectionTime:
-                      description: Minimum ejection duration.
-                      type: string
-                    consecutive5xxErrors:
-                      description: Number of 5xx errors before a host is ejected from
-                        the connection pool.
-                      type: integer
-                    consecutiveErrors:
-                      format: int32
-                      type: integer
-                    consecutiveGatewayErrors:
-                      description: Number of gateway errors before a host is ejected
-                        from the connection pool.
-                      type: integer
-                    interval:
-                      description: Time interval between ejection sweep analysis.
-                      type: string
-                    maxEjectionPercent:
-                      format: int32
-                      type: integer
-                    minHealthPercent:
-                      format: int32
-                      type: integer
-                  type: object
-                portLevelSettings:
-                  description: Traffic policies specific to individual ports.
-                  items:
-                    properties:
-                      connectionPool:
-                        properties:
-                          http:
-                            description: HTTP connection pool settings.
-                            properties:
-                              h2UpgradePolicy:
-                                description: Specify if http1.1 connection should
-                                  be upgraded to http2 for the associated destination.
-                                enum:
-                                - DEFAULT
-                                - DO_NOT_UPGRADE
-                                - UPGRADE
-                                type: string
-                              http1MaxPendingRequests:
-                                description: Maximum number of pending HTTP requests
-                                  to a destination.
-                                format: int32
-                                type: integer
-                              http2MaxRequests:
-                                description: Maximum number of requests to a backend.
-                                format: int32
-                                type: integer
-                              idleTimeout:
-                                description: The idle timeout for upstream connection
-                                  pool connections.
-                                type: string
-                              maxRequestsPerConnection:
-                                description: Maximum number of requests per connection
-                                  to a backend.
-                                format: int32
-                                type: integer
-                              maxRetries:
-                                format: int32
-                                type: integer
-                            type: object
-                          tcp:
-                            description: Settings common to both HTTP and TCP upstream
-                              connections.
-                            properties:
-                              connectTimeout:
-                                description: TCP connection timeout.
-                                type: string
-                              maxConnections:
-                                description: Maximum number of HTTP1 /TCP connections
-                                  to a destination host.
-                                format: int32
-                                type: integer
-                              tcpKeepalive:
-                                description: If set then set SO_KEEPALIVE on the socket
-                                  to enable TCP Keepalives.
-                                properties:
-                                  interval:
-                                    description: The time duration between keep-alive
-                                      probes.
-                                    type: string
-                                  probes:
-                                    type: integer
-                                  time:
-                                    type: string
-                                type: object
-                            type: object
-                        type: object
-                      loadBalancer:
-                        description: Settings controlling the load balancer algorithms.
-                        oneOf:
-                        - not:
-                            anyOf:
-                            - required:
-                              - simple
-                            - properties:
-                                consistentHash:
-                                  oneOf:
-                                  - not:
-                                      anyOf:
-                                      - required:
-                                        - httpHeaderName
-                                      - required:
-                                        - httpCookie
-                                      - required:
-                                        - useSourceIp
-                                      - required:
-                                        - httpQueryParameterName
-                                  - required:
-                                    - httpHeaderName
-                                  - required:
-                                    - httpCookie
-                                  - required:
-                                    - useSourceIp
-                                  - required:
-                                    - httpQueryParameterName
-                              required:
-                              - consistentHash
-                        - required:
-                          - simple
-                        - properties:
-                            consistentHash:
-                              oneOf:
-                              - not:
-                                  anyOf:
-                                  - required:
-                                    - httpHeaderName
-                                  - required:
-                                    - httpCookie
-                                  - required:
-                                    - useSourceIp
-                                  - required:
-                                    - httpQueryParameterName
-                              - required:
-                                - httpHeaderName
-                              - required:
-                                - httpCookie
-                              - required:
-                                - useSourceIp
-                              - required:
-                                - httpQueryParameterName
-                          required:
-                          - consistentHash
-                        properties:
-                          consistentHash:
-                            properties:
-                              httpCookie:
-                                description: Hash based on HTTP cookie.
-                                properties:
-                                  name:
-                                    description: Name of the cookie.
-                                    format: string
-                                    type: string
-                                  path:
-                                    description: Path to set for the cookie.
-                                    format: string
-                                    type: string
-                                  ttl:
-                                    description: Lifetime of the cookie.
-                                    type: string
-                                type: object
-                              httpHeaderName:
-                                description: Hash based on a specific HTTP header.
-                                format: string
-                                type: string
-                              httpQueryParameterName:
-                                description: Hash based on a specific HTTP query parameter.
-                                format: string
-                                type: string
-                              minimumRingSize:
-                                type: integer
-                              useSourceIp:
-                                description: Hash based on the source IP address.
-                                type: boolean
-                            type: object
-                          localityLbSetting:
-                            properties:
-                              distribute:
-                                description: 'Optional: only one of distribute or
-                                  failover can be set.'
-                                items:
-                                  properties:
-                                    from:
-                                      description: Originating locality, '/' separated,
-                                        e.g.
-                                      format: string
-                                      type: string
-                                    to:
-                                      additionalProperties:
-                                        type: integer
-                                      description: Map of upstream localities to traffic
-                                        distribution weights.
-                                      type: object
-                                  type: object
-                                type: array
-                              enabled:
-                                description: enable locality load balancing, this
-                                  is DestinationRule-level and will override mesh
-                                  wide settings in entirety.
-                                type: boolean
-                              failover:
-                                description: 'Optional: only failover or distribute
-                                  can be set.'
-                                items:
-                                  properties:
-                                    from:
-                                      description: Originating region.
-                                      format: string
-                                      type: string
-                                    to:
-                                      format: string
-                                      type: string
-                                  type: object
-                                type: array
-                            type: object
-                          simple:
-                            enum:
-                            - ROUND_ROBIN
-                            - LEAST_CONN
-                            - RANDOM
-                            - PASSTHROUGH
-                            type: string
-                        type: object
-                      outlierDetection:
-                        properties:
-                          baseEjectionTime:
-                            description: Minimum ejection duration.
-                            type: string
-                          consecutive5xxErrors:
-                            description: Number of 5xx errors before a host is ejected
-                              from the connection pool.
-                            type: integer
-                          consecutiveErrors:
-                            format: int32
-                            type: integer
-                          consecutiveGatewayErrors:
-                            description: Number of gateway errors before a host is
-                              ejected from the connection pool.
-                            type: integer
-                          interval:
-                            description: Time interval between ejection sweep analysis.
-                            type: string
-                          maxEjectionPercent:
-                            format: int32
-                            type: integer
-                          minHealthPercent:
-                            format: int32
-                            type: integer
-                        type: object
-                      port:
-                        properties:
-                          number:
-                            type: integer
-                        type: object
-                      tls:
-                        description: TLS related settings for connections to the upstream
-                          service.
-                        properties:
-                          caCertificates:
-                            format: string
-                            type: string
-                          clientCertificate:
-                            description: REQUIRED if mode is `MUTUAL`.
-                            format: string
-                            type: string
-                          mode:
-                            enum:
-                            - DISABLE
-                            - SIMPLE
-                            - MUTUAL
-                            - ISTIO_MUTUAL
-                            type: string
-                          privateKey:
-                            description: REQUIRED if mode is `MUTUAL`.
-                            format: string
-                            type: string
-                          sni:
-                            description: SNI string to present to the server during
-                              TLS handshake.
-                            format: string
-                            type: string
-                          subjectAltNames:
-                            items:
-                              format: string
-                              type: string
-                            type: array
-                        type: object
-                    type: object
-                  type: array
-                tls:
-                  description: TLS related settings for connections to the upstream
-                    service.
-                  properties:
-                    caCertificates:
-                      format: string
-                      type: string
-                    clientCertificate:
-                      description: REQUIRED if mode is `MUTUAL`.
-                      format: string
-                      type: string
-                    mode:
-                      enum:
-                      - DISABLE
-                      - SIMPLE
-                      - MUTUAL
-                      - ISTIO_MUTUAL
-                      type: string
-                    privateKey:
-                      description: REQUIRED if mode is `MUTUAL`.
-                      format: string
-                      type: string
-                    sni:
-                      description: SNI string to present to the server during TLS
-                        handshake.
-                      format: string
-                      type: string
-                    subjectAltNames:
-                      items:
-                        format: string
-                        type: string
-                      type: array
-                  type: object
-              type: object
-          type: object
-        status:
-          type: object
-          x-kubernetes-preserve-unknown-fields: true
-      type: object
-  versions:
-  - name: v1alpha3
-    served: true
-    storage: true
-  - name: v1beta1
-    served: true
-    storage: false
----
-apiVersion: apiextensions.k8s.io/v1beta1
-kind: CustomResourceDefinition
-metadata:
-  annotations:
-    helm.sh/resource-policy: keep
-  labels:
-    app: istio-pilot
-    chart: istio
-    cloudfoundry.org/istio_version: 1.6.4
-    heritage: Tiller
-    release: istio
-  name: envoyfilters.networking.istio.io
-spec:
-  group: networking.istio.io
-  names:
-    categories:
-    - istio-io
-    - networking-istio-io
-    kind: EnvoyFilter
-    listKind: EnvoyFilterList
-    plural: envoyfilters
-    singular: envoyfilter
-  scope: Namespaced
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      properties:
-        spec:
-          description: 'Customizing Envoy configuration generated by Istio. See more
-            details at: https://istio.io/docs/reference/config/networking/envoy-filter.html'
-          properties:
-            configPatches:
-              description: One or more patches with match conditions.
-              items:
-                properties:
-                  applyTo:
-                    enum:
-                    - INVALID
-                    - LISTENER
-                    - FILTER_CHAIN
-                    - NETWORK_FILTER
-                    - HTTP_FILTER
-                    - ROUTE_CONFIGURATION
-                    - VIRTUAL_HOST
-                    - HTTP_ROUTE
-                    - CLUSTER
-                    type: string
-                  match:
-                    description: Match on listener/route configuration/cluster.
-                    oneOf:
-                    - not:
-                        anyOf:
-                        - required:
-                          - listener
-                        - required:
-                          - routeConfiguration
-                        - required:
-                          - cluster
-                    - required:
-                      - listener
-                    - required:
-                      - routeConfiguration
-                    - required:
-                      - cluster
-                    properties:
-                      cluster:
-                        description: Match on envoy cluster attributes.
-                        properties:
-                          name:
-                            description: The exact name of the cluster to match.
-                            format: string
-                            type: string
-                          portNumber:
-                            description: The service port for which this cluster was
-                              generated.
-                            type: integer
-                          service:
-                            description: The fully qualified service name for this
-                              cluster.
-                            format: string
-                            type: string
-                          subset:
-                            description: The subset associated with the service.
-                            format: string
-                            type: string
-                        type: object
-                      context:
-                        description: The specific config generation context to match
-                          on.
-                        enum:
-                        - ANY
-                        - SIDECAR_INBOUND
-                        - SIDECAR_OUTBOUND
-                        - GATEWAY
-                        type: string
-                      listener:
-                        description: Match on envoy listener attributes.
-                        properties:
-                          filterChain:
-                            description: Match a specific filter chain in a listener.
-                            properties:
-                              applicationProtocols:
-                                description: Applies only to sidecars.
-                                format: string
-                                type: string
-                              filter:
-                                description: The name of a specific filter to apply
-                                  the patch to.
-                                properties:
-                                  name:
-                                    description: The filter name to match on.
-                                    format: string
-                                    type: string
-                                  subFilter:
-                                    properties:
-                                      name:
-                                        description: The filter name to match on.
-                                        format: string
-                                        type: string
-                                    type: object
-                                type: object
-                              name:
-                                description: The name assigned to the filter chain.
-                                format: string
-                                type: string
-                              sni:
-                                description: The SNI value used by a filter chain's
-                                  match condition.
-                                format: string
-                                type: string
-                              transportProtocol:
-                                description: Applies only to SIDECAR_INBOUND context.
-                                format: string
-                                type: string
-                            type: object
-                          name:
-                            description: Match a specific listener by its name.
-                            format: string
-                            type: string
-                          portName:
-                            format: string
-                            type: string
-                          portNumber:
-                            type: integer
-                        type: object
-                      proxy:
-                        description: Match on properties associated with a proxy.
-                        properties:
-                          metadata:
-                            additionalProperties:
-                              format: string
-                              type: string
-                            type: object
-                          proxyVersion:
-                            format: string
-                            type: string
-                        type: object
-                      routeConfiguration:
-                        description: Match on envoy HTTP route configuration attributes.
-                        properties:
-                          gateway:
-                            format: string
-                            type: string
-                          name:
-                            description: Route configuration name to match on.
-                            format: string
-                            type: string
-                          portName:
-                            description: Applicable only for GATEWAY context.
-                            format: string
-                            type: string
-                          portNumber:
-                            type: integer
-                          vhost:
-                            properties:
-                              name:
-                                format: string
-                                type: string
-                              route:
-                                description: Match a specific route within the virtual
-                                  host.
-                                properties:
-                                  action:
-                                    description: Match a route with specific action
-                                      type.
-                                    enum:
-                                    - ANY
-                                    - ROUTE
-                                    - REDIRECT
-                                    - DIRECT_RESPONSE
-                                    type: string
-                                  name:
-                                    format: string
-                                    type: string
-                                type: object
-                            type: object
-                        type: object
-                    type: object
-                  patch:
-                    description: The patch to apply along with the operation.
-                    properties:
-                      operation:
-                        description: Determines how the patch should be applied.
-                        enum:
-                        - INVALID
-                        - MERGE
-                        - ADD
-                        - REMOVE
-                        - INSERT_BEFORE
-                        - INSERT_AFTER
-                        - INSERT_FIRST
-                        type: string
-                      value:
-                        description: The JSON config of the object being patched.
-                        type: object
-                    type: object
-                type: object
-              type: array
-            workloadSelector:
-              properties:
-                labels:
-                  additionalProperties:
-                    format: string
-                    type: string
-                  type: object
-              type: object
-          type: object
-        status:
-          type: object
-          x-kubernetes-preserve-unknown-fields: true
-      type: object
-  versions:
-  - name: v1alpha3
-    served: true
-    storage: true
----
-apiVersion: apiextensions.k8s.io/v1beta1
-kind: CustomResourceDefinition
-metadata:
-  annotations:
-    helm.sh/resource-policy: keep
-  labels:
-    app: istio-pilot
-    chart: istio
-    cloudfoundry.org/istio_version: 1.6.4
-    heritage: Tiller
-    release: istio
-  name: gateways.networking.istio.io
-spec:
-  group: networking.istio.io
-  names:
-    categories:
-    - istio-io
-    - networking-istio-io
-    kind: Gateway
-    listKind: GatewayList
-    plural: gateways
-    shortNames:
-    - gw
-    singular: gateway
-  preserveUnknownFields: false
-  scope: Namespaced
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      properties:
-        spec:
-          description: 'Configuration affecting edge load balancer. See more details
-            at: https://istio.io/docs/reference/config/networking/gateway.html'
-          properties:
-            selector:
-              additionalProperties:
-                format: string
-                type: string
-              type: object
-            servers:
-              description: A list of server specifications.
-              items:
-                properties:
-                  bind:
-                    format: string
-                    type: string
-                  defaultEndpoint:
-                    format: string
-                    type: string
-                  hosts:
-                    description: One or more hosts exposed by this gateway.
-                    items:
-                      format: string
-                      type: string
-                    type: array
-                  port:
-                    properties:
-                      name:
-                        description: Label assigned to the port.
-                        format: string
-                        type: string
-                      number:
-                        description: A valid non-negative integer port number.
-                        type: integer
-                      protocol:
-                        description: The protocol exposed on the port.
-                        format: string
-                        type: string
-                    type: object
-                  tls:
-                    description: Set of TLS related options that govern the server's
-                      behavior.
-                    properties:
-                      caCertificates:
-                        description: REQUIRED if mode is `MUTUAL`.
-                        format: string
-                        type: string
-                      cipherSuites:
-                        description: 'Optional: If specified, only support the specified
-                          cipher list.'
-                        items:
-                          format: string
-                          type: string
-                        type: array
-                      credentialName:
-                        format: string
-                        type: string
-                      httpsRedirect:
-                        type: boolean
-                      maxProtocolVersion:
-                        description: 'Optional: Maximum TLS protocol version.'
-                        enum:
-                        - TLS_AUTO
-                        - TLSV1_0
-                        - TLSV1_1
-                        - TLSV1_2
-                        - TLSV1_3
-                        type: string
-                      minProtocolVersion:
-                        description: 'Optional: Minimum TLS protocol version.'
-                        enum:
-                        - TLS_AUTO
-                        - TLSV1_0
-                        - TLSV1_1
-                        - TLSV1_2
-                        - TLSV1_3
-                        type: string
-                      mode:
-                        enum:
-                        - PASSTHROUGH
-                        - SIMPLE
-                        - MUTUAL
-                        - AUTO_PASSTHROUGH
-                        - ISTIO_MUTUAL
-                        type: string
-                      privateKey:
-                        description: REQUIRED if mode is `SIMPLE` or `MUTUAL`.
-                        format: string
-                        type: string
-                      serverCertificate:
-                        description: REQUIRED if mode is `SIMPLE` or `MUTUAL`.
-                        format: string
-                        type: string
-                      subjectAltNames:
-                        items:
-                          format: string
-                          type: string
-                        type: array
-                      verifyCertificateHash:
-                        items:
-                          format: string
-                          type: string
-                        type: array
-                      verifyCertificateSpki:
-                        items:
-                          format: string
-                          type: string
-                        type: array
-                    type: object
-                type: object
-              type: array
-          type: object
-        status:
-          type: object
-          x-kubernetes-preserve-unknown-fields: true
-      type: object
-  versions:
-  - name: v1alpha3
-    served: true
-    storage: true
-  - name: v1beta1
-    served: true
-    storage: false
----
-apiVersion: apiextensions.k8s.io/v1beta1
-kind: CustomResourceDefinition
-metadata:
-  annotations:
-    helm.sh/resource-policy: keep
-  labels:
-    app: istio-pilot
-    chart: istio
-    cloudfoundry.org/istio_version: 1.6.4
-    heritage: Tiller
-    release: istio
-  name: serviceentries.networking.istio.io
-spec:
-  additionalPrinterColumns:
-  - JSONPath: .spec.hosts
-    description: The hosts associated with the ServiceEntry
-    name: Hosts
-    type: string
-  - JSONPath: .spec.location
-    description: Whether the service is external to the mesh or part of the mesh (MESH_EXTERNAL
-      or MESH_INTERNAL)
-    name: Location
-    type: string
-  - JSONPath: .spec.resolution
-    description: Service discovery mode for the hosts (NONE, STATIC, or DNS)
-    name: Resolution
-    type: string
-  - JSONPath: .metadata.creationTimestamp
-    description: 'CreationTimestamp is a timestamp representing the server time when
-      this object was created. It is not guaranteed to be set in happens-before order
-      across separate operations. Clients may not set this value. It is represented
-      in RFC3339 form and is in UTC. Populated by the system. Read-only. Null for
-      lists. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata'
-    name: Age
-    type: date
-  group: networking.istio.io
-  names:
-    categories:
-    - istio-io
-    - networking-istio-io
-    kind: ServiceEntry
-    listKind: ServiceEntryList
-    plural: serviceentries
-    shortNames:
-    - se
-    singular: serviceentry
-  preserveUnknownFields: false
-  scope: Namespaced
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      properties:
-        spec:
-          description: 'Configuration affecting service registry. See more details
-            at: https://istio.io/docs/reference/config/networking/service-entry.html'
-          properties:
-            addresses:
-              description: The virtual IP addresses associated with the service.
-              items:
-                format: string
-                type: string
-              type: array
-            endpoints:
-              description: One or more endpoints associated with the service.
-              items:
-                properties:
-                  address:
-                    format: string
-                    type: string
-                  labels:
-                    additionalProperties:
-                      format: string
-                      type: string
-                    description: One or more labels associated with the endpoint.
-                    type: object
-                  locality:
-                    description: The locality associated with the endpoint.
-                    format: string
-                    type: string
-                  network:
-                    format: string
-                    type: string
-                  ports:
-                    additionalProperties:
-                      type: integer
-                    description: Set of ports associated with the endpoint.
-                    type: object
-                  serviceAccount:
-                    format: string
-                    type: string
-                  weight:
-                    description: The load balancing weight associated with the endpoint.
-                    type: integer
-                type: object
-              type: array
-            exportTo:
-              description: A list of namespaces to which this service is exported.
-              items:
-                format: string
-                type: string
-              type: array
-            hosts:
-              description: The hosts associated with the ServiceEntry.
-              items:
-                format: string
-                type: string
-              type: array
-            location:
-              enum:
-              - MESH_EXTERNAL
-              - MESH_INTERNAL
-              type: string
-            ports:
-              description: The ports associated with the external service.
-              items:
-                properties:
-                  name:
-                    description: Label assigned to the port.
-                    format: string
-                    type: string
-                  number:
-                    description: A valid non-negative integer port number.
-                    type: integer
-                  protocol:
-                    description: The protocol exposed on the port.
-                    format: string
-                    type: string
-                type: object
-              type: array
-            resolution:
-              description: Service discovery mode for the hosts.
-              enum:
-              - NONE
-              - STATIC
-              - DNS
-              type: string
-            subjectAltNames:
-              items:
-                format: string
-                type: string
-              type: array
-            workloadSelector:
-              description: Applicable only for MESH_INTERNAL services.
-              properties:
-                labels:
-                  additionalProperties:
-                    format: string
-                    type: string
-                  type: object
-              type: object
-          type: object
-        status:
-          type: object
-          x-kubernetes-preserve-unknown-fields: true
-      type: object
-  versions:
-  - name: v1alpha3
-    served: true
-    storage: true
-  - name: v1beta1
-    served: true
-    storage: false
----
-apiVersion: apiextensions.k8s.io/v1beta1
-kind: CustomResourceDefinition
-metadata:
-  annotations:
-    helm.sh/resource-policy: keep
-  labels:
-    app: istio-pilot
-    chart: istio
-    cloudfoundry.org/istio_version: 1.6.4
-    heritage: Tiller
-    release: istio
-  name: sidecars.networking.istio.io
-spec:
-  group: networking.istio.io
-  names:
-    categories:
-    - istio-io
-    - networking-istio-io
-    kind: Sidecar
-    listKind: SidecarList
-    plural: sidecars
-    singular: sidecar
-  preserveUnknownFields: false
-  scope: Namespaced
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      properties:
-        spec:
-          description: 'Configuration affecting network reachability of a sidecar.
-            See more details at: https://istio.io/docs/reference/config/networking/sidecar.html'
-          properties:
-            egress:
-              items:
-                properties:
-                  bind:
-                    format: string
-                    type: string
-                  captureMode:
-                    enum:
-                    - DEFAULT
-                    - IPTABLES
-                    - NONE
-                    type: string
-                  hosts:
-                    items:
-                      format: string
-                      type: string
-                    type: array
-                  localhostServerTls:
-                    properties:
-                      caCertificates:
-                        description: REQUIRED if mode is `MUTUAL`.
-                        format: string
-                        type: string
-                      cipherSuites:
-                        description: 'Optional: If specified, only support the specified
-                          cipher list.'
-                        items:
-                          format: string
-                          type: string
-                        type: array
-                      credentialName:
-                        format: string
-                        type: string
-                      httpsRedirect:
-                        type: boolean
-                      maxProtocolVersion:
-                        description: 'Optional: Maximum TLS protocol version.'
-                        enum:
-                        - TLS_AUTO
-                        - TLSV1_0
-                        - TLSV1_1
-                        - TLSV1_2
-                        - TLSV1_3
-                        type: string
-                      minProtocolVersion:
-                        description: 'Optional: Minimum TLS protocol version.'
-                        enum:
-                        - TLS_AUTO
-                        - TLSV1_0
-                        - TLSV1_1
-                        - TLSV1_2
-                        - TLSV1_3
-                        type: string
-                      mode:
-                        enum:
-                        - PASSTHROUGH
-                        - SIMPLE
-                        - MUTUAL
-                        - AUTO_PASSTHROUGH
-                        - ISTIO_MUTUAL
-                        type: string
-                      privateKey:
-                        description: REQUIRED if mode is `SIMPLE` or `MUTUAL`.
-                        format: string
-                        type: string
-                      serverCertificate:
-                        description: REQUIRED if mode is `SIMPLE` or `MUTUAL`.
-                        format: string
-                        type: string
-                      subjectAltNames:
-                        items:
-                          format: string
-                          type: string
-                        type: array
-                      verifyCertificateHash:
-                        items:
-                          format: string
-                          type: string
-                        type: array
-                      verifyCertificateSpki:
-                        items:
-                          format: string
-                          type: string
-                        type: array
-                    type: object
-                  port:
-                    description: The port associated with the listener.
-                    properties:
-                      name:
-                        description: Label assigned to the port.
-                        format: string
-                        type: string
-                      number:
-                        description: A valid non-negative integer port number.
-                        type: integer
-                      protocol:
-                        description: The protocol exposed on the port.
-                        format: string
-                        type: string
-                    type: object
-                type: object
-              type: array
-            ingress:
-              items:
-                properties:
-                  bind:
-                    description: The IP to which the listener should be bound.
-                    format: string
-                    type: string
-                  captureMode:
-                    enum:
-                    - DEFAULT
-                    - IPTABLES
-                    - NONE
-                    type: string
-                  defaultEndpoint:
-                    format: string
-                    type: string
-                  localhostClientTls:
-                    properties:
-                      caCertificates:
-                        format: string
-                        type: string
-                      clientCertificate:
-                        description: REQUIRED if mode is `MUTUAL`.
-                        format: string
-                        type: string
-                      mode:
-                        enum:
-                        - DISABLE
-                        - SIMPLE
-                        - MUTUAL
-                        - ISTIO_MUTUAL
-                        type: string
-                      privateKey:
-                        description: REQUIRED if mode is `MUTUAL`.
-                        format: string
-                        type: string
-                      sni:
-                        description: SNI string to present to the server during TLS
-                          handshake.
-                        format: string
-                        type: string
-                      subjectAltNames:
-                        items:
-                          format: string
-                          type: string
-                        type: array
-                    type: object
-                  port:
-                    description: The port associated with the listener.
-                    properties:
-                      name:
-                        description: Label assigned to the port.
-                        format: string
-                        type: string
-                      number:
-                        description: A valid non-negative integer port number.
-                        type: integer
-                      protocol:
-                        description: The protocol exposed on the port.
-                        format: string
-                        type: string
-                    type: object
-                type: object
-              type: array
-            localhost:
-              properties:
-                clientTls:
-                  properties:
-                    caCertificates:
-                      format: string
-                      type: string
-                    clientCertificate:
-                      description: REQUIRED if mode is `MUTUAL`.
-                      format: string
-                      type: string
-                    mode:
-                      enum:
-                      - DISABLE
-                      - SIMPLE
-                      - MUTUAL
-                      - ISTIO_MUTUAL
-                      type: string
-                    privateKey:
-                      description: REQUIRED if mode is `MUTUAL`.
-                      format: string
-                      type: string
-                    sni:
-                      description: SNI string to present to the server during TLS
-                        handshake.
-                      format: string
-                      type: string
-                    subjectAltNames:
-                      items:
-                        format: string
-                        type: string
-                      type: array
-                  type: object
-                serverTls:
-                  properties:
-                    caCertificates:
-                      description: REQUIRED if mode is `MUTUAL`.
-                      format: string
-                      type: string
-                    cipherSuites:
-                      description: 'Optional: If specified, only support the specified
-                        cipher list.'
-                      items:
-                        format: string
-                        type: string
-                      type: array
-                    credentialName:
-                      format: string
-                      type: string
-                    httpsRedirect:
-                      type: boolean
-                    maxProtocolVersion:
-                      description: 'Optional: Maximum TLS protocol version.'
-                      enum:
-                      - TLS_AUTO
-                      - TLSV1_0
-                      - TLSV1_1
-                      - TLSV1_2
-                      - TLSV1_3
-                      type: string
-                    minProtocolVersion:
-                      description: 'Optional: Minimum TLS protocol version.'
-                      enum:
-                      - TLS_AUTO
-                      - TLSV1_0
-                      - TLSV1_1
-                      - TLSV1_2
-                      - TLSV1_3
-                      type: string
-                    mode:
-                      enum:
-                      - PASSTHROUGH
-                      - SIMPLE
-                      - MUTUAL
-                      - AUTO_PASSTHROUGH
-                      - ISTIO_MUTUAL
-                      type: string
-                    privateKey:
-                      description: REQUIRED if mode is `SIMPLE` or `MUTUAL`.
-                      format: string
-                      type: string
-                    serverCertificate:
-                      description: REQUIRED if mode is `SIMPLE` or `MUTUAL`.
-                      format: string
-                      type: string
-                    subjectAltNames:
-                      items:
-                        format: string
-                        type: string
-                      type: array
-                    verifyCertificateHash:
-                      items:
-                        format: string
-                        type: string
-                      type: array
-                    verifyCertificateSpki:
-                      items:
-                        format: string
-                        type: string
-                      type: array
-                  type: object
-              type: object
-            outboundTrafficPolicy:
-              description: Configuration for the outbound traffic policy.
-              properties:
-                egressProxy:
-                  properties:
-                    host:
-                      description: The name of a service from the service registry.
-                      format: string
-                      type: string
-                    port:
-                      description: Specifies the port on the host that is being addressed.
-                      properties:
-                        number:
-                          type: integer
-                      type: object
-                    subset:
-                      description: The name of a subset within the service.
-                      format: string
-                      type: string
-                  type: object
-                mode:
-                  enum:
-                  - REGISTRY_ONLY
-                  - ALLOW_ANY
-                  type: string
-              type: object
-            workloadSelector:
-              properties:
-                labels:
-                  additionalProperties:
-                    format: string
-                    type: string
-                  type: object
-              type: object
-          type: object
-        status:
-          type: object
-          x-kubernetes-preserve-unknown-fields: true
-      type: object
-  versions:
-  - name: v1alpha3
-    served: true
-    storage: true
-  - name: v1beta1
-    served: true
-    storage: false
----
-apiVersion: apiextensions.k8s.io/v1beta1
-kind: CustomResourceDefinition
-metadata:
-  annotations:
-    helm.sh/resource-policy: keep
-  labels:
-    app: istio-pilot
-    chart: istio
-    cloudfoundry.org/istio_version: 1.6.4
-    heritage: Tiller
-    release: istio
-  name: virtualservices.networking.istio.io
-spec:
-  additionalPrinterColumns:
-  - JSONPath: .spec.gateways
-    description: The names of gateways and sidecars that should apply these routes
-    name: Gateways
-    type: string
-  - JSONPath: .spec.hosts
-    description: The destination hosts to which traffic is being sent
-    name: Hosts
-    type: string
-  - JSONPath: .metadata.creationTimestamp
-    description: 'CreationTimestamp is a timestamp representing the server time when
-      this object was created. It is not guaranteed to be set in happens-before order
-      across separate operations. Clients may not set this value. It is represented
-      in RFC3339 form and is in UTC. Populated by the system. Read-only. Null for
-      lists. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata'
-    name: Age
-    type: date
-  group: networking.istio.io
-  names:
-    categories:
-    - istio-io
-    - networking-istio-io
-    kind: VirtualService
-    listKind: VirtualServiceList
-    plural: virtualservices
-    shortNames:
-    - vs
-    singular: virtualservice
-  preserveUnknownFields: false
-  scope: Namespaced
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      properties:
-        spec:
-          description: 'Configuration affecting label/content routing, sni routing,
-            etc. See more details at: https://istio.io/docs/reference/config/networking/virtual-service.html'
-          properties:
-            exportTo:
-              description: A list of namespaces to which this virtual service is exported.
-              items:
-                format: string
-                type: string
-              type: array
-            gateways:
-              description: The names of gateways and sidecars that should apply these
-                routes.
-              items:
-                format: string
-                type: string
-              type: array
-            hosts:
-              description: The destination hosts to which traffic is being sent.
-              items:
-                format: string
-                type: string
-              type: array
-            http:
-              description: An ordered list of route rules for HTTP traffic.
-              items:
-                properties:
-                  corsPolicy:
-                    description: Cross-Origin Resource Sharing policy (CORS).
-                    properties:
-                      allowCredentials:
-                        type: boolean
-                      allowHeaders:
-                        items:
-                          format: string
-                          type: string
-                        type: array
-                      allowMethods:
-                        description: List of HTTP methods allowed to access the resource.
-                        items:
-                          format: string
-                          type: string
-                        type: array
-                      allowOrigin:
-                        description: The list of origins that are allowed to perform
-                          CORS requests.
-                        items:
-                          format: string
-                          type: string
-                        type: array
-                      allowOrigins:
-                        description: String patterns that match allowed origins.
-                        items:
-                          oneOf:
-                          - not:
-                              anyOf:
-                              - required:
-                                - exact
-                              - required:
-                                - prefix
-                              - required:
-                                - regex
-                          - required:
-                            - exact
-                          - required:
-                            - prefix
-                          - required:
-                            - regex
-                          properties:
-                            exact:
-                              format: string
-                              type: string
-                            prefix:
-                              format: string
-                              type: string
-                            regex:
-                              description: RE2 style regex-based match (https://github.com/google/re2/wiki/Syntax).
-                              format: string
-                              type: string
-                          type: object
-                        type: array
-                      exposeHeaders:
-                        items:
-                          format: string
-                          type: string
-                        type: array
-                      maxAge:
-                        type: string
-                    type: object
-                  delegate:
-                    properties:
-                      name:
-                        description: Name specifies the name of the delegate VirtualService.
-                        format: string
-                        type: string
-                      namespace:
-                        description: Namespace specifies the namespace where the delegate
-                          VirtualService resides.
-                        format: string
-                        type: string
-                    type: object
-                  fault:
-                    description: Fault injection policy to apply on HTTP traffic at
-                      the client side.
-                    properties:
-                      abort:
-                        oneOf:
-                        - not:
-                            anyOf:
-                            - required:
-                              - httpStatus
-                            - required:
-                              - grpcStatus
-                            - required:
-                              - http2Error
-                        - required:
-                          - httpStatus
-                        - required:
-                          - grpcStatus
-                        - required:
-                          - http2Error
-                        properties:
-                          grpcStatus:
-                            format: string
-                            type: string
-                          http2Error:
-                            format: string
-                            type: string
-                          httpStatus:
-                            description: HTTP status code to use to abort the Http
-                              request.
-                            format: int32
-                            type: integer
-                          percentage:
-                            description: Percentage of requests to be aborted with
-                              the error code provided.
-                            properties:
-                              value:
-                                format: double
-                                type: number
-                            type: object
-                        type: object
-                      delay:
-                        oneOf:
-                        - not:
-                            anyOf:
-                            - required:
-                              - fixedDelay
-                            - required:
-                              - exponentialDelay
-                        - required:
-                          - fixedDelay
-                        - required:
-                          - exponentialDelay
-                        properties:
-                          exponentialDelay:
-                            type: string
-                          fixedDelay:
-                            description: Add a fixed delay before forwarding the request.
-                            type: string
-                          percent:
-                            description: Percentage of requests on which the delay
-                              will be injected (0-100).
-                            format: int32
-                            type: integer
-                          percentage:
-                            description: Percentage of requests on which the delay
-                              will be injected.
-                            properties:
-                              value:
-                                format: double
-                                type: number
-                            type: object
-                        type: object
-                    type: object
-                  headers:
-                    properties:
-                      request:
-                        properties:
-                          add:
-                            additionalProperties:
-                              format: string
-                              type: string
-                            type: object
-                          remove:
-                            items:
-                              format: string
-                              type: string
-                            type: array
-                          set:
-                            additionalProperties:
-                              format: string
-                              type: string
-                            type: object
-                        type: object
-                      response:
-                        properties:
-                          add:
-                            additionalProperties:
-                              format: string
-                              type: string
-                            type: object
-                          remove:
-                            items:
-                              format: string
-                              type: string
-                            type: array
-                          set:
-                            additionalProperties:
-                              format: string
-                              type: string
-                            type: object
-                        type: object
-                    type: object
-                  match:
-                    items:
-                      properties:
-                        authority:
-                          oneOf:
-                          - not:
-                              anyOf:
-                              - required:
-                                - exact
-                              - required:
-                                - prefix
-                              - required:
-                                - regex
-                          - required:
-                            - exact
-                          - required:
-                            - prefix
-                          - required:
-                            - regex
-                          properties:
-                            exact:
-                              format: string
-                              type: string
-                            prefix:
-                              format: string
-                              type: string
-                            regex:
-                              description: RE2 style regex-based match (https://github.com/google/re2/wiki/Syntax).
-                              format: string
-                              type: string
-                          type: object
-                        gateways:
-                          description: Names of gateways where the rule should be
-                            applied.
-                          items:
-                            format: string
-                            type: string
-                          type: array
-                        headers:
-                          additionalProperties:
-                            oneOf:
-                            - not:
-                                anyOf:
-                                - required:
-                                  - exact
-                                - required:
-                                  - prefix
-                                - required:
-                                  - regex
-                            - required:
-                              - exact
-                            - required:
-                              - prefix
-                            - required:
-                              - regex
-                            properties:
-                              exact:
-                                format: string
-                                type: string
-                              prefix:
-                                format: string
-                                type: string
-                              regex:
-                                description: RE2 style regex-based match (https://github.com/google/re2/wiki/Syntax).
-                                format: string
-                                type: string
-                            type: object
-                          type: object
-                        ignoreUriCase:
-                          description: Flag to specify whether the URI matching should
-                            be case-insensitive.
-                          type: boolean
-                        method:
-                          oneOf:
-                          - not:
-                              anyOf:
-                              - required:
-                                - exact
-                              - required:
-                                - prefix
-                              - required:
-                                - regex
-                          - required:
-                            - exact
-                          - required:
-                            - prefix
-                          - required:
-                            - regex
-                          properties:
-                            exact:
-                              format: string
-                              type: string
-                            prefix:
-                              format: string
-                              type: string
-                            regex:
-                              description: RE2 style regex-based match (https://github.com/google/re2/wiki/Syntax).
-                              format: string
-                              type: string
-                          type: object
-                        name:
-                          description: The name assigned to a match.
-                          format: string
-                          type: string
-                        port:
-                          description: Specifies the ports on the host that is being
-                            addressed.
-                          type: integer
-                        queryParams:
-                          additionalProperties:
-                            oneOf:
-                            - not:
-                                anyOf:
-                                - required:
-                                  - exact
-                                - required:
-                                  - prefix
-                                - required:
-                                  - regex
-                            - required:
-                              - exact
-                            - required:
-                              - prefix
-                            - required:
-                              - regex
-                            properties:
-                              exact:
-                                format: string
-                                type: string
-                              prefix:
-                                format: string
-                                type: string
-                              regex:
-                                description: RE2 style regex-based match (https://github.com/google/re2/wiki/Syntax).
-                                format: string
-                                type: string
-                            type: object
-                          description: Query parameters for matching.
-                          type: object
-                        scheme:
-                          oneOf:
-                          - not:
-                              anyOf:
-                              - required:
-                                - exact
-                              - required:
-                                - prefix
-                              - required:
-                                - regex
-                          - required:
-                            - exact
-                          - required:
-                            - prefix
-                          - required:
-                            - regex
-                          properties:
-                            exact:
-                              format: string
-                              type: string
-                            prefix:
-                              format: string
-                              type: string
-                            regex:
-                              description: RE2 style regex-based match (https://github.com/google/re2/wiki/Syntax).
-                              format: string
-                              type: string
-                          type: object
-                        sourceLabels:
-                          additionalProperties:
-                            format: string
-                            type: string
-                          type: object
-                        sourceNamespace:
-                          description: Source namespace constraining the applicability
-                            of a rule to workloads in that namespace.
-                          format: string
-                          type: string
-                        uri:
-                          oneOf:
-                          - not:
-                              anyOf:
-                              - required:
-                                - exact
-                              - required:
-                                - prefix
-                              - required:
-                                - regex
-                          - required:
-                            - exact
-                          - required:
-                            - prefix
-                          - required:
-                            - regex
-                          properties:
-                            exact:
-                              format: string
-                              type: string
-                            prefix:
-                              format: string
-                              type: string
-                            regex:
-                              description: RE2 style regex-based match (https://github.com/google/re2/wiki/Syntax).
-                              format: string
-                              type: string
-                          type: object
-                        withoutHeaders:
-                          additionalProperties:
-                            oneOf:
-                            - not:
-                                anyOf:
-                                - required:
-                                  - exact
-                                - required:
-                                  - prefix
-                                - required:
-                                  - regex
-                            - required:
-                              - exact
-                            - required:
-                              - prefix
-                            - required:
-                              - regex
-                            properties:
-                              exact:
-                                format: string
-                                type: string
-                              prefix:
-                                format: string
-                                type: string
-                              regex:
-                                description: RE2 style regex-based match (https://github.com/google/re2/wiki/Syntax).
-                                format: string
-                                type: string
-                            type: object
-                          description: withoutHeader has the same syntax with the
-                            header, but has opposite meaning.
-                          type: object
-                      type: object
-                    type: array
-                  mirror:
-                    properties:
-                      host:
-                        description: The name of a service from the service registry.
-                        format: string
-                        type: string
-                      port:
-                        description: Specifies the port on the host that is being
-                          addressed.
-                        properties:
-                          number:
-                            type: integer
-                        type: object
-                      subset:
-                        description: The name of a subset within the service.
-                        format: string
-                        type: string
-                    type: object
-                  mirror_percent:
-                    description: Percentage of the traffic to be mirrored by the `mirror`
-                      field.
-                    type: integer
-                  mirrorPercent:
-                    description: Percentage of the traffic to be mirrored by the `mirror`
-                      field.
-                    type: integer
-                  mirrorPercentage:
-                    description: Percentage of the traffic to be mirrored by the `mirror`
-                      field.
-                    properties:
-                      value:
-                        format: double
-                        type: number
-                    type: object
-                  name:
-                    description: The name assigned to the route for debugging purposes.
-                    format: string
-                    type: string
-                  redirect:
-                    description: A HTTP rule can either redirect or forward (default)
-                      traffic.
-                    properties:
-                      authority:
-                        format: string
-                        type: string
-                      redirectCode:
-                        type: integer
-                      uri:
-                        format: string
-                        type: string
-                    type: object
-                  retries:
-                    description: Retry policy for HTTP requests.
-                    properties:
-                      attempts:
-                        description: Number of retries for a given request.
-                        format: int32
-                        type: integer
-                      perTryTimeout:
-                        description: Timeout per retry attempt for a given request.
-                        type: string
-                      retryOn:
-                        description: Specifies the conditions under which retry takes
-                          place.
-                        format: string
-                        type: string
-                      retryRemoteLocalities:
-                        description: Flag to specify whether the retries should retry
-                          to other localities.
-                        type: boolean
-                    type: object
-                  rewrite:
-                    description: Rewrite HTTP URIs and Authority headers.
-                    properties:
-                      authority:
-                        description: rewrite the Authority/Host header with this value.
-                        format: string
-                        type: string
-                      uri:
-                        format: string
-                        type: string
-                    type: object
-                  route:
-                    description: A HTTP rule can either redirect or forward (default)
-                      traffic.
-                    items:
-                      properties:
-                        destination:
-                          properties:
-                            host:
-                              description: The name of a service from the service
-                                registry.
-                              format: string
-                              type: string
-                            port:
-                              description: Specifies the port on the host that is
-                                being addressed.
-                              properties:
-                                number:
-                                  type: integer
-                              type: object
-                            subset:
-                              description: The name of a subset within the service.
-                              format: string
-                              type: string
-                          type: object
-                        headers:
-                          properties:
-                            request:
-                              properties:
-                                add:
-                                  additionalProperties:
-                                    format: string
-                                    type: string
-                                  type: object
-                                remove:
-                                  items:
-                                    format: string
-                                    type: string
-                                  type: array
-                                set:
-                                  additionalProperties:
-                                    format: string
-                                    type: string
-                                  type: object
-                              type: object
-                            response:
-                              properties:
-                                add:
-                                  additionalProperties:
-                                    format: string
-                                    type: string
-                                  type: object
-                                remove:
-                                  items:
-                                    format: string
-                                    type: string
-                                  type: array
-                                set:
-                                  additionalProperties:
-                                    format: string
-                                    type: string
-                                  type: object
-                              type: object
-                          type: object
-                        weight:
-                          format: int32
-                          type: integer
-                      type: object
-                    type: array
-                  timeout:
-                    description: Timeout for HTTP requests.
-                    type: string
-                type: object
-              type: array
-            tcp:
-              description: An ordered list of route rules for opaque TCP traffic.
-              items:
-                properties:
-                  match:
-                    items:
-                      properties:
-                        destinationSubnets:
-                          description: IPv4 or IPv6 ip addresses of destination with
-                            optional subnet.
-                          items:
-                            format: string
-                            type: string
-                          type: array
-                        gateways:
-                          description: Names of gateways where the rule should be
-                            applied.
-                          items:
-                            format: string
-                            type: string
-                          type: array
-                        port:
-                          description: Specifies the port on the host that is being
-                            addressed.
-                          type: integer
-                        sourceLabels:
-                          additionalProperties:
-                            format: string
-                            type: string
-                          type: object
-                        sourceNamespace:
-                          description: Source namespace constraining the applicability
-                            of a rule to workloads in that namespace.
-                          format: string
-                          type: string
-                        sourceSubnet:
-                          description: IPv4 or IPv6 ip address of source with optional
-                            subnet.
-                          format: string
-                          type: string
-                      type: object
-                    type: array
-                  route:
-                    description: The destination to which the connection should be
-                      forwarded to.
-                    items:
-                      properties:
-                        destination:
-                          properties:
-                            host:
-                              description: The name of a service from the service
-                                registry.
-                              format: string
-                              type: string
-                            port:
-                              description: Specifies the port on the host that is
-                                being addressed.
-                              properties:
-                                number:
-                                  type: integer
-                              type: object
-                            subset:
-                              description: The name of a subset within the service.
-                              format: string
-                              type: string
-                          type: object
-                        weight:
-                          format: int32
-                          type: integer
-                      type: object
-                    type: array
-                type: object
-              type: array
-            tls:
-              items:
-                properties:
-                  match:
-                    items:
-                      properties:
-                        destinationSubnets:
-                          description: IPv4 or IPv6 ip addresses of destination with
-                            optional subnet.
-                          items:
-                            format: string
-                            type: string
-                          type: array
-                        gateways:
-                          description: Names of gateways where the rule should be
-                            applied.
-                          items:
-                            format: string
-                            type: string
-                          type: array
-                        port:
-                          description: Specifies the port on the host that is being
-                            addressed.
-                          type: integer
-                        sniHosts:
-                          description: SNI (server name indicator) to match on.
-                          items:
-                            format: string
-                            type: string
-                          type: array
-                        sourceLabels:
-                          additionalProperties:
-                            format: string
-                            type: string
-                          type: object
-                        sourceNamespace:
-                          description: Source namespace constraining the applicability
-                            of a rule to workloads in that namespace.
-                          format: string
-                          type: string
-                      type: object
-                    type: array
-                  route:
-                    description: The destination to which the connection should be
-                      forwarded to.
-                    items:
-                      properties:
-                        destination:
-                          properties:
-                            host:
-                              description: The name of a service from the service
-                                registry.
-                              format: string
-                              type: string
-                            port:
-                              description: Specifies the port on the host that is
-                                being addressed.
-                              properties:
-                                number:
-                                  type: integer
-                              type: object
-                            subset:
-                              description: The name of a subset within the service.
-                              format: string
-                              type: string
-                          type: object
-                        weight:
-                          format: int32
-                          type: integer
-                      type: object
-                    type: array
-                type: object
-              type: array
-          type: object
-        status:
-          type: object
-          x-kubernetes-preserve-unknown-fields: true
-      type: object
-  versions:
-  - name: v1alpha3
-    served: true
-    storage: true
-  - name: v1beta1
-    served: true
-    storage: false
----
-apiVersion: apiextensions.k8s.io/v1beta1
-kind: CustomResourceDefinition
-metadata:
-  annotations:
-    helm.sh/resource-policy: keep
-  labels:
-    app: istio-pilot
-    chart: istio
-    cloudfoundry.org/istio_version: 1.6.4
-    heritage: Tiller
-    release: istio
-  name: workloadentries.networking.istio.io
-spec:
-  additionalPrinterColumns:
-  - JSONPath: .metadata.creationTimestamp
-    description: 'CreationTimestamp is a timestamp representing the server time when
-      this object was created. It is not guaranteed to be set in happens-before order
-      across separate operations. Clients may not set this value. It is represented
-      in RFC3339 form and is in UTC. Populated by the system. Read-only. Null for
-      lists. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata'
-    name: Age
-    type: date
-  - JSONPath: .spec.address
-    description: Address associated with the network endpoint.
-    name: Address
-    type: string
-  group: networking.istio.io
-  names:
-    categories:
-    - istio-io
-    - networking-istio-io
-    kind: WorkloadEntry
-    listKind: WorkloadEntryList
-    plural: workloadentries
-    shortNames:
-    - we
-    singular: workloadentry
-  preserveUnknownFields: false
-  scope: Namespaced
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      properties:
-        spec:
-          description: 'Configuration affecting VMs onboarded into the mesh. See more
-            details at: https://istio.io/docs/reference/config/networking/workload-entry.html'
-          properties:
-            address:
-              format: string
-              type: string
-            labels:
-              additionalProperties:
-                format: string
-                type: string
-              description: One or more labels associated with the endpoint.
-              type: object
-            locality:
-              description: The locality associated with the endpoint.
-              format: string
-              type: string
-            network:
-              format: string
-              type: string
-            ports:
-              additionalProperties:
-                type: integer
-              description: Set of ports associated with the endpoint.
-              type: object
-            serviceAccount:
-              format: string
-              type: string
-            weight:
-              description: The load balancing weight associated with the endpoint.
-              type: integer
-          type: object
-        status:
-          type: object
-          x-kubernetes-preserve-unknown-fields: true
-      type: object
-  versions:
-  - name: v1alpha3
-    served: true
-    storage: true
-  - name: v1beta1
-    served: true
-    storage: false
----
-apiVersion: apiextensions.k8s.io/v1beta1
-kind: CustomResourceDefinition
-metadata:
-  annotations:
-    helm.sh/resource-policy: keep
-  labels:
-    app: mixer
-    chart: istio
-    cloudfoundry.org/istio_version: 1.6.4
-    heritage: Tiller
-    istio: core
-    package: istio.io.mixer
-    release: istio
-  name: attributemanifests.config.istio.io
-spec:
-  group: config.istio.io
-  names:
-    categories:
-    - istio-io
-    - policy-istio-io
-    kind: attributemanifest
-    listKind: attributemanifestList
-    plural: attributemanifests
-    singular: attributemanifest
-  preserveUnknownFields: false
-  scope: Namespaced
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      properties:
-        spec:
-          description: 'Describes the rules used to configure Mixer''s policy and
-            telemetry features. See more details at: https://istio.io/docs/reference/config/policy-and-telemetry/istio.policy.v1beta1.html'
-          properties:
-            attributes:
-              additionalProperties:
-                properties:
-                  description:
-                    description: A human-readable description of the attribute's purpose.
-                    format: string
-                    type: string
-                  valueType:
-                    description: The type of data carried by this attribute.
-                    enum:
-                    - VALUE_TYPE_UNSPECIFIED
-                    - STRING
-                    - INT64
-                    - DOUBLE
-                    - BOOL
-                    - TIMESTAMP
-                    - IP_ADDRESS
-                    - EMAIL_ADDRESS
-                    - URI
-                    - DNS_NAME
-                    - DURATION
-                    - STRING_MAP
-                    type: string
-                type: object
-              description: The set of attributes this Istio component will be responsible
-                for producing at runtime.
-              type: object
-            name:
-              description: Name of the component producing these attributes.
-              format: string
-              type: string
-            revision:
-              description: The revision of this document.
-              format: string
-              type: string
-          type: object
-        status:
-          type: object
-          x-kubernetes-preserve-unknown-fields: true
-      type: object
-  versions:
-  - name: v1alpha2
-    served: true
-    storage: true
----
-apiVersion: apiextensions.k8s.io/v1beta1
-kind: CustomResourceDefinition
-metadata:
-  annotations:
-    helm.sh/resource-policy: keep
-  labels:
-    app: mixer
-    chart: istio
-    cloudfoundry.org/istio_version: 1.6.4
-    heritage: Tiller
-    istio: mixer-handler
-    package: handler
-    release: istio
-  name: handlers.config.istio.io
-spec:
-  group: config.istio.io
-  names:
-    categories:
-    - istio-io
-    - policy-istio-io
-    kind: handler
-    listKind: handlerList
-    plural: handlers
-    singular: handler
-  scope: Namespaced
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      properties:
-        spec:
-          description: Handler allows the operator to configure a specific adapter
-            implementation.
-          properties:
-            adapter:
-              description: The name of a specific adapter implementation.
-              format: string
-              type: string
-            compiledAdapter:
-              description: The name of the compiled in adapter this handler instantiates.
-              format: string
-              type: string
-            connection:
-              description: Information on how to connect to the out-of-process adapter.
-              properties:
-                address:
-                  description: The address of the backend.
-                  format: string
-                  type: string
-                authentication:
-                  description: Auth config for the connection to the backend.
-                  oneOf:
-                  - not:
-                      anyOf:
-                      - properties:
-                          tls:
-                            allOf:
-                            - oneOf:
-                              - not:
-                                  anyOf:
-                                  - required:
-                                    - tokenPath
-                                  - required:
-                                    - oauth
-                              - required:
-                                - tokenPath
-                              - required:
-                                - oauth
-                            - oneOf:
-                              - not:
-                                  anyOf:
-                                  - required:
-                                    - authHeader
-                                  - required:
-                                    - customHeader
-                              - required:
-                                - authHeader
-                              - required:
-                                - customHeader
-                        required:
-                        - tls
-                      - required:
-                        - mutual
-                  - properties:
-                      tls:
-                        allOf:
-                        - oneOf:
-                          - not:
-                              anyOf:
-                              - required:
-                                - tokenPath
-                              - required:
-                                - oauth
-                          - required:
-                            - tokenPath
-                          - required:
-                            - oauth
-                        - oneOf:
-                          - not:
-                              anyOf:
-                              - required:
-                                - authHeader
-                              - required:
-                                - customHeader
-                          - required:
-                            - authHeader
-                          - required:
-                            - customHeader
-                    required:
-                    - tls
-                  - required:
-                    - mutual
-                  properties:
-                    mutual:
-                      properties:
-                        caCertificates:
-                          format: string
-                          type: string
-                        clientCertificate:
-                          description: The path to the file holding client certificate
-                            for mutual TLS.
-                          format: string
-                          type: string
-                        privateKey:
-                          description: The path to the file holding the private key
-                            for mutual TLS.
-                          format: string
-                          type: string
-                        serverName:
-                          description: Used to configure mixer mutual TLS client to
-                            supply server name for SNI.
-                          format: string
-                          type: string
-                      type: object
-                    tls:
-                      properties:
-                        authHeader:
-                          description: Access token is passed as authorization header.
-                          enum:
-                          - PLAIN
-                          - BEARER
-                          type: string
-                        caCertificates:
-                          format: string
-                          type: string
-                        customHeader:
-                          description: Customized header key to hold access token,
-                            e.g.
-                          format: string
-                          type: string
-                        oauth:
-                          description: Oauth config to fetch access token from auth
-                            provider.
-                          properties:
-                            clientId:
-                              description: OAuth client id for mixer.
-                              format: string
-                              type: string
-                            clientSecret:
-                              description: The path to the file holding the client
-                                secret for oauth.
-                              format: string
-                              type: string
-                            endpointParams:
-                              additionalProperties:
-                                format: string
-                                type: string
-                              description: Additional parameters for requests to the
-                                token endpoint.
-                              type: object
-                            scopes:
-                              description: List of requested permissions.
-                              items:
-                                format: string
-                                type: string
-                              type: array
-                            tokenUrl:
-                              description: The Resource server's token endpoint URL.
-                              format: string
-                              type: string
-                          type: object
-                        serverName:
-                          format: string
-                          type: string
-                        tokenPath:
-                          format: string
-                          type: string
-                      type: object
-                  type: object
-                timeout:
-                  description: Timeout for remote calls to the backend.
-                  type: string
-              type: object
-            name:
-              description: Must be unique in the entire Mixer configuration.
-              format: string
-              type: string
-            params:
-              description: Depends on adapter implementation.
-              type: object
-          type: object
-        status:
-          type: object
-          x-kubernetes-preserve-unknown-fields: true
-      type: object
-  versions:
-  - name: v1alpha2
-    served: true
-    storage: true
----
-apiVersion: apiextensions.k8s.io/v1beta1
-kind: CustomResourceDefinition
-metadata:
-  annotations:
-    helm.sh/resource-policy: keep
-  labels:
-    app: mixer
-    chart: istio
-    cloudfoundry.org/istio_version: 1.6.4
-    heritage: Tiller
-    istio: mixer-instance
-    package: instance
-    release: istio
-  name: instances.config.istio.io
-spec:
-  group: config.istio.io
-  names:
-    categories:
-    - istio-io
-    - policy-istio-io
-    kind: instance
-    listKind: instanceList
-    plural: instances
-    singular: instance
-  scope: Namespaced
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      properties:
-        spec:
-          description: An Instance tells Mixer how to create instances for particular
-            template.
-          properties:
-            attributeBindings:
-              additionalProperties:
-                format: string
-                type: string
-              type: object
-            compiledTemplate:
-              description: The name of the compiled in template this instance creates
-                instances for.
-              format: string
-              type: string
-            name:
-              format: string
-              type: string
-            params:
-              description: Depends on referenced template.
-              type: object
-            template:
-              description: The name of the template this instance creates instances
-                for.
-              format: string
-              type: string
-          type: object
-        status:
-          type: object
-          x-kubernetes-preserve-unknown-fields: true
-      type: object
-  versions:
-  - name: v1alpha2
-    served: true
-    storage: true
----
-apiVersion: apiextensions.k8s.io/v1beta1
-kind: CustomResourceDefinition
-metadata:
-  annotations:
-    helm.sh/resource-policy: keep
-  labels:
-    app: mixer
-    chart: istio
-    cloudfoundry.org/istio_version: 1.6.4
-    heritage: Tiller
-    istio: core
-    package: istio.io.mixer
-    release: istio
-  name: rules.config.istio.io
-spec:
-  group: config.istio.io
-  names:
-    categories:
-    - istio-io
-    - policy-istio-io
-    kind: rule
-    listKind: ruleList
-    plural: rules
-    singular: rule
-  preserveUnknownFields: false
-  scope: Namespaced
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      properties:
-        spec:
-          description: 'Describes the rules used to configure Mixer''s policy and
-            telemetry features. See more details at: https://istio.io/docs/reference/config/policy-and-telemetry/istio.policy.v1beta1.html'
-          properties:
-            actions:
-              description: The actions that will be executed when match evaluates
-                to `true`.
-              items:
-                properties:
-                  handler:
-                    description: Fully qualified name of the handler to invoke.
-                    format: string
-                    type: string
-                  instances:
-                    items:
-                      format: string
-                      type: string
-                    type: array
-                  name:
-                    description: A handle to refer to the results of the action.
-                    format: string
-                    type: string
-                type: object
-              type: array
-            match:
-              description: Match is an attribute based predicate.
-              format: string
-              type: string
-            requestHeaderOperations:
-              items:
-                properties:
-                  name:
-                    description: Header name literal value.
-                    format: string
-                    type: string
-                  operation:
-                    description: Header operation type.
-                    enum:
-                    - REPLACE
-                    - REMOVE
-                    - APPEND
-                    type: string
-                  values:
-                    description: Header value expressions.
-                    items:
-                      format: string
-                      type: string
-                    type: array
-                type: object
-              type: array
-            responseHeaderOperations:
-              items:
-                properties:
-                  name:
-                    description: Header name literal value.
-                    format: string
-                    type: string
-                  operation:
-                    description: Header operation type.
-                    enum:
-                    - REPLACE
-                    - REMOVE
-                    - APPEND
-                    type: string
-                  values:
-                    description: Header value expressions.
-                    items:
-                      format: string
-                      type: string
-                    type: array
-                type: object
-              type: array
-            sampling:
-              properties:
-                random:
-                  description: Provides filtering of actions based on random selection
-                    per request.
-                  properties:
-                    attributeExpression:
-                      description: Specifies an attribute expression to use to override
-                        the numerator in the `percent_sampled` field.
-                      format: string
-                      type: string
-                    percentSampled:
-                      description: The default sampling rate, expressed as a percentage.
-                      properties:
-                        denominator:
-                          description: Specifies the denominator.
-                          enum:
-                          - HUNDRED
-                          - TEN_THOUSAND
-                          type: string
-                        numerator:
-                          description: Specifies the numerator.
-                          type: integer
-                      type: object
-                    useIndependentRandomness:
-                      description: By default sampling will be based on the value
-                        of the request header `x-request-id`.
-                      type: boolean
-                  type: object
-                rateLimit:
-                  properties:
-                    maxUnsampledEntries:
-                      description: Number of entries to allow during the `sampling_duration`
-                        before sampling is enforced.
-                      format: int64
-                      type: integer
-                    samplingDuration:
-                      description: Window in which to enforce the sampling rate.
-                      type: string
-                    samplingRate:
-                      description: The rate at which to sample entries once the unsampled
-                        limit has been reached.
-                      format: int64
-                      type: integer
-                  type: object
-              type: object
-          type: object
-        status:
-          type: object
-          x-kubernetes-preserve-unknown-fields: true
-      type: object
-  versions:
-  - name: v1alpha2
-    served: true
-    storage: true
----
-apiVersion: apiextensions.k8s.io/v1beta1
-kind: CustomResourceDefinition
-metadata:
-  annotations:
-    helm.sh/resource-policy: keep
-  labels:
-    app: istio-pilot
-    chart: istio
-    cloudfoundry.org/istio_version: 1.6.4
-    heritage: Tiller
-    istio: rbac
-    release: istio
-  name: clusterrbacconfigs.rbac.istio.io
-spec:
-  group: rbac.istio.io
-  names:
-    categories:
-    - istio-io
-    - rbac-istio-io
-    kind: ClusterRbacConfig
-    listKind: ClusterRbacConfigList
-    plural: clusterrbacconfigs
-    singular: clusterrbacconfig
-  preserveUnknownFields: false
-  scope: Cluster
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      properties:
-        spec:
-          description: 'See more details at:'
-          properties:
-            enforcementMode:
-              enum:
-              - ENFORCED
-              - PERMISSIVE
-              type: string
-            exclusion:
-              description: A list of services or namespaces that should not be enforced
-                by Istio RBAC policies.
-              properties:
-                namespaces:
-                  description: A list of namespaces.
-                  items:
-                    format: string
-                    type: string
-                  type: array
-                services:
-                  description: A list of services.
-                  items:
-                    format: string
-                    type: string
-                  type: array
-              type: object
-            inclusion:
-              description: A list of services or namespaces that should be enforced
-                by Istio RBAC policies.
-              properties:
-                namespaces:
-                  description: A list of namespaces.
-                  items:
-                    format: string
-                    type: string
-                  type: array
-                services:
-                  description: A list of services.
-                  items:
-                    format: string
-                    type: string
-                  type: array
-              type: object
-            mode:
-              description: Istio RBAC mode.
-              enum:
-              - "OFF"
-              - "ON"
-              - ON_WITH_INCLUSION
-              - ON_WITH_EXCLUSION
-              type: string
-          type: object
-        status:
-          type: object
-          x-kubernetes-preserve-unknown-fields: true
-      type: object
-  versions:
-  - name: v1alpha1
-    served: true
-    storage: true
----
-apiVersion: apiextensions.k8s.io/v1beta1
-kind: CustomResourceDefinition
-metadata:
-  annotations:
-    helm.sh/resource-policy: keep
-  labels:
-    app: mixer
-    chart: istio
-    cloudfoundry.org/istio_version: 1.6.4
-    heritage: Tiller
-    istio: rbac
-    package: istio.io.mixer
-    release: istio
-  name: rbacconfigs.rbac.istio.io
-spec:
-  group: rbac.istio.io
-  names:
-    categories:
-    - istio-io
-    - rbac-istio-io
-    kind: RbacConfig
-    listKind: RbacConfigList
-    plural: rbacconfigs
-    singular: rbacconfig
-  preserveUnknownFields: false
-  scope: Namespaced
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      properties:
-        spec:
-          description: 'See more details at:'
-          properties:
-            enforcementMode:
-              enum:
-              - ENFORCED
-              - PERMISSIVE
-              type: string
-            exclusion:
-              description: A list of services or namespaces that should not be enforced
-                by Istio RBAC policies.
-              properties:
-                namespaces:
-                  description: A list of namespaces.
-                  items:
-                    format: string
-                    type: string
-                  type: array
-                services:
-                  description: A list of services.
-                  items:
-                    format: string
-                    type: string
-                  type: array
-              type: object
-            inclusion:
-              description: A list of services or namespaces that should be enforced
-                by Istio RBAC policies.
-              properties:
-                namespaces:
-                  description: A list of namespaces.
-                  items:
-                    format: string
-                    type: string
-                  type: array
-                services:
-                  description: A list of services.
-                  items:
-                    format: string
-                    type: string
-                  type: array
-              type: object
-            mode:
-              description: Istio RBAC mode.
-              enum:
-              - "OFF"
-              - "ON"
-              - ON_WITH_INCLUSION
-              - ON_WITH_EXCLUSION
-              type: string
-          type: object
-        status:
-          type: object
-          x-kubernetes-preserve-unknown-fields: true
-      type: object
-  versions:
-  - name: v1alpha1
-    served: true
-    storage: true
----
-apiVersion: apiextensions.k8s.io/v1beta1
-kind: CustomResourceDefinition
-metadata:
-  annotations:
-    helm.sh/resource-policy: keep
-  labels:
-    app: mixer
-    chart: istio
-    cloudfoundry.org/istio_version: 1.6.4
-    heritage: Tiller
-    istio: rbac
-    package: istio.io.mixer
-    release: istio
-  name: serviceroles.rbac.istio.io
-spec:
-  group: rbac.istio.io
-  names:
-    categories:
-    - istio-io
-    - rbac-istio-io
-    kind: ServiceRole
-    listKind: ServiceRoleList
-    plural: serviceroles
-    singular: servicerole
-  preserveUnknownFields: false
-  scope: Namespaced
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      properties:
-        spec:
-          description: 'See more details at:'
-          properties:
-            rules:
-              description: The set of access rules (permissions) that the role has.
-              items:
-                properties:
-                  constraints:
-                    description: Optional.
-                    items:
-                      properties:
-                        key:
-                          description: Key of the constraint.
-                          format: string
-                          type: string
-                        values:
-                          description: List of valid values for the constraint.
-                          items:
-                            format: string
-                            type: string
-                          type: array
-                      type: object
-                    type: array
-                  hosts:
-                    items:
-                      format: string
-                      type: string
-                    type: array
-                  methods:
-                    description: Optional.
-                    items:
-                      format: string
-                      type: string
-                    type: array
-                  notHosts:
-                    items:
-                      format: string
-                      type: string
-                    type: array
-                  notMethods:
-                    items:
-                      format: string
-                      type: string
-                    type: array
-                  notPaths:
-                    items:
-                      format: string
-                      type: string
-                    type: array
-                  notPorts:
-                    items:
-                      format: int32
-                      type: integer
-                    type: array
-                  paths:
-                    description: Optional.
-                    items:
-                      format: string
-                      type: string
-                    type: array
-                  ports:
-                    items:
-                      format: int32
-                      type: integer
-                    type: array
-                  services:
-                    description: A list of service names.
-                    items:
-                      format: string
-                      type: string
-                    type: array
-                type: object
-              type: array
-          type: object
-        status:
-          type: object
-          x-kubernetes-preserve-unknown-fields: true
-      type: object
-  versions:
-  - name: v1alpha1
-    served: true
-    storage: true
----
-apiVersion: apiextensions.k8s.io/v1beta1
-kind: CustomResourceDefinition
-metadata:
-  annotations:
-    helm.sh/resource-policy: keep
-  labels:
-    app: mixer
-    chart: istio
-    cloudfoundry.org/istio_version: 1.6.4
-    heritage: Tiller
-    istio: rbac
-    package: istio.io.mixer
-    release: istio
-  name: servicerolebindings.rbac.istio.io
-spec:
-  additionalPrinterColumns:
-  - JSONPath: .spec.roleRef.name
-    description: The name of the ServiceRole object being referenced
-    name: Reference
-    type: string
-  - JSONPath: .metadata.creationTimestamp
-    description: 'CreationTimestamp is a timestamp representing the server time when
-      this object was created. It is not guaranteed to be set in happens-before order
-      across separate operations. Clients may not set this value. It is represented
-      in RFC3339 form and is in UTC. Populated by the system. Read-only. Null for
-      lists. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata'
-    name: Age
-    type: date
-  group: rbac.istio.io
-  names:
-    categories:
-    - istio-io
-    - rbac-istio-io
-    kind: ServiceRoleBinding
-    listKind: ServiceRoleBindingList
-    plural: servicerolebindings
-    singular: servicerolebinding
-  preserveUnknownFields: false
-  scope: Namespaced
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      properties:
-        spec:
-          description: 'See more details at:'
-          properties:
-            actions:
-              items:
-                properties:
-                  constraints:
-                    description: Optional.
-                    items:
-                      properties:
-                        key:
-                          description: Key of the constraint.
-                          format: string
-                          type: string
-                        values:
-                          description: List of valid values for the constraint.
-                          items:
-                            format: string
-                            type: string
-                          type: array
-                      type: object
-                    type: array
-                  hosts:
-                    items:
-                      format: string
-                      type: string
-                    type: array
-                  methods:
-                    description: Optional.
-                    items:
-                      format: string
-                      type: string
-                    type: array
-                  notHosts:
-                    items:
-                      format: string
-                      type: string
-                    type: array
-                  notMethods:
-                    items:
-                      format: string
-                      type: string
-                    type: array
-                  notPaths:
-                    items:
-                      format: string
-                      type: string
-                    type: array
-                  notPorts:
-                    items:
-                      format: int32
-                      type: integer
-                    type: array
-                  paths:
-                    description: Optional.
-                    items:
-                      format: string
-                      type: string
-                    type: array
-                  ports:
-                    items:
-                      format: int32
-                      type: integer
-                    type: array
-                  services:
-                    description: A list of service names.
-                    items:
-                      format: string
-                      type: string
-                    type: array
-                type: object
-              type: array
-            mode:
-              enum:
-              - ENFORCED
-              - PERMISSIVE
-              type: string
-            role:
-              format: string
-              type: string
-            roleRef:
-              description: Reference to the ServiceRole object.
-              properties:
-                kind:
-                  description: The type of the role being referenced.
-                  format: string
-                  type: string
-                name:
-                  description: The name of the ServiceRole object being referenced.
-                  format: string
-                  type: string
-              type: object
-            subjects:
-              description: List of subjects that are assigned the ServiceRole object.
-              items:
-                properties:
-                  group:
-                    format: string
-                    type: string
-                  groups:
-                    items:
-                      format: string
-                      type: string
-                    type: array
-                  ips:
-                    items:
-                      format: string
-                      type: string
-                    type: array
-                  names:
-                    items:
-                      format: string
-                      type: string
-                    type: array
-                  namespaces:
-                    items:
-                      format: string
-                      type: string
-                    type: array
-                  notGroups:
-                    items:
-                      format: string
-                      type: string
-                    type: array
-                  notIps:
-                    items:
-                      format: string
-                      type: string
-                    type: array
-                  notNames:
-                    items:
-                      format: string
-                      type: string
-                    type: array
-                  notNamespaces:
-                    items:
-                      format: string
-                      type: string
-                    type: array
-                  properties:
-                    additionalProperties:
-                      format: string
-                      type: string
-                    description: Optional.
-                    type: object
-                  user:
-                    description: Optional.
-                    format: string
-                    type: string
-                type: object
-              type: array
-          type: object
-        status:
-          type: object
-          x-kubernetes-preserve-unknown-fields: true
-      type: object
-  versions:
-  - name: v1alpha1
-    served: true
-    storage: true
----
-apiVersion: apiextensions.k8s.io/v1beta1
-kind: CustomResourceDefinition
-metadata:
-  annotations:
-    helm.sh/resource-policy: keep
-  labels:
-    app: istio-pilot
-    chart: istio
-    cloudfoundry.org/istio_version: 1.6.4
-    heritage: Tiller
-    istio: security
-    release: istio
-  name: authorizationpolicies.security.istio.io
-spec:
-  group: security.istio.io
-  names:
-    categories:
-    - istio-io
-    - security-istio-io
-    kind: AuthorizationPolicy
-    listKind: AuthorizationPolicyList
-    plural: authorizationpolicies
-    singular: authorizationpolicy
-  preserveUnknownFields: false
-  scope: Namespaced
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      properties:
-        spec:
-          description: 'Configuration for access control on workloads. See more details
-            at: https://istio.io/docs/reference/config/security/authorization-policy.html'
-          properties:
-            action:
-              description: Optional.
-              enum:
-              - ALLOW
-              - DENY
-              type: string
-            rules:
-              description: Optional.
-              items:
-                properties:
-                  from:
-                    description: Optional.
-                    items:
-                      properties:
-                        source:
-                          description: Source specifies the source of a request.
-                          properties:
-                            ipBlocks:
-                              description: Optional.
-                              items:
-                                format: string
-                                type: string
-                              type: array
-                            namespaces:
-                              description: Optional.
-                              items:
-                                format: string
-                                type: string
-                              type: array
-                            notIpBlocks:
-                              description: Optional.
-                              items:
-                                format: string
-                                type: string
-                              type: array
-                            notNamespaces:
-                              description: Optional.
-                              items:
-                                format: string
-                                type: string
-                              type: array
-                            notPrincipals:
-                              description: Optional.
-                              items:
-                                format: string
-                                type: string
-                              type: array
-                            notRequestPrincipals:
-                              description: Optional.
-                              items:
-                                format: string
-                                type: string
-                              type: array
-                            principals:
-                              description: Optional.
-                              items:
-                                format: string
-                                type: string
-                              type: array
-                            requestPrincipals:
-                              description: Optional.
-                              items:
-                                format: string
-                                type: string
-                              type: array
-                          type: object
-                      type: object
-                    type: array
-                  to:
-                    description: Optional.
-                    items:
-                      properties:
-                        operation:
-                          description: Operation specifies the operation of a request.
-                          properties:
-                            hosts:
-                              description: Optional.
-                              items:
-                                format: string
-                                type: string
-                              type: array
-                            methods:
-                              description: Optional.
-                              items:
-                                format: string
-                                type: string
-                              type: array
-                            notHosts:
-                              description: Optional.
-                              items:
-                                format: string
-                                type: string
-                              type: array
-                            notMethods:
-                              description: Optional.
-                              items:
-                                format: string
-                                type: string
-                              type: array
-                            notPaths:
-                              description: Optional.
-                              items:
-                                format: string
-                                type: string
-                              type: array
-                            notPorts:
-                              description: Optional.
-                              items:
-                                format: string
-                                type: string
-                              type: array
-                            paths:
-                              description: Optional.
-                              items:
-                                format: string
-                                type: string
-                              type: array
-                            ports:
-                              description: Optional.
-                              items:
-                                format: string
-                                type: string
-                              type: array
-                          type: object
-                      type: object
-                    type: array
-                  when:
-                    description: Optional.
-                    items:
-                      properties:
-                        key:
-                          description: The name of an Istio attribute.
-                          format: string
-                          type: string
-                        notValues:
-                          description: Optional.
-                          items:
-                            format: string
-                            type: string
-                          type: array
-                        values:
-                          description: Optional.
-                          items:
-                            format: string
-                            type: string
-                          type: array
-                      type: object
-                    type: array
-                type: object
-              type: array
-            selector:
-              description: Optional.
-              properties:
-                matchLabels:
-                  additionalProperties:
-                    format: string
-                    type: string
-                  type: object
-              type: object
-          type: object
-        status:
-          type: object
-          x-kubernetes-preserve-unknown-fields: true
-      type: object
-  versions:
-  - name: v1beta1
-    served: true
-    storage: true
----
-apiVersion: apiextensions.k8s.io/v1beta1
-kind: CustomResourceDefinition
-metadata:
-  annotations:
-    helm.sh/resource-policy: keep
-  labels:
-    app: istio-pilot
-    chart: istio
-    cloudfoundry.org/istio_version: 1.6.4
-    heritage: Tiller
-    istio: security
-    release: istio
-  name: peerauthentications.security.istio.io
-spec:
-  group: security.istio.io
-  names:
-    categories:
-    - istio-io
-    - security-istio-io
-    kind: PeerAuthentication
-    listKind: PeerAuthenticationList
-    plural: peerauthentications
-    shortNames:
-    - pa
-    singular: peerauthentication
-  preserveUnknownFields: false
-  scope: Namespaced
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      properties:
-        spec:
-          description: PeerAuthentication defines how traffic will be tunneled (or
-            not) to the sidecar.
-          properties:
-            mtls:
-              description: Mutual TLS settings for workload.
-              properties:
-                mode:
-                  description: Defines the mTLS mode used for peer authentication.
-                  enum:
-                  - UNSET
-                  - DISABLE
-                  - PERMISSIVE
-                  - STRICT
-                  type: string
-              type: object
-            portLevelMtls:
-              additionalProperties:
-                properties:
-                  mode:
-                    description: Defines the mTLS mode used for peer authentication.
-                    enum:
-                    - UNSET
-                    - DISABLE
-                    - PERMISSIVE
-                    - STRICT
-                    type: string
-                type: object
-              description: Port specific mutual TLS settings.
-              type: object
-            selector:
-              description: The selector determines the workloads to apply the ChannelAuthentication
-                on.
-              properties:
-                matchLabels:
-                  additionalProperties:
-                    format: string
-                    type: string
-                  type: object
-              type: object
-          type: object
-        status:
-          type: object
-          x-kubernetes-preserve-unknown-fields: true
-      type: object
-  versions:
-  - name: v1beta1
-    served: true
-    storage: true
----
-apiVersion: apiextensions.k8s.io/v1beta1
-kind: CustomResourceDefinition
-metadata:
-  annotations:
-    helm.sh/resource-policy: keep
-  labels:
-    app: istio-pilot
-    chart: istio
-    cloudfoundry.org/istio_version: 1.6.4
-    heritage: Tiller
-    istio: security
-    release: istio
-  name: requestauthentications.security.istio.io
-spec:
-  group: security.istio.io
-  names:
-    categories:
-    - istio-io
-    - security-istio-io
-    kind: RequestAuthentication
-    listKind: RequestAuthenticationList
-    plural: requestauthentications
-    shortNames:
-    - ra
-    singular: requestauthentication
-  preserveUnknownFields: false
-  scope: Namespaced
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      properties:
-        spec:
-          description: RequestAuthentication defines what request authentication methods
-            are supported by a workload.
-          properties:
-            jwtRules:
-              description: Define the list of JWTs that can be validated at the selected
-                workloads' proxy.
-              items:
-                properties:
-                  audiences:
-                    items:
-                      format: string
-                      type: string
-                    type: array
-                  forwardOriginalToken:
-                    description: If set to true, the orginal token will be kept for
-                      the ustream request.
-                    type: boolean
-                  fromHeaders:
-                    description: List of header locations from which JWT is expected.
-                    items:
-                      properties:
-                        name:
-                          description: The HTTP header name.
-                          format: string
-                          type: string
-                        prefix:
-                          description: The prefix that should be stripped before decoding
-                            the token.
-                          format: string
-                          type: string
-                      type: object
-                    type: array
-                  fromParams:
-                    description: List of query parameters from which JWT is expected.
-                    items:
-                      format: string
-                      type: string
-                    type: array
-                  issuer:
-                    description: Identifies the issuer that issued the JWT.
-                    format: string
-                    type: string
-                  jwks:
-                    description: JSON Web Key Set of public keys to validate signature
-                      of the JWT.
-                    format: string
-                    type: string
-                  jwks_uri:
-                    format: string
-                    type: string
-                  jwksUri:
-                    format: string
-                    type: string
-                  outputPayloadToHeader:
-                    format: string
-                    type: string
-                type: object
-              type: array
-            selector:
-              description: The selector determines the workloads to apply the RequestAuthentication
-                on.
-              properties:
-                matchLabels:
-                  additionalProperties:
-                    format: string
-                    type: string
-                  type: object
-              type: object
-          type: object
-        status:
-          type: object
-          x-kubernetes-preserve-unknown-fields: true
-      type: object
-  versions:
-  - name: v1beta1
-    served: true
-    storage: true
----
-apiVersion: apiextensions.k8s.io/v1beta1
-kind: CustomResourceDefinition
-metadata:
-  annotations:
-    helm.sh/resource-policy: keep
-  labels:
-    app: mixer
-    chart: istio
-    cloudfoundry.org/istio_version: 1.6.4
-    heritage: Tiller
-    istio: mixer-adapter
-    package: adapter
-    release: istio
-  name: adapters.config.istio.io
-spec:
-  group: config.istio.io
-  names:
-    categories:
-    - istio-io
-    - policy-istio-io
-    kind: adapter
-    plural: adapters
-    singular: adapter
-  scope: Namespaced
-  subresources:
-    status: {}
-  versions:
-  - name: v1alpha2
-    served: true
-    storage: true
----
-apiVersion: apiextensions.k8s.io/v1beta1
-kind: CustomResourceDefinition
-metadata:
-  annotations:
-    helm.sh/resource-policy: keep
-  labels:
-    app: mixer
-    chart: istio
-    cloudfoundry.org/istio_version: 1.6.4
-    heritage: Tiller
-    istio: mixer-template
-    package: template
-    release: istio
-  name: templates.config.istio.io
-spec:
-  group: config.istio.io
-  names:
-    categories:
-    - istio-io
-    - policy-istio-io
-    kind: template
-    plural: templates
-    singular: template
-  scope: Namespaced
-  subresources:
-    status: {}
-  versions:
-  - name: v1alpha2
-    served: true
-    storage: true
----
-apiVersion: apiextensions.k8s.io/v1beta1
-kind: CustomResourceDefinition
+apiVersion: networking.istio.io/v1alpha3
+kind: EnvoyFilter
 metadata:
   labels:
-    cloudfoundry.org/istio_version: 1.6.4
-    release: istio
-  name: istiooperators.install.istio.io
-spec:
-  additionalPrinterColumns:
-  - JSONPath: .spec.revision
-    description: Istio control plane revision
-    name: Revision
-    type: string
-  - JSONPath: .metadata.creationTimestamp
-    description: 'CreationTimestamp is a timestamp representing the server time when
-      this object was created. It is not guaranteed to be set in happens-before order
-      across separate operations. Clients may not set this value. It is represented
-      in RFC3339 form and is in UTC. Populated by the system. Read-only. Null for
-      lists. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata'
-    name: Age
-    type: date
-  group: install.istio.io
-  names:
-    kind: IstioOperator
-    plural: istiooperators
-    shortNames:
-    - iop
-    singular: istiooperator
-  scope: Namespaced
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-          type: string
-        spec:
-          description: 'Specification of the desired state of the istio control plane
-            resource. More info: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#spec-and-status'
-          type: object
-        status:
-          description: 'Status describes each of istio control plane component status
-            at the current time. 0 means NONE, 1 means UPDATING, 2 means HEALTHY,
-            3 means ERROR, 4 means RECONCILING. More info: https://github.com/istio/api/blob/master/operator/v1alpha1/istio.operator.v1alpha1.pb.html
-            & https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#spec-and-status'
-          type: object
-  versions:
-  - name: v1alpha1
-    served: true
-    storage: true
----
-apiVersion: autoscaling/v2beta1
-kind: HorizontalPodAutoscaler
-metadata:
-  labels:
-    app: istio-ingressgateway
-    cloudfoundry.org/istio_version: 1.6.4
-    istio: ingressgateway
-    release: istio
-  name: istio-ingressgateway
-  namespace: istio-system
-spec:
-  maxReplicas: 1
-  metrics:
-  - resource:
-      name: cpu
-      targetAverageUtilization: 80
-    type: Resource
-  minReplicas: 1
-  scaleTargetRef:
-    apiVersion: apps/v1
-    kind: Deployment
-    name: istio-ingressgateway
----
-apiVersion: apps/v1
-kind: DaemonSet
-metadata:
-  annotations:
-    kbld.k14s.io/images: |
-      - Metas:
-        - Tag: 1.6.4
-          Type: resolved
-          URL: gcr.io/cf-routing/proxyv2:1.6.4
-        URL: gcr.io/cf-routing/proxyv2@sha256:4e4d05059e65080b158a347bcfac67090968e96f302dea54c0efac9a16ef62f0
-  labels:
-    app: istio-ingressgateway
-    cloudfoundry.org/istio_version: 1.6.4
-    istio: ingressgateway
-    release: istio
-  name: istio-ingressgateway
-  namespace: istio-system
-spec:
-  selector:
-    matchLabels:
-      app: istio-ingressgateway
-      istio: ingressgateway
-  template:
-    metadata:
-      annotations:
-        sidecar.istio.io/inject: "false"
-      labels:
-        app: istio-ingressgateway
-        chart: gateways
-        cloudfoundry.org/istio_version: 1.6.4
-        heritage: Tiller
-        istio: ingressgateway
-        release: istio
-        service.istio.io/canonical-name: istio-ingressgateway
-        service.istio.io/canonical-revision: latest
-    spec:
-      affinity:
-        nodeAffinity:
-          preferredDuringSchedulingIgnoredDuringExecution:
-          - preference:
-              matchExpressions:
-              - key: beta.kubernetes.io/arch
-                operator: In
-                values:
-                - amd64
-            weight: 2
-          - preference:
-              matchExpressions:
-              - key: beta.kubernetes.io/arch
-                operator: In
-                values:
-                - ppc64le
-            weight: 2
-          - preference:
-              matchExpressions:
-              - key: beta.kubernetes.io/arch
-                operator: In
-                values:
-                - s390x
-            weight: 2
-          requiredDuringSchedulingIgnoredDuringExecution:
-            nodeSelectorTerms:
-            - matchExpressions:
-              - key: beta.kubernetes.io/arch
-                operator: In
-                values:
-                - amd64
-                - ppc64le
-                - s390x
-      containers:
-      - args:
-        - proxy
-        - router
-        - --domain
-        - $(POD_NAMESPACE).svc.cluster.local
-        - --proxyLogLevel=warning
-        - --proxyComponentLogLevel=misc:error
-        - --log_output_level=default:info
-        - --serviceCluster
-        - istio-ingressgateway
-        - --trust-domain=cluster.local
-        env:
-        - name: JWT_POLICY
-          value: third-party-jwt
-        - name: PILOT_CERT_PROVIDER
-          value: istiod
-        - name: CA_ADDR
-          value: istiod.istio-system.svc:15012
-        - name: NODE_NAME
-          valueFrom:
-            fieldRef:
-              apiVersion: v1
-              fieldPath: spec.nodeName
-        - name: POD_NAME
-          valueFrom:
-            fieldRef:
-              apiVersion: v1
-              fieldPath: metadata.name
-        - name: POD_NAMESPACE
-          valueFrom:
-            fieldRef:
-              apiVersion: v1
-              fieldPath: metadata.namespace
-        - name: INSTANCE_IP
-          valueFrom:
-            fieldRef:
-              apiVersion: v1
-              fieldPath: status.podIP
-        - name: HOST_IP
-          valueFrom:
-            fieldRef:
-              apiVersion: v1
-              fieldPath: status.hostIP
-        - name: SERVICE_ACCOUNT
-          valueFrom:
-            fieldRef:
-              fieldPath: spec.serviceAccountName
-        - name: CANONICAL_SERVICE
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.labels['service.istio.io/canonical-name']
-        - name: CANONICAL_REVISION
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.labels['service.istio.io/canonical-revision']
-        - name: ISTIO_META_WORKLOAD_NAME
-          value: istio-ingressgateway
-        - name: ISTIO_META_OWNER
-          value: kubernetes://apis/apps/v1/namespaces/istio-system/deployments/istio-ingressgateway
-        - name: ISTIO_META_MESH_ID
-          value: cluster.local
-        - name: ISTIO_META_ROUTER_MODE
-          value: sni-dnat
-        - name: ISTIO_META_CLUSTER_ID
-          value: Kubernetes
-        - name: TERMINATION_DRAIN_DURATION_SECONDS
-          value: "60"
-        image: gcr.io/cf-routing/proxyv2@sha256:4e4d05059e65080b158a347bcfac67090968e96f302dea54c0efac9a16ef62f0
-        lifecycle:
-          preStop:
-            exec:
-              command:
-              - /bin/bash
-              - -c
-              - sleep 20
-        name: istio-proxy
-        ports:
-        - containerPort: 15021
-        - containerPort: 8080
-          hostPort: 80
-        - containerPort: 8443
-          hostPort: 443
-        - containerPort: 15443
-        - containerPort: 15011
-        - containerPort: 15012
-        - containerPort: 8060
-        - containerPort: 853
-        - containerPort: 15090
-          name: http-envoy-prom
-          protocol: TCP
-        readinessProbe:
-          failureThreshold: 30
-          httpGet:
-            path: /healthz/ready
-            port: 15021
-            scheme: HTTP
-          initialDelaySeconds: 1
-          periodSeconds: 2
-          successThreshold: 1
-          timeoutSeconds: 1
-        resources:
-          limits:
-            cpu: 2000m
-            memory: 1024Mi
-          requests:
-            cpu: 100m
-            memory: 128Mi
-        volumeMounts:
-        - mountPath: /etc/istio/proxy
-          name: istio-envoy
-        - mountPath: /etc/istio/config
-          name: config-volume
-        - mountPath: /var/run/secrets/istio
-          name: istiod-ca-cert
-        - mountPath: /var/run/secrets/tokens
-          name: istio-token
-          readOnly: true
-        - mountPath: /var/run/ingress_gateway
-          name: ingressgatewaysdsudspath
-        - mountPath: /etc/istio/pod
-          name: podinfo
-        - mountPath: /etc/istio/ingressgateway-certs
-          name: ingressgateway-certs
-          readOnly: true
-        - mountPath: /etc/istio/ingressgateway-ca-certs
-          name: ingressgateway-ca-certs
-          readOnly: true
-      - image: gcr.io/cf-networking-images/cf-k8s-networking/fluentbit@sha256:9d0f364a682b1903b1230d836d2270f86f29b2904ea5b2b8ee3ea9132a9ab9d7
-        name: fluent-bit
-        resources:
-          limits:
-            cpu: 100m
-            memory: 100Mi
-          requests:
-            cpu: 10m
-            memory: 10Mi
-        volumeMounts:
-        - mountPath: /fluent-bit/etc
-          name: fluent-bit-config
-        - mountPath: /var/log
-          name: varlog
-        - mountPath: /var/lib/docker/containers
-          name: dockercontainers
-          readOnly: true
-      serviceAccountName: istio-ingressgateway-service-account
-      terminationGracePeriodSeconds: 80
-      volumes:
-      - configMap:
-          name: istio-ca-root-cert
-        name: istiod-ca-cert
-      - downwardAPI:
-          items:
-          - fieldRef:
-              fieldPath: metadata.labels
-            path: labels
-          - fieldRef:
-              fieldPath: metadata.annotations
-            path: annotations
-        name: podinfo
-      - emptyDir: {}
-        name: istio-envoy
-      - emptyDir: {}
-        name: ingressgatewaysdsudspath
-      - name: istio-token
-        projected:
-          sources:
-          - serviceAccountToken:
-              audience: istio-ca
-              expirationSeconds: 43200
-              path: istio-token
-      - configMap:
-          name: istio
-          optional: true
-        name: config-volume
-      - name: ingressgateway-certs
-        secret:
-          optional: true
-          secretName: istio-ingressgateway-certs
-      - name: ingressgateway-ca-certs
-        secret:
-          optional: true
-          secretName: istio-ingressgateway-ca-certs
-      - configMap:
-          name: ingressgateway-fluent-bit-forwarder-config
-        name: fluent-bit-config
-      - hostPath:
-          path: /var/log
-        name: varlog
-      - hostPath:
-          path: /var/lib/docker/containers
-        name: dockercontainers
-  updateStrategy:
-    rollingUpdate:
-      maxUnavailable: 1
----
-apiVersion: policy/v1beta1
-kind: PodDisruptionBudget
-metadata:
-  annotations:
-    kapp.k14s.io/update-strategy: fallback-on-replace
-  labels:
-    app: istio-ingressgateway
-    cloudfoundry.org/istio_version: 1.6.4
-    istio: ingressgateway
-    release: istio
-  name: istio-ingressgateway
-  namespace: istio-system
-spec:
-  minAvailable: 1
-  selector:
-    matchLabels:
-      app: istio-ingressgateway
-      istio: ingressgateway
-      release: istio
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: Role
-metadata:
-  labels:
-    cloudfoundry.org/istio_version: 1.6.4
-    release: istio
-  name: istio-ingressgateway-sds
-  namespace: istio-system
-rules:
-- apiGroups:
-  - ""
-  resources:
-  - secrets
-  verbs:
-  - get
-  - watch
-  - list
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
-metadata:
-  labels:
-    cloudfoundry.org/istio_version: 1.6.4
-    release: istio
-  name: istio-ingressgateway-sds
-  namespace: istio-system
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: Role
-  name: istio-ingressgateway-sds
-subjects:
-- kind: ServiceAccount
-  name: istio-ingressgateway-service-account
----
-apiVersion: v1
-kind: Service
-metadata:
-  annotations: null
-  labels:
-    app: istio-ingressgateway
-    cloudfoundry.org/istio_version: 1.6.4
-    istio: ingressgateway
-    release: istio
-  name: istio-ingressgateway
-  namespace: istio-system
-spec:
-  externalTrafficPolicy: Local
-  ports:
-  - name: status-port
-    port: 15021
-    targetPort: 15021
-  - name: http2
-    port: 80
-    targetPort: 8080
-  - name: https
-    port: 443
-    targetPort: 8443
-  - name: tls
-    port: 15443
-    targetPort: 15443
-  selector:
-    app: istio-ingressgateway
-    istio: ingressgateway
-  type: LoadBalancer
----
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  labels:
-    app: istio-ingressgateway
-    cloudfoundry.org/istio_version: 1.6.4
-    istio: ingressgateway
-    release: istio
-  name: istio-ingressgateway-service-account
-  namespace: istio-system
----
-apiVersion: autoscaling/v2beta1
-kind: HorizontalPodAutoscaler
-metadata:
-  labels:
-    app: istiod
-    cloudfoundry.org/istio_version: 1.6.4
+    cloudfoundry.org/istio_version: 1.7.1
     istio.io/rev: default
-    release: istio
-  name: istiod
+  name: metadata-exchange-1.6
   namespace: istio-system
 spec:
-  maxReplicas: 1
-  metrics:
-  - resource:
-      name: cpu
-      targetAverageUtilization: 80
-    type: Resource
-  minReplicas: 1
-  scaleTargetRef:
-    apiVersion: apps/v1
-    kind: Deployment
-    name: istiod
+  configPatches:
+  - applyTo: HTTP_FILTER
+    match:
+      context: ANY
+      listener:
+        filterChain:
+          filter:
+            name: envoy.http_connection_manager
+      proxy:
+        proxyVersion: ^1\.6.*
+    patch:
+      operation: INSERT_BEFORE
+      value:
+        name: istio.metadata_exchange
+        typed_config:
+          '@type': type.googleapis.com/udpa.type.v1.TypedStruct
+          type_url: type.googleapis.com/envoy.extensions.filters.http.wasm.v3.Wasm
+          value:
+            config:
+              configuration: |
+                {}
+              vm_config:
+                code:
+                  local:
+                    inline_string: envoy.wasm.metadata_exchange
+                runtime: envoy.wasm.runtime.null
+---
+apiVersion: networking.istio.io/v1alpha3
+kind: EnvoyFilter
+metadata:
+  labels:
+    cloudfoundry.org/istio_version: 1.7.1
+    istio.io/rev: default
+  name: metadata-exchange-1.7
+  namespace: istio-system
+spec:
+  configPatches:
+  - applyTo: HTTP_FILTER
+    match:
+      context: SIDECAR_INBOUND
+      listener:
+        filterChain:
+          filter:
+            name: envoy.http_connection_manager
+      proxy:
+        proxyVersion: ^1\.7.*
+    patch:
+      operation: INSERT_BEFORE
+      value:
+        name: istio.metadata_exchange
+        typed_config:
+          '@type': type.googleapis.com/udpa.type.v1.TypedStruct
+          type_url: type.googleapis.com/envoy.extensions.filters.http.wasm.v3.Wasm
+          value:
+            config:
+              configuration:
+                '@type': type.googleapis.com/google.protobuf.StringValue
+                value: |
+                  {}
+              vm_config:
+                code:
+                  local:
+                    inline_string: envoy.wasm.metadata_exchange
+                runtime: envoy.wasm.runtime.null
+  - applyTo: HTTP_FILTER
+    match:
+      context: SIDECAR_OUTBOUND
+      listener:
+        filterChain:
+          filter:
+            name: envoy.http_connection_manager
+      proxy:
+        proxyVersion: ^1\.7.*
+    patch:
+      operation: INSERT_BEFORE
+      value:
+        name: istio.metadata_exchange
+        typed_config:
+          '@type': type.googleapis.com/udpa.type.v1.TypedStruct
+          type_url: type.googleapis.com/envoy.extensions.filters.http.wasm.v3.Wasm
+          value:
+            config:
+              configuration:
+                '@type': type.googleapis.com/google.protobuf.StringValue
+                value: |
+                  {}
+              vm_config:
+                code:
+                  local:
+                    inline_string: envoy.wasm.metadata_exchange
+                runtime: envoy.wasm.runtime.null
+  - applyTo: HTTP_FILTER
+    match:
+      context: GATEWAY
+      listener:
+        filterChain:
+          filter:
+            name: envoy.http_connection_manager
+      proxy:
+        proxyVersion: ^1\.7.*
+    patch:
+      operation: INSERT_BEFORE
+      value:
+        name: istio.metadata_exchange
+        typed_config:
+          '@type': type.googleapis.com/udpa.type.v1.TypedStruct
+          type_url: type.googleapis.com/envoy.extensions.filters.http.wasm.v3.Wasm
+          value:
+            config:
+              configuration:
+                '@type': type.googleapis.com/google.protobuf.StringValue
+                value: |
+                  {}
+              vm_config:
+                code:
+                  local:
+                    inline_string: envoy.wasm.metadata_exchange
+                runtime: envoy.wasm.runtime.null
+---
+apiVersion: networking.istio.io/v1alpha3
+kind: EnvoyFilter
+metadata:
+  labels:
+    cloudfoundry.org/istio_version: 1.7.1
+    istio.io/rev: default
+  name: stats-filter-1.6
+  namespace: istio-system
+spec:
+  configPatches:
+  - applyTo: HTTP_FILTER
+    match:
+      context: SIDECAR_OUTBOUND
+      listener:
+        filterChain:
+          filter:
+            name: envoy.http_connection_manager
+            subFilter:
+              name: envoy.router
+      proxy:
+        proxyVersion: ^1\.6.*
+    patch:
+      operation: INSERT_BEFORE
+      value:
+        name: istio.stats
+        typed_config:
+          '@type': type.googleapis.com/udpa.type.v1.TypedStruct
+          type_url: type.googleapis.com/envoy.extensions.filters.http.wasm.v3.Wasm
+          value:
+            config:
+              configuration: |
+                {
+                  "debug": "false",
+                  "stat_prefix": "istio"
+                }
+              root_id: stats_outbound
+              vm_config:
+                code:
+                  local:
+                    inline_string: envoy.wasm.stats
+                runtime: envoy.wasm.runtime.null
+                vm_id: stats_outbound
+  - applyTo: HTTP_FILTER
+    match:
+      context: SIDECAR_INBOUND
+      listener:
+        filterChain:
+          filter:
+            name: envoy.http_connection_manager
+            subFilter:
+              name: envoy.router
+      proxy:
+        proxyVersion: ^1\.6.*
+    patch:
+      operation: INSERT_BEFORE
+      value:
+        name: istio.stats
+        typed_config:
+          '@type': type.googleapis.com/udpa.type.v1.TypedStruct
+          type_url: type.googleapis.com/envoy.extensions.filters.http.wasm.v3.Wasm
+          value:
+            config:
+              configuration: |
+                {
+                  "debug": "false",
+                  "stat_prefix": "istio"
+                }
+              root_id: stats_inbound
+              vm_config:
+                code:
+                  local:
+                    inline_string: envoy.wasm.stats
+                runtime: envoy.wasm.runtime.null
+                vm_id: stats_inbound
+  - applyTo: HTTP_FILTER
+    match:
+      context: GATEWAY
+      listener:
+        filterChain:
+          filter:
+            name: envoy.http_connection_manager
+            subFilter:
+              name: envoy.router
+      proxy:
+        proxyVersion: ^1\.6.*
+    patch:
+      operation: INSERT_BEFORE
+      value:
+        name: istio.stats
+        typed_config:
+          '@type': type.googleapis.com/udpa.type.v1.TypedStruct
+          type_url: type.googleapis.com/envoy.extensions.filters.http.wasm.v3.Wasm
+          value:
+            config:
+              configuration: |
+                {
+                  "debug": "false",
+                  "stat_prefix": "istio",
+                  "disable_host_header_fallback": true
+                }
+              root_id: stats_outbound
+              vm_config:
+                code:
+                  local:
+                    inline_string: envoy.wasm.stats
+                runtime: envoy.wasm.runtime.null
+                vm_id: stats_outbound
+---
+apiVersion: networking.istio.io/v1alpha3
+kind: EnvoyFilter
+metadata:
+  labels:
+    cloudfoundry.org/istio_version: 1.7.1
+    istio.io/rev: default
+  name: stats-filter-1.7
+  namespace: istio-system
+spec:
+  configPatches:
+  - applyTo: HTTP_FILTER
+    match:
+      context: SIDECAR_OUTBOUND
+      listener:
+        filterChain:
+          filter:
+            name: envoy.http_connection_manager
+            subFilter:
+              name: envoy.router
+      proxy:
+        proxyVersion: ^1\.7.*
+    patch:
+      operation: INSERT_BEFORE
+      value:
+        name: istio.stats
+        typed_config:
+          '@type': type.googleapis.com/udpa.type.v1.TypedStruct
+          type_url: type.googleapis.com/envoy.extensions.filters.http.wasm.v3.Wasm
+          value:
+            config:
+              configuration:
+                '@type': type.googleapis.com/google.protobuf.StringValue
+                value: |
+                  {
+                    "debug": "false",
+                    "stat_prefix": "istio"
+                  }
+              root_id: stats_outbound
+              vm_config:
+                code:
+                  local:
+                    inline_string: envoy.wasm.stats
+                runtime: envoy.wasm.runtime.null
+                vm_id: stats_outbound
+  - applyTo: HTTP_FILTER
+    match:
+      context: SIDECAR_INBOUND
+      listener:
+        filterChain:
+          filter:
+            name: envoy.http_connection_manager
+            subFilter:
+              name: envoy.router
+      proxy:
+        proxyVersion: ^1\.7.*
+    patch:
+      operation: INSERT_BEFORE
+      value:
+        name: istio.stats
+        typed_config:
+          '@type': type.googleapis.com/udpa.type.v1.TypedStruct
+          type_url: type.googleapis.com/envoy.extensions.filters.http.wasm.v3.Wasm
+          value:
+            config:
+              configuration:
+                '@type': type.googleapis.com/google.protobuf.StringValue
+                value: |
+                  {
+                    "debug": "false",
+                    "stat_prefix": "istio"
+                  }
+              root_id: stats_inbound
+              vm_config:
+                code:
+                  local:
+                    inline_string: envoy.wasm.stats
+                runtime: envoy.wasm.runtime.null
+                vm_id: stats_inbound
+  - applyTo: HTTP_FILTER
+    match:
+      context: GATEWAY
+      listener:
+        filterChain:
+          filter:
+            name: envoy.http_connection_manager
+            subFilter:
+              name: envoy.router
+      proxy:
+        proxyVersion: ^1\.7.*
+    patch:
+      operation: INSERT_BEFORE
+      value:
+        name: istio.stats
+        typed_config:
+          '@type': type.googleapis.com/udpa.type.v1.TypedStruct
+          type_url: type.googleapis.com/envoy.extensions.filters.http.wasm.v3.Wasm
+          value:
+            config:
+              configuration:
+                '@type': type.googleapis.com/google.protobuf.StringValue
+                value: |
+                  {
+                    "debug": "false",
+                    "stat_prefix": "istio",
+                    "disable_host_header_fallback": true
+                  }
+              root_id: stats_outbound
+              vm_config:
+                code:
+                  local:
+                    inline_string: envoy.wasm.stats
+                runtime: envoy.wasm.runtime.null
+                vm_id: stats_outbound
+---
+apiVersion: networking.istio.io/v1alpha3
+kind: EnvoyFilter
+metadata:
+  labels:
+    cloudfoundry.org/istio_version: 1.7.1
+    istio.io/rev: default
+  name: tcp-metadata-exchange-1.6
+  namespace: istio-system
+spec:
+  configPatches:
+  - applyTo: NETWORK_FILTER
+    match:
+      context: SIDECAR_INBOUND
+      listener: {}
+      proxy:
+        proxyVersion: ^1\.6.*
+    patch:
+      operation: INSERT_BEFORE
+      value:
+        name: istio.metadata_exchange
+        typed_config:
+          '@type': type.googleapis.com/udpa.type.v1.TypedStruct
+          type_url: type.googleapis.com/envoy.tcp.metadataexchange.config.MetadataExchange
+          value:
+            protocol: istio-peer-exchange
+  - applyTo: CLUSTER
+    match:
+      cluster: {}
+      context: SIDECAR_OUTBOUND
+      proxy:
+        proxyVersion: ^1\.6.*
+    patch:
+      operation: MERGE
+      value:
+        filters:
+        - name: istio.metadata_exchange
+          typed_config:
+            '@type': type.googleapis.com/udpa.type.v1.TypedStruct
+            type_url: type.googleapis.com/envoy.tcp.metadataexchange.config.MetadataExchange
+            value:
+              protocol: istio-peer-exchange
+  - applyTo: CLUSTER
+    match:
+      cluster: {}
+      context: GATEWAY
+      proxy:
+        proxyVersion: ^1\.6.*
+    patch:
+      operation: MERGE
+      value:
+        filters:
+        - name: istio.metadata_exchange
+          typed_config:
+            '@type': type.googleapis.com/udpa.type.v1.TypedStruct
+            type_url: type.googleapis.com/envoy.tcp.metadataexchange.config.MetadataExchange
+            value:
+              protocol: istio-peer-exchange
+---
+apiVersion: networking.istio.io/v1alpha3
+kind: EnvoyFilter
+metadata:
+  labels:
+    cloudfoundry.org/istio_version: 1.7.1
+    istio.io/rev: default
+  name: tcp-metadata-exchange-1.7
+  namespace: istio-system
+spec:
+  configPatches:
+  - applyTo: NETWORK_FILTER
+    match:
+      context: SIDECAR_INBOUND
+      listener: {}
+      proxy:
+        proxyVersion: ^1\.7.*
+    patch:
+      operation: INSERT_BEFORE
+      value:
+        name: istio.metadata_exchange
+        typed_config:
+          '@type': type.googleapis.com/udpa.type.v1.TypedStruct
+          type_url: type.googleapis.com/envoy.tcp.metadataexchange.config.MetadataExchange
+          value:
+            protocol: istio-peer-exchange
+  - applyTo: CLUSTER
+    match:
+      cluster: {}
+      context: SIDECAR_OUTBOUND
+      proxy:
+        proxyVersion: ^1\.7.*
+    patch:
+      operation: MERGE
+      value:
+        filters:
+        - name: istio.metadata_exchange
+          typed_config:
+            '@type': type.googleapis.com/udpa.type.v1.TypedStruct
+            type_url: type.googleapis.com/envoy.tcp.metadataexchange.config.MetadataExchange
+            value:
+              protocol: istio-peer-exchange
+  - applyTo: CLUSTER
+    match:
+      cluster: {}
+      context: GATEWAY
+      proxy:
+        proxyVersion: ^1\.7.*
+    patch:
+      operation: MERGE
+      value:
+        filters:
+        - name: istio.metadata_exchange
+          typed_config:
+            '@type': type.googleapis.com/udpa.type.v1.TypedStruct
+            type_url: type.googleapis.com/envoy.tcp.metadataexchange.config.MetadataExchange
+            value:
+              protocol: istio-peer-exchange
+---
+apiVersion: networking.istio.io/v1alpha3
+kind: EnvoyFilter
+metadata:
+  labels:
+    cloudfoundry.org/istio_version: 1.7.1
+    istio.io/rev: default
+  name: tcp-stats-filter-1.6
+  namespace: istio-system
+spec:
+  configPatches:
+  - applyTo: NETWORK_FILTER
+    match:
+      context: SIDECAR_INBOUND
+      listener:
+        filterChain:
+          filter:
+            name: envoy.tcp_proxy
+      proxy:
+        proxyVersion: ^1\.6.*
+    patch:
+      operation: INSERT_BEFORE
+      value:
+        name: istio.stats
+        typed_config:
+          '@type': type.googleapis.com/udpa.type.v1.TypedStruct
+          type_url: type.googleapis.com/envoy.extensions.filters.network.wasm.v3.Wasm
+          value:
+            config:
+              configuration: |
+                {
+                  "debug": "false",
+                  "stat_prefix": "istio"
+                }
+              root_id: stats_inbound
+              vm_config:
+                code:
+                  local:
+                    inline_string: envoy.wasm.stats
+                runtime: envoy.wasm.runtime.null
+                vm_id: tcp_stats_inbound
+  - applyTo: NETWORK_FILTER
+    match:
+      context: SIDECAR_OUTBOUND
+      listener:
+        filterChain:
+          filter:
+            name: envoy.tcp_proxy
+      proxy:
+        proxyVersion: ^1\.6.*
+    patch:
+      operation: INSERT_BEFORE
+      value:
+        name: istio.stats
+        typed_config:
+          '@type': type.googleapis.com/udpa.type.v1.TypedStruct
+          type_url: type.googleapis.com/envoy.extensions.filters.network.wasm.v3.Wasm
+          value:
+            config:
+              configuration: |
+                {
+                  "debug": "false",
+                  "stat_prefix": "istio"
+                }
+              root_id: stats_outbound
+              vm_config:
+                code:
+                  local:
+                    inline_string: envoy.wasm.stats
+                runtime: envoy.wasm.runtime.null
+                vm_id: tcp_stats_outbound
+  - applyTo: NETWORK_FILTER
+    match:
+      context: GATEWAY
+      listener:
+        filterChain:
+          filter:
+            name: envoy.tcp_proxy
+      proxy:
+        proxyVersion: ^1\.6.*
+    patch:
+      operation: INSERT_BEFORE
+      value:
+        name: istio.stats
+        typed_config:
+          '@type': type.googleapis.com/udpa.type.v1.TypedStruct
+          type_url: type.googleapis.com/envoy.extensions.filters.network.wasm.v3.Wasm
+          value:
+            config:
+              configuration: |
+                {
+                  "debug": "false",
+                  "stat_prefix": "istio"
+                }
+              root_id: stats_outbound
+              vm_config:
+                code:
+                  local:
+                    inline_string: envoy.wasm.stats
+                runtime: envoy.wasm.runtime.null
+                vm_id: tcp_stats_outbound
+---
+apiVersion: networking.istio.io/v1alpha3
+kind: EnvoyFilter
+metadata:
+  labels:
+    cloudfoundry.org/istio_version: 1.7.1
+    istio.io/rev: default
+  name: tcp-stats-filter-1.7
+  namespace: istio-system
+spec:
+  configPatches:
+  - applyTo: NETWORK_FILTER
+    match:
+      context: SIDECAR_INBOUND
+      listener:
+        filterChain:
+          filter:
+            name: envoy.tcp_proxy
+      proxy:
+        proxyVersion: ^1\.7.*
+    patch:
+      operation: INSERT_BEFORE
+      value:
+        name: istio.stats
+        typed_config:
+          '@type': type.googleapis.com/udpa.type.v1.TypedStruct
+          type_url: type.googleapis.com/envoy.extensions.filters.network.wasm.v3.Wasm
+          value:
+            config:
+              configuration:
+                '@type': type.googleapis.com/google.protobuf.StringValue
+                value: |
+                  {
+                    "debug": "false",
+                    "stat_prefix": "istio"
+                  }
+              root_id: stats_inbound
+              vm_config:
+                code:
+                  local:
+                    inline_string: envoy.wasm.stats
+                runtime: envoy.wasm.runtime.null
+                vm_id: tcp_stats_inbound
+  - applyTo: NETWORK_FILTER
+    match:
+      context: SIDECAR_OUTBOUND
+      listener:
+        filterChain:
+          filter:
+            name: envoy.tcp_proxy
+      proxy:
+        proxyVersion: ^1\.7.*
+    patch:
+      operation: INSERT_BEFORE
+      value:
+        name: istio.stats
+        typed_config:
+          '@type': type.googleapis.com/udpa.type.v1.TypedStruct
+          type_url: type.googleapis.com/envoy.extensions.filters.network.wasm.v3.Wasm
+          value:
+            config:
+              configuration:
+                '@type': type.googleapis.com/google.protobuf.StringValue
+                value: |
+                  {
+                    "debug": "false",
+                    "stat_prefix": "istio"
+                  }
+              root_id: stats_outbound
+              vm_config:
+                code:
+                  local:
+                    inline_string: envoy.wasm.stats
+                runtime: envoy.wasm.runtime.null
+                vm_id: tcp_stats_outbound
+  - applyTo: NETWORK_FILTER
+    match:
+      context: GATEWAY
+      listener:
+        filterChain:
+          filter:
+            name: envoy.tcp_proxy
+      proxy:
+        proxyVersion: ^1\.7.*
+    patch:
+      operation: INSERT_BEFORE
+      value:
+        name: istio.stats
+        typed_config:
+          '@type': type.googleapis.com/udpa.type.v1.TypedStruct
+          type_url: type.googleapis.com/envoy.extensions.filters.network.wasm.v3.Wasm
+          value:
+            config:
+              configuration:
+                '@type': type.googleapis.com/google.protobuf.StringValue
+                value: |
+                  {
+                    "debug": "false",
+                    "stat_prefix": "istio"
+                  }
+              root_id: stats_outbound
+              vm_config:
+                code:
+                  local:
+                    inline_string: envoy.wasm.stats
+                runtime: envoy.wasm.runtime.null
+                vm_id: tcp_stats_outbound
 ---
 apiVersion: v1
 data:
@@ -5768,191 +7748,26 @@ data:
         "x_forwarded_proto": "%REQ(X-FORWARDED-PROTO)%"
       }
     defaultConfig:
-      concurrency: 2
-      configPath: ./etc/istio/proxy
-      connectTimeout: 10s
-      controlPlaneAuthPolicy: NONE
       discoveryAddress: istiod.istio-system.svc:15012
-      drainDuration: 45s
-      parentShutdownDuration: 1m0s
-      proxyAdminPort: 15000
       proxyMetadata:
         DNS_AGENT: ""
-      serviceCluster: istio-proxy
       tracing:
         zipkin:
           address: zipkin.istio-system:9411
     disableMixerHttpReports: true
-    disablePolicyChecks: true
     enableAutoMtls: true
-    enablePrometheusMerge: false
-    ingressClass: istio
-    ingressControllerMode: STRICT
-    ingressService: istio-ingressgateway
-    protocolDetectionTimeout: 100ms
-    reportBatchMaxEntries: 100
-    reportBatchMaxTime: 1s
-    sdsUdsPath: unix:/etc/istio/proxy/SDS
+    enablePrometheusMerge: true
+    rootNamespace: istio-system
     trustDomain: cluster.local
-    trustDomainAliases: null
   meshNetworks: 'networks: {}'
 kind: ConfigMap
 metadata:
   labels:
-    cloudfoundry.org/istio_version: 1.6.4
+    cloudfoundry.org/istio_version: 1.7.1
     istio.io/rev: default
     release: istio
   name: istio
   namespace: istio-system
----
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  annotations:
-    kbld.k14s.io/images: |
-      - Metas:
-        - Tag: 1.6.4
-          Type: resolved
-          URL: gcr.io/cf-routing/pilot:1.6.4
-        URL: gcr.io/cf-routing/pilot@sha256:0516ef03cc2fb03e0202c7d08e73ffc761caad6946b664bd9ad1814020462c09
-  labels:
-    app: istiod
-    cloudfoundry.org/istio_version: 1.6.4
-    istio: pilot
-    istio.io/rev: default
-    release: istio
-  name: istiod
-  namespace: istio-system
-spec:
-  selector:
-    matchLabels:
-      istio: pilot
-  strategy:
-    rollingUpdate:
-      maxSurge: 100%
-      maxUnavailable: 25%
-  template:
-    metadata:
-      annotations:
-        sidecar.istio.io/inject: "false"
-      labels:
-        app: istiod
-        cloudfoundry.org/istio_version: 1.6.4
-        istio: pilot
-        istio.io/rev: default
-    spec:
-      containers:
-      - args:
-        - discovery
-        - --monitoringAddr=:15014
-        - --log_output_level=default:info
-        - --domain
-        - cluster.local
-        - --trust-domain=cluster.local
-        - --keepaliveMaxServerConnectionAge
-        - 30m
-        env:
-        - name: REVISION
-          value: default
-        - name: JWT_POLICY
-          value: third-party-jwt
-        - name: PILOT_CERT_PROVIDER
-          value: istiod
-        - name: POD_NAME
-          valueFrom:
-            fieldRef:
-              apiVersion: v1
-              fieldPath: metadata.name
-        - name: POD_NAMESPACE
-          valueFrom:
-            fieldRef:
-              apiVersion: v1
-              fieldPath: metadata.namespace
-        - name: SERVICE_ACCOUNT
-          valueFrom:
-            fieldRef:
-              apiVersion: v1
-              fieldPath: spec.serviceAccountName
-        - name: PILOT_TRACE_SAMPLING
-          value: "1"
-        - name: PILOT_ENABLE_PROTOCOL_SNIFFING_FOR_OUTBOUND
-          value: "true"
-        - name: PILOT_ENABLE_PROTOCOL_SNIFFING_FOR_INBOUND
-          value: "true"
-        - name: INJECTION_WEBHOOK_CONFIG_NAME
-          value: istio-sidecar-injector
-        - name: ISTIOD_ADDR
-          value: istiod.istio-system.svc:15012
-        - name: PILOT_ENABLE_ANALYSIS
-          value: "false"
-        - name: CLUSTER_ID
-          value: Kubernetes
-        - name: CENTRAL_ISTIOD
-          value: "false"
-        image: gcr.io/cf-routing/pilot@sha256:0516ef03cc2fb03e0202c7d08e73ffc761caad6946b664bd9ad1814020462c09
-        name: discovery
-        ports:
-        - containerPort: 8080
-        - containerPort: 15010
-        - containerPort: 15017
-        - containerPort: 15053
-        readinessProbe:
-          httpGet:
-            path: /ready
-            port: 8080
-          initialDelaySeconds: 1
-          periodSeconds: 3
-          timeoutSeconds: 5
-        resources:
-          requests:
-            cpu: 500m
-            memory: 2048Mi
-        securityContext:
-          capabilities:
-            drop:
-            - ALL
-          runAsGroup: 1337
-          runAsNonRoot: true
-          runAsUser: 1337
-        volumeMounts:
-        - mountPath: /etc/istio/config
-          name: config-volume
-        - mountPath: /var/run/secrets/tokens
-          name: istio-token
-          readOnly: true
-        - mountPath: /var/run/secrets/istio-dns
-          name: local-certs
-        - mountPath: /etc/cacerts
-          name: cacerts
-          readOnly: true
-        - mountPath: /var/lib/istio/inject
-          name: inject
-          readOnly: true
-      securityContext:
-        fsGroup: 1337
-      serviceAccountName: istiod-service-account
-      volumes:
-      - emptyDir:
-          medium: Memory
-        name: local-certs
-      - name: istio-token
-        projected:
-          sources:
-          - serviceAccountToken:
-              audience: istio-ca
-              expirationSeconds: 43200
-              path: istio-token
-      - name: cacerts
-        secret:
-          optional: true
-          secretName: cacerts
-      - configMap:
-          name: istio-sidecar-injector
-          optional: true
-        name: inject
-      - configMap:
-          name: istio
-        name: config-volume
 ---
 apiVersion: v1
 data:
@@ -5995,7 +7810,15 @@ data:
         - "-b"
         - "{{ annotation .ObjectMeta `traffic.sidecar.istio.io/includeInboundPorts` `*` }}"
         - "-d"
+      {{- if excludeInboundPort (annotation .ObjectMeta `status.sidecar.istio.io/port` .Values.global.proxy.statusPort) (annotation .ObjectMeta `traffic.sidecar.istio.io/excludeInboundPorts` .Values.global.proxy.excludeInboundPorts) }}
         - "15090,15021,{{ excludeInboundPort (annotation .ObjectMeta `status.sidecar.istio.io/port` .Values.global.proxy.statusPort) (annotation .ObjectMeta `traffic.sidecar.istio.io/excludeInboundPorts` .Values.global.proxy.excludeInboundPorts) }}"
+      {{- else }}
+        - "15090,15021"
+      {{- end }}
+        {{ if or (isset .ObjectMeta.Annotations `traffic.sidecar.istio.io/includeOutboundPorts`) (ne (valueOrDefault .Values.global.proxy.includeOutboundPorts "") "") -}}
+        - "-q"
+        - "{{ annotation .ObjectMeta `traffic.sidecar.istio.io/includeOutboundPorts` .Values.global.proxy.includeOutboundPorts }}"
+        {{ end -}}
         {{ if or (isset .ObjectMeta.Annotations `traffic.sidecar.istio.io/excludeOutboundPorts`) (ne (valueOrDefault .Values.global.proxy.excludeOutboundPorts "") "") -}}
         - "-o"
         - "{{ annotation .ObjectMeta `traffic.sidecar.istio.io/excludeOutboundPorts` .Values.global.proxy.excludeOutboundPorts }}"
@@ -6009,12 +7832,14 @@ data:
         - "--skip-rule-apply"
         {{ end -}}
         imagePullPolicy: "{{ valueOrDefault .Values.global.imagePullPolicy `Always` }}"
-      {{- if .Values.global.proxy_init.resources }}
+      {{- if .ProxyConfig.ProxyMetadata }}
         env:
         {{- range $key, $value := .ProxyConfig.ProxyMetadata }}
         - name: {{ $key }}
           value: "{{ $value }}"
         {{- end }}
+      {{- end }}
+      {{- if .Values.global.proxy_init.resources }}
         resources:
           {{ toYaml .Values.global.proxy_init.resources | indent 4 }}
       {{- else }}
@@ -6104,20 +7929,26 @@ data:
       {{- if .Values.global.logAsJson }}
         - --log_as_json
       {{- end }}
-      {{- if gt .ProxyConfig.Concurrency 0 }}
+      {{- if gt .ProxyConfig.Concurrency.GetValue 0 }}
         - --concurrency
-        - "{{ .ProxyConfig.Concurrency }}"
+        - "{{ .ProxyConfig.Concurrency.GetValue }}"
       {{- end -}}
       {{- if .Values.global.proxy.lifecycle }}
         lifecycle:
           {{ toYaml .Values.global.proxy.lifecycle | indent 4 }}
-        {{- end }}
+      {{- else if .Values.global.proxy.holdApplicationUntilProxyStarts}}
+        lifecycle:
+          postStart:
+            exec:
+              command:
+              - pilot-agent
+              - wait
+      {{- end }}
         env:
         - name: JWT_POLICY
           value: {{ .Values.global.jwtPolicy }}
         - name: PILOT_CERT_PROVIDER
           value: {{ .Values.global.pilotCertProvider }}
-        # Temp, pending PR to make it default or based on the istiodAddr env
         - name: CA_ADDR
         {{- if .Values.global.caAddress }}
           value: {{ .Values.global.caAddress }}
@@ -6169,13 +8000,7 @@ data:
             {{- end}}
             ]
         - name: ISTIO_META_APP_CONTAINERS
-          value: |-
-            [
-              {{- range $index, $container := .Spec.Containers }}
-                {{- if ne $index 0}},{{- end}}
-                {{ $container.Name }}
-              {{- end}}
-            ]
+          value: "{{- range $index, $container := .Spec.Containers }}{{- if ne $index 0}},{{- end}}{{ $container.Name }}{{- end}}"
         - name: ISTIO_META_CLUSTER_ID
           value: "{{ valueOrDefault .Values.global.multiCluster.clusterName `Kubernetes` }}"
         - name: ISTIO_META_INTERCEPTION_MODE
@@ -6315,6 +8140,12 @@ data:
           {{ toYaml $value | indent 4 }}
           {{ end }}
           {{- end }}
+      {{- if .ProxyConfig.ProxyMetadata.ISTIO_META_DNS_CAPTURE }}
+      dnsConfig:
+        options:
+        - name: "ndots"
+          value: "4"
+      {{- end }}
       volumes:
       {{- if (isset .ObjectMeta.Annotations `sidecar.istio.io/bootstrapOverride`) }}
       - name: custom-bootstrap-volume
@@ -6393,6 +8224,9 @@ data:
         traffic.sidecar.istio.io/excludeOutboundIPRanges: "{{ annotation .ObjectMeta `traffic.sidecar.istio.io/excludeOutboundIPRanges` .Values.global.proxy.excludeIPRanges }}"
         traffic.sidecar.istio.io/includeInboundPorts: "{{ annotation .ObjectMeta `traffic.sidecar.istio.io/includeInboundPorts` (includeInboundPorts .Spec.Containers) }}"
         traffic.sidecar.istio.io/excludeInboundPorts: "{{ excludeInboundPort (annotation .ObjectMeta `status.sidecar.istio.io/port` .Values.global.proxy.statusPort) (annotation .ObjectMeta `traffic.sidecar.istio.io/excludeInboundPorts` .Values.global.proxy.excludeInboundPorts) }}"
+      {{ if or (isset .ObjectMeta.Annotations `traffic.sidecar.istio.io/includeOutboundPorts`) (ne (valueOrDefault .Values.global.proxy.includeOutboundPorts "") "") }}
+        traffic.sidecar.istio.io/includeOutboundPorts: "{{ annotation .ObjectMeta `traffic.sidecar.istio.io/includeOutboundPorts` .Values.global.proxy.includeOutboundPorts }}"
+      {{- end }}
       {{ if or (isset .ObjectMeta.Annotations `traffic.sidecar.istio.io/excludeOutboundPorts`) (ne .Values.global.proxy.excludeOutboundPorts "") }}
         traffic.sidecar.istio.io/excludeOutboundPorts: "{{ annotation .ObjectMeta `traffic.sidecar.istio.io/excludeOutboundPorts` .Values.global.proxy.excludeOutboundPorts }}"
       {{- end }}
@@ -6411,9 +8245,11 @@ data:
           "ppc64le": 2,
           "s390x": 2
         },
-        "configNamespace": "istio-system",
+        "caAddress": "",
+        "centralIstiod": false,
         "configValidation": true,
         "controlPlaneSecurityEnabled": true,
+        "createRemoteSvcEndpoints": false,
         "defaultNodeSelector": {},
         "defaultPodDisruptionBudget": {
           "enabled": true
@@ -6430,8 +8266,7 @@ data:
         "imagePullSecrets": [],
         "istioNamespace": "istio-system",
         "istiod": {
-          "enableAnalysis": false,
-          "enabled": true
+          "enableAnalysis": false
         },
         "jwtPolicy": "third-party-jwt",
         "logAsJson": false,
@@ -6442,6 +8277,7 @@ data:
           "enabled": false,
           "useILB": false
         },
+        "meshID": "",
         "meshNetworks": {},
         "mountMtlsCerts": false,
         "multiCluster": {
@@ -6456,19 +8292,15 @@ data:
         "pilotCertProvider": "istiod",
         "policyNamespace": "istio-system",
         "priorityClassName": "",
-        "prometheusNamespace": "istio-system",
         "proxy": {
-          "accessLogEncoding": "JSON",
           "autoInject": "enabled",
           "clusterDomain": "cluster.local",
           "componentLogLevel": "misc:error",
           "enableCoreDump": false,
-          "envoyStatsd": {
-            "enabled": false
-          },
           "excludeIPRanges": "",
           "excludeInboundPorts": "",
           "excludeOutboundPorts": "",
+          "holdApplicationUntilProxyStarts": false,
           "image": "proxyv2",
           "includeIPRanges": "*",
           "logLevel": "warning",
@@ -6493,8 +8325,8 @@ data:
           "image": "proxyv2",
           "resources": {
             "limits": {
-              "cpu": "100m",
-              "memory": "50Mi"
+              "cpu": "2000m",
+              "memory": "1024Mi"
             },
             "requests": {
               "cpu": "10m",
@@ -6502,16 +8334,18 @@ data:
             }
           }
         },
+        "remotePilotAddress": "",
+        "remotePolicyAddress": "",
+        "remoteTelemetryAddress": "",
         "sds": {
           "token": {
             "aud": "istio-ca"
           }
         },
-        "securityNamespace": "istio-system",
         "sts": {
           "servicePort": 0
         },
-        "tag": "1.6.4",
+        "tag": "1.7.1",
         "telemetryNamespace": "istio-system",
         "tracer": {
           "datadog": {
@@ -6541,10 +8375,8 @@ data:
       "sidecarInjectorWebhook": {
         "alwaysInjectSelector": [],
         "enableNamespacesByDefault": false,
-        "enabled": false,
         "injectLabel": "istio-injection",
         "injectedAnnotations": {},
-        "namespace": "istio-system",
         "neverInjectSelector": [],
         "objectSelector": {
           "autoInject": true,
@@ -6556,7 +8388,7 @@ data:
 kind: ConfigMap
 metadata:
   labels:
-    cloudfoundry.org/istio_version: 1.6.4
+    cloudfoundry.org/istio_version: 1.7.1
     istio.io/rev: default
     release: istio
   name: istio-sidecar-injector
@@ -6567,12 +8399,15 @@ kind: MutatingWebhookConfiguration
 metadata:
   labels:
     app: sidecar-injector
-    cloudfoundry.org/istio_version: 1.6.4
+    cloudfoundry.org/istio_version: 1.7.1
     istio.io/rev: default
     release: istio
   name: istio-sidecar-injector
 webhooks:
-- clientConfig:
+- admissionReviewVersions:
+  - v1beta1
+  - v1
+  clientConfig:
     service:
       name: istiod
       namespace: istio-system
@@ -6593,6 +8428,460 @@ webhooks:
     - pods
   sideEffects: None
 ---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  annotations:
+    kbld.k14s.io/images: |
+      - Metas:
+        - Tag: 1.7.1
+          Type: resolved
+          URL: gcr.io/cf-routing/proxyv2:1.7.1
+        URL: gcr.io/cf-routing/proxyv2@sha256:196c444fb59d1bb0f612c378691071c53b1157503e0a0772bc43192b160a0255
+  labels:
+    app: istio-ingressgateway
+    cloudfoundry.org/istio_version: 1.7.1
+    istio: ingressgateway
+    release: istio
+  name: istio-ingressgateway
+  namespace: istio-system
+spec:
+  selector:
+    matchLabels:
+      app: istio-ingressgateway
+      istio: ingressgateway
+  template:
+    metadata:
+      annotations:
+        prometheus.io/path: /stats/prometheus
+        prometheus.io/port: "15090"
+        prometheus.io/scrape: "true"
+        sidecar.istio.io/inject: "false"
+      labels:
+        app: istio-ingressgateway
+        chart: gateways
+        cloudfoundry.org/istio_version: 1.7.1
+        heritage: Tiller
+        istio: ingressgateway
+        release: istio
+        service.istio.io/canonical-name: istio-ingressgateway
+        service.istio.io/canonical-revision: latest
+    spec:
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - preference:
+              matchExpressions:
+              - key: kubernetes.io/arch
+                operator: In
+                values:
+                - amd64
+            weight: 2
+          - preference:
+              matchExpressions:
+              - key: kubernetes.io/arch
+                operator: In
+                values:
+                - ppc64le
+            weight: 2
+          - preference:
+              matchExpressions:
+              - key: kubernetes.io/arch
+                operator: In
+                values:
+                - s390x
+            weight: 2
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: kubernetes.io/arch
+                operator: In
+                values:
+                - amd64
+                - ppc64le
+                - s390x
+      containers:
+      - args:
+        - proxy
+        - router
+        - --domain
+        - $(POD_NAMESPACE).svc.cluster.local
+        - --proxyLogLevel=warning
+        - --proxyComponentLogLevel=misc:error
+        - --log_output_level=default:info
+        - --serviceCluster
+        - istio-ingressgateway
+        - --trust-domain=cluster.local
+        env:
+        - name: JWT_POLICY
+          value: third-party-jwt
+        - name: PILOT_CERT_PROVIDER
+          value: istiod
+        - name: CA_ADDR
+          value: istiod.istio-system.svc:15012
+        - name: NODE_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: spec.nodeName
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.name
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.namespace
+        - name: INSTANCE_IP
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: status.podIP
+        - name: HOST_IP
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: status.hostIP
+        - name: SERVICE_ACCOUNT
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.serviceAccountName
+        - name: CANONICAL_SERVICE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.labels['service.istio.io/canonical-name']
+        - name: CANONICAL_REVISION
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.labels['service.istio.io/canonical-revision']
+        - name: ISTIO_META_WORKLOAD_NAME
+          value: istio-ingressgateway
+        - name: ISTIO_META_OWNER
+          value: kubernetes://apis/apps/v1/namespaces/istio-system/deployments/istio-ingressgateway
+        - name: ISTIO_META_MESH_ID
+          value: cluster.local
+        - name: ISTIO_META_ROUTER_MODE
+          value: sni-dnat
+        - name: ISTIO_META_CLUSTER_ID
+          value: Kubernetes
+        - name: TERMINATION_DRAIN_DURATION_SECONDS
+          value: "60"
+        image: gcr.io/cf-routing/proxyv2@sha256:196c444fb59d1bb0f612c378691071c53b1157503e0a0772bc43192b160a0255
+        lifecycle:
+          preStop:
+            exec:
+              command:
+              - /bin/bash
+              - -c
+              - sleep 20
+        name: istio-proxy
+        ports:
+        - containerPort: 15021
+        - containerPort: 8080
+          hostPort: 80
+        - containerPort: 8443
+          hostPort: 443
+        - containerPort: 15443
+        - containerPort: 15090
+          name: http-envoy-prom
+          protocol: TCP
+        readinessProbe:
+          failureThreshold: 30
+          httpGet:
+            path: /healthz/ready
+            port: 15021
+            scheme: HTTP
+          initialDelaySeconds: 1
+          periodSeconds: 2
+          successThreshold: 1
+          timeoutSeconds: 1
+        resources:
+          limits:
+            cpu: 2000m
+            memory: 1024Mi
+          requests:
+            cpu: 100m
+            memory: 128Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          privileged: false
+          readOnlyRootFilesystem: true
+        volumeMounts:
+        - mountPath: /etc/istio/proxy
+          name: istio-envoy
+        - mountPath: /etc/istio/config
+          name: config-volume
+        - mountPath: /var/run/secrets/istio
+          name: istiod-ca-cert
+        - mountPath: /var/run/secrets/tokens
+          name: istio-token
+          readOnly: true
+        - mountPath: /var/run/ingress_gateway
+          name: gatewaysdsudspath
+        - mountPath: /etc/istio/pod
+          name: podinfo
+        - mountPath: /etc/istio/ingressgateway-certs
+          name: ingressgateway-certs
+          readOnly: true
+        - mountPath: /etc/istio/ingressgateway-ca-certs
+          name: ingressgateway-ca-certs
+          readOnly: true
+      - image: gcr.io/cf-networking-images/cf-k8s-networking/fluentbit@sha256:9d0f364a682b1903b1230d836d2270f86f29b2904ea5b2b8ee3ea9132a9ab9d7
+        name: fluent-bit
+        resources:
+          limits:
+            cpu: 100m
+            memory: 100Mi
+          requests:
+            cpu: 10m
+            memory: 10Mi
+        volumeMounts:
+        - mountPath: /fluent-bit/etc
+          name: fluent-bit-config
+        - mountPath: /var/log
+          name: varlog
+        - mountPath: /var/lib/docker/containers
+          name: dockercontainers
+          readOnly: true
+      securityContext:
+        fsGroup: 1337
+        runAsGroup: 1337
+        runAsNonRoot: true
+        runAsUser: 1337
+      serviceAccountName: istio-ingressgateway-service-account
+      terminationGracePeriodSeconds: 80
+      volumes:
+      - configMap:
+          name: istio-ca-root-cert
+        name: istiod-ca-cert
+      - downwardAPI:
+          items:
+          - fieldRef:
+              fieldPath: metadata.labels
+            path: labels
+          - fieldRef:
+              fieldPath: metadata.annotations
+            path: annotations
+        name: podinfo
+      - emptyDir: {}
+        name: istio-envoy
+      - emptyDir: {}
+        name: gatewaysdsudspath
+      - name: istio-token
+        projected:
+          sources:
+          - serviceAccountToken:
+              audience: istio-ca
+              expirationSeconds: 43200
+              path: istio-token
+      - configMap:
+          name: istio
+          optional: true
+        name: config-volume
+      - name: ingressgateway-certs
+        secret:
+          optional: true
+          secretName: istio-ingressgateway-certs
+      - name: ingressgateway-ca-certs
+        secret:
+          optional: true
+          secretName: istio-ingressgateway-ca-certs
+      - configMap:
+          name: ingressgateway-fluent-bit-forwarder-config
+        name: fluent-bit-config
+      - hostPath:
+          path: /var/log
+        name: varlog
+      - hostPath:
+          path: /var/lib/docker/containers
+        name: dockercontainers
+  updateStrategy:
+    rollingUpdate:
+      maxUnavailable: 1
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+    kbld.k14s.io/images: |
+      - Metas:
+        - Tag: 1.7.1
+          Type: resolved
+          URL: gcr.io/cf-routing/pilot:1.7.1
+        URL: gcr.io/cf-routing/pilot@sha256:363d1b09d74fa0aa9ce26e25e8fb39c5384e1378a671efbdcdba628682b17dd6
+  labels:
+    app: istiod
+    cloudfoundry.org/istio_version: 1.7.1
+    istio: pilot
+    istio.io/rev: default
+    release: istio
+  name: istiod
+  namespace: istio-system
+spec:
+  selector:
+    matchLabels:
+      istio: pilot
+  strategy:
+    rollingUpdate:
+      maxSurge: 100%
+      maxUnavailable: 25%
+  template:
+    metadata:
+      annotations:
+        prometheus.io/port: "15014"
+        prometheus.io/scrape: "true"
+        sidecar.istio.io/inject: "false"
+      labels:
+        app: istiod
+        cloudfoundry.org/istio_version: 1.7.1
+        istio: pilot
+        istio.io/rev: default
+    spec:
+      containers:
+      - args:
+        - discovery
+        - --monitoringAddr=:15014
+        - --log_output_level=default:info
+        - --domain
+        - cluster.local
+        - --trust-domain=cluster.local
+        - --keepaliveMaxServerConnectionAge
+        - 30m
+        env:
+        - name: REVISION
+          value: default
+        - name: JWT_POLICY
+          value: third-party-jwt
+        - name: PILOT_CERT_PROVIDER
+          value: istiod
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.name
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.namespace
+        - name: SERVICE_ACCOUNT
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: spec.serviceAccountName
+        - name: KUBECONFIG
+          value: /var/run/secrets/remote/config
+        - name: PILOT_TRACE_SAMPLING
+          value: "1"
+        - name: PILOT_ENABLE_PROTOCOL_SNIFFING_FOR_OUTBOUND
+          value: "true"
+        - name: PILOT_ENABLE_PROTOCOL_SNIFFING_FOR_INBOUND
+          value: "true"
+        - name: INJECTION_WEBHOOK_CONFIG_NAME
+          value: istio-sidecar-injector
+        - name: ISTIOD_ADDR
+          value: istiod.istio-system.svc:15012
+        - name: PILOT_ENABLE_ANALYSIS
+          value: "false"
+        - name: CLUSTER_ID
+          value: Kubernetes
+        - name: CENTRAL_ISTIOD
+          value: "false"
+        image: gcr.io/cf-routing/pilot@sha256:363d1b09d74fa0aa9ce26e25e8fb39c5384e1378a671efbdcdba628682b17dd6
+        name: discovery
+        ports:
+        - containerPort: 8080
+        - containerPort: 15010
+        - containerPort: 15017
+        - containerPort: 15053
+        readinessProbe:
+          httpGet:
+            path: /ready
+            port: 8080
+          initialDelaySeconds: 1
+          periodSeconds: 3
+          timeoutSeconds: 5
+        resources:
+          requests:
+            cpu: 500m
+            memory: 2048Mi
+        securityContext:
+          capabilities:
+            drop:
+            - ALL
+          runAsGroup: 1337
+          runAsNonRoot: true
+          runAsUser: 1337
+        volumeMounts:
+        - mountPath: /etc/istio/config
+          name: config-volume
+        - mountPath: /var/run/secrets/tokens
+          name: istio-token
+          readOnly: true
+        - mountPath: /var/run/secrets/istio-dns
+          name: local-certs
+        - mountPath: /etc/cacerts
+          name: cacerts
+          readOnly: true
+        - mountPath: /var/run/secrets/remote
+          name: istio-kubeconfig
+          readOnly: true
+        - mountPath: /var/lib/istio/inject
+          name: inject
+          readOnly: true
+      securityContext:
+        fsGroup: 1337
+      serviceAccountName: istiod-service-account
+      volumes:
+      - emptyDir:
+          medium: Memory
+        name: local-certs
+      - name: istio-token
+        projected:
+          sources:
+          - serviceAccountToken:
+              audience: istio-ca
+              expirationSeconds: 43200
+              path: istio-token
+      - name: cacerts
+        secret:
+          optional: true
+          secretName: cacerts
+      - name: istio-kubeconfig
+        secret:
+          optional: true
+          secretName: istio-kubeconfig
+      - configMap:
+          name: istio-sidecar-injector
+        name: inject
+      - configMap:
+          name: istio
+        name: config-volume
+---
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  annotations:
+    kapp.k14s.io/update-strategy: fallback-on-replace
+  labels:
+    app: istio-ingressgateway
+    cloudfoundry.org/istio_version: 1.7.1
+    istio: ingressgateway
+    release: istio
+  name: istio-ingressgateway
+  namespace: istio-system
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app: istio-ingressgateway
+      istio: ingressgateway
+---
 apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:
@@ -6600,7 +8889,7 @@ metadata:
     kapp.k14s.io/update-strategy: fallback-on-replace
   labels:
     app: istiod
-    cloudfoundry.org/istio_version: 1.6.4
+    cloudfoundry.org/istio_version: 1.7.1
     istio: pilot
     istio.io/rev: default
     release: istio
@@ -6613,12 +8902,169 @@ spec:
       app: istiod
       istio: pilot
 ---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  labels:
+    cloudfoundry.org/istio_version: 1.7.1
+    release: istio
+  name: istio-ingressgateway-sds
+  namespace: istio-system
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+  - watch
+  - list
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  labels:
+    app: istiod
+    cloudfoundry.org/istio_version: 1.7.1
+    release: istio
+  name: istiod-istio-system
+  namespace: istio-system
+rules:
+- apiGroups:
+  - networking.istio.io
+  resources:
+  - gateways
+  verbs:
+  - create
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - create
+  - get
+  - watch
+  - list
+  - update
+  - delete
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  labels:
+    cloudfoundry.org/istio_version: 1.7.1
+    release: istio
+  name: istio-ingressgateway-sds
+  namespace: istio-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: istio-ingressgateway-sds
+subjects:
+- kind: ServiceAccount
+  name: istio-ingressgateway-service-account
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  labels:
+    app: pilot
+    cloudfoundry.org/istio_version: 1.7.1
+    release: istio
+  name: istiod-istio-system
+  namespace: istio-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: istiod-istio-system
+subjects:
+- kind: ServiceAccount
+  name: istiod-service-account
+  namespace: istio-system
+---
+apiVersion: autoscaling/v2beta1
+kind: HorizontalPodAutoscaler
+metadata:
+  labels:
+    app: istio-ingressgateway
+    cloudfoundry.org/istio_version: 1.7.1
+    istio: ingressgateway
+    release: istio
+  name: istio-ingressgateway
+  namespace: istio-system
+spec:
+  maxReplicas: 1
+  metrics:
+  - resource:
+      name: cpu
+      targetAverageUtilization: 80
+    type: Resource
+  minReplicas: 1
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: istio-ingressgateway
+---
+apiVersion: autoscaling/v2beta1
+kind: HorizontalPodAutoscaler
+metadata:
+  labels:
+    app: istiod
+    cloudfoundry.org/istio_version: 1.7.1
+    istio.io/rev: default
+    release: istio
+  name: istiod
+  namespace: istio-system
+spec:
+  maxReplicas: 1
+  metrics:
+  - resource:
+      name: cpu
+      targetAverageUtilization: 80
+    type: Resource
+  minReplicas: 1
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: istiod
+---
+apiVersion: v1
+kind: Service
+metadata:
+  annotations: null
+  labels:
+    app: istio-ingressgateway
+    cloudfoundry.org/istio_version: 1.7.1
+    istio: ingressgateway
+    release: istio
+  name: istio-ingressgateway
+  namespace: istio-system
+spec:
+  externalTrafficPolicy: Local
+  ports:
+  - name: status-port
+    port: 15021
+    targetPort: 15021
+  - name: http2
+    port: 80
+    targetPort: 8080
+  - name: https
+    port: 443
+    targetPort: 8443
+  - name: tls
+    port: 15443
+    targetPort: 15443
+  selector:
+    app: istio-ingressgateway
+    istio: ingressgateway
+  type: LoadBalancer
+---
 apiVersion: v1
 kind: Service
 metadata:
   labels:
     app: istiod
-    cloudfoundry.org/istio_version: 1.6.4
+    cloudfoundry.org/istio_version: 1.7.1
     istio: pilot
     istio.io/rev: default
     release: istio
@@ -6635,10 +9081,6 @@ spec:
     targetPort: 15017
   - name: http-monitoring
     port: 15014
-  - name: dns
-    port: 53
-    protocol: UDP
-    targetPort: 15053
   - name: dns-tls
     port: 853
     protocol: TCP
@@ -6647,747 +9089,18 @@ spec:
     app: istiod
     istio: pilot
 ---
-apiVersion: networking.istio.io/v1alpha3
-kind: EnvoyFilter
-metadata:
-  labels:
-    cloudfoundry.org/istio_version: 1.6.4
-    istio.io/rev: default
-  name: metadata-exchange-1.4
-  namespace: istio-system
-spec:
-  configPatches:
-  - applyTo: HTTP_FILTER
-    match:
-      context: ANY
-      listener:
-        filterChain:
-          filter:
-            name: envoy.http_connection_manager
-      proxy:
-        proxyVersion: ^1\.4.*
-    patch:
-      operation: INSERT_BEFORE
-      value:
-        config:
-          config:
-            configuration: envoy.wasm.metadata_exchange
-            vm_config:
-              code:
-                inline_string: envoy.wasm.metadata_exchange
-              runtime: envoy.wasm.runtime.null
-        name: envoy.filters.http.wasm
----
-apiVersion: networking.istio.io/v1alpha3
-kind: EnvoyFilter
-metadata:
-  labels:
-    cloudfoundry.org/istio_version: 1.6.4
-    istio.io/rev: default
-  name: stats-filter-1.4
-  namespace: istio-system
-spec:
-  configPatches:
-  - applyTo: HTTP_FILTER
-    match:
-      context: SIDECAR_OUTBOUND
-      listener:
-        filterChain:
-          filter:
-            name: envoy.http_connection_manager
-            subFilter:
-              name: envoy.router
-      proxy:
-        proxyVersion: ^1\.4.*
-    patch:
-      operation: INSERT_BEFORE
-      value:
-        config:
-          config:
-            configuration: |
-              {
-                "debug": "false",
-                "stat_prefix": "istio",
-              }
-            root_id: stats_outbound
-            vm_config:
-              code:
-                inline_string: envoy.wasm.stats
-              runtime: envoy.wasm.runtime.null
-              vm_id: stats_outbound
-        name: envoy.filters.http.wasm
-  - applyTo: HTTP_FILTER
-    match:
-      context: SIDECAR_INBOUND
-      listener:
-        filterChain:
-          filter:
-            name: envoy.http_connection_manager
-            subFilter:
-              name: envoy.router
-      proxy:
-        proxyVersion: ^1\.4.*
-    patch:
-      operation: INSERT_BEFORE
-      value:
-        config:
-          config:
-            configuration: |
-              {
-                "debug": "false",
-                "stat_prefix": "istio",
-              }
-            root_id: stats_inbound
-            vm_config:
-              code:
-                inline_string: envoy.wasm.stats
-              runtime: envoy.wasm.runtime.null
-              vm_id: stats_inbound
-        name: envoy.filters.http.wasm
-  - applyTo: HTTP_FILTER
-    match:
-      context: GATEWAY
-      listener:
-        filterChain:
-          filter:
-            name: envoy.http_connection_manager
-            subFilter:
-              name: envoy.router
-      proxy:
-        proxyVersion: ^1\.4.*
-    patch:
-      operation: INSERT_BEFORE
-      value:
-        config:
-          config:
-            configuration: |
-              {
-                "debug": "false",
-                "stat_prefix": "istio",
-                "disable_host_header_fallback": true,
-              }
-            root_id: stats_outbound
-            vm_config:
-              code:
-                inline_string: envoy.wasm.stats
-              runtime: envoy.wasm.runtime.null
-              vm_id: stats_outbound
-        name: envoy.filters.http.wasm
----
-apiVersion: networking.istio.io/v1alpha3
-kind: EnvoyFilter
-metadata:
-  labels:
-    cloudfoundry.org/istio_version: 1.6.4
-    istio.io/rev: default
-  name: metadata-exchange-1.5
-  namespace: istio-system
-spec:
-  configPatches:
-  - applyTo: HTTP_FILTER
-    match:
-      context: ANY
-      listener:
-        filterChain:
-          filter:
-            name: envoy.http_connection_manager
-      proxy:
-        proxyVersion: ^1\.5.*
-    patch:
-      operation: INSERT_BEFORE
-      value:
-        name: envoy.filters.http.wasm
-        typed_config:
-          '@type': type.googleapis.com/udpa.type.v1.TypedStruct
-          type_url: type.googleapis.com/envoy.config.filter.http.wasm.v2.Wasm
-          value:
-            config:
-              configuration: envoy.wasm.metadata_exchange
-              vm_config:
-                code:
-                  local:
-                    inline_string: envoy.wasm.metadata_exchange
-                runtime: envoy.wasm.runtime.null
----
-apiVersion: networking.istio.io/v1alpha3
-kind: EnvoyFilter
-metadata:
-  labels:
-    cloudfoundry.org/istio_version: 1.6.4
-    istio.io/rev: default
-  name: tcp-metadata-exchange-1.5
-  namespace: istio-system
-spec:
-  configPatches:
-  - applyTo: NETWORK_FILTER
-    match:
-      context: SIDECAR_INBOUND
-      listener: {}
-      proxy:
-        proxyVersion: ^1\.5.*
-    patch:
-      operation: INSERT_BEFORE
-      value:
-        config:
-          protocol: istio-peer-exchange
-        name: envoy.filters.network.metadata_exchange
-  - applyTo: CLUSTER
-    match:
-      cluster: {}
-      context: SIDECAR_OUTBOUND
-      proxy:
-        proxyVersion: ^1\.5.*
-    patch:
-      operation: MERGE
-      value:
-        filters:
-        - name: envoy.filters.network.upstream.metadata_exchange
-          typed_config:
-            '@type': type.googleapis.com/udpa.type.v1.TypedStruct
-            type_url: type.googleapis.com/envoy.tcp.metadataexchange.config.MetadataExchange
-            value:
-              protocol: istio-peer-exchange
-  - applyTo: CLUSTER
-    match:
-      cluster: {}
-      context: GATEWAY
-      proxy:
-        proxyVersion: ^1\.5.*
-    patch:
-      operation: MERGE
-      value:
-        filters:
-        - name: envoy.filters.network.upstream.metadata_exchange
-          typed_config:
-            '@type': type.googleapis.com/udpa.type.v1.TypedStruct
-            type_url: type.googleapis.com/envoy.tcp.metadataexchange.config.MetadataExchange
-            value:
-              protocol: istio-peer-exchange
----
-apiVersion: networking.istio.io/v1alpha3
-kind: EnvoyFilter
-metadata:
-  labels:
-    cloudfoundry.org/istio_version: 1.6.4
-    istio.io/rev: default
-  name: stats-filter-1.5
-  namespace: istio-system
-spec:
-  configPatches:
-  - applyTo: HTTP_FILTER
-    match:
-      context: SIDECAR_OUTBOUND
-      listener:
-        filterChain:
-          filter:
-            name: envoy.http_connection_manager
-            subFilter:
-              name: envoy.router
-      proxy:
-        proxyVersion: ^1\.5.*
-    patch:
-      operation: INSERT_BEFORE
-      value:
-        name: envoy.filters.http.wasm
-        typed_config:
-          '@type': type.googleapis.com/udpa.type.v1.TypedStruct
-          type_url: type.googleapis.com/envoy.config.filter.http.wasm.v2.Wasm
-          value:
-            config:
-              configuration: |
-                {
-                  "debug": "false",
-                  "stat_prefix": "istio",
-                }
-              root_id: stats_outbound
-              vm_config:
-                code:
-                  local:
-                    inline_string: envoy.wasm.stats
-                runtime: envoy.wasm.runtime.null
-                vm_id: stats_outbound
-  - applyTo: HTTP_FILTER
-    match:
-      context: SIDECAR_INBOUND
-      listener:
-        filterChain:
-          filter:
-            name: envoy.http_connection_manager
-            subFilter:
-              name: envoy.router
-      proxy:
-        proxyVersion: ^1\.5.*
-    patch:
-      operation: INSERT_BEFORE
-      value:
-        name: envoy.filters.http.wasm
-        typed_config:
-          '@type': type.googleapis.com/udpa.type.v1.TypedStruct
-          type_url: type.googleapis.com/envoy.config.filter.http.wasm.v2.Wasm
-          value:
-            config:
-              configuration: |
-                {
-                  "debug": "false",
-                  "stat_prefix": "istio",
-                }
-              root_id: stats_inbound
-              vm_config:
-                code:
-                  local:
-                    inline_string: envoy.wasm.stats
-                runtime: envoy.wasm.runtime.null
-                vm_id: stats_inbound
-  - applyTo: HTTP_FILTER
-    match:
-      context: GATEWAY
-      listener:
-        filterChain:
-          filter:
-            name: envoy.http_connection_manager
-            subFilter:
-              name: envoy.router
-      proxy:
-        proxyVersion: ^1\.5.*
-    patch:
-      operation: INSERT_BEFORE
-      value:
-        name: envoy.filters.http.wasm
-        typed_config:
-          '@type': type.googleapis.com/udpa.type.v1.TypedStruct
-          type_url: type.googleapis.com/envoy.config.filter.http.wasm.v2.Wasm
-          value:
-            config:
-              configuration: |
-                {
-                  "debug": "false",
-                  "stat_prefix": "istio",
-                  "disable_host_header_fallback": true,
-                }
-              root_id: stats_outbound
-              vm_config:
-                code:
-                  local:
-                    inline_string: envoy.wasm.stats
-                runtime: envoy.wasm.runtime.null
-                vm_id: stats_outbound
----
-apiVersion: networking.istio.io/v1alpha3
-kind: EnvoyFilter
-metadata:
-  labels:
-    cloudfoundry.org/istio_version: 1.6.4
-    istio.io/rev: default
-  name: tcp-stats-filter-1.5
-  namespace: istio-system
-spec:
-  configPatches:
-  - applyTo: NETWORK_FILTER
-    match:
-      context: SIDECAR_INBOUND
-      listener:
-        filterChain:
-          filter:
-            name: envoy.tcp_proxy
-      proxy:
-        proxyVersion: ^1\.5.*
-    patch:
-      operation: INSERT_BEFORE
-      value:
-        name: envoy.filters.network.wasm
-        typed_config:
-          '@type': type.googleapis.com/udpa.type.v1.TypedStruct
-          type_url: type.googleapis.com/envoy.config.filter.network.wasm.v2.Wasm
-          value:
-            config:
-              configuration: |
-                {
-                  "debug": "false",
-                  "stat_prefix": "istio",
-                }
-              root_id: stats_inbound
-              vm_config:
-                code:
-                  local:
-                    inline_string: envoy.wasm.stats
-                runtime: envoy.wasm.runtime.null
-                vm_id: tcp_stats_inbound
-  - applyTo: NETWORK_FILTER
-    match:
-      context: SIDECAR_OUTBOUND
-      listener:
-        filterChain:
-          filter:
-            name: envoy.tcp_proxy
-      proxy:
-        proxyVersion: ^1\.5.*
-    patch:
-      operation: INSERT_BEFORE
-      value:
-        name: envoy.filters.network.wasm
-        typed_config:
-          '@type': type.googleapis.com/udpa.type.v1.TypedStruct
-          type_url: type.googleapis.com/envoy.config.filter.network.wasm.v2.Wasm
-          value:
-            config:
-              configuration: |
-                {
-                  "debug": "false",
-                  "stat_prefix": "istio",
-                }
-              root_id: stats_outbound
-              vm_config:
-                code:
-                  local:
-                    inline_string: envoy.wasm.stats
-                runtime: envoy.wasm.runtime.null
-                vm_id: tcp_stats_outbound
-  - applyTo: NETWORK_FILTER
-    match:
-      context: GATEWAY
-      listener:
-        filterChain:
-          filter:
-            name: envoy.tcp_proxy
-      proxy:
-        proxyVersion: ^1\.5.*
-    patch:
-      operation: INSERT_BEFORE
-      value:
-        name: envoy.filters.network.wasm
-        typed_config:
-          '@type': type.googleapis.com/udpa.type.v1.TypedStruct
-          type_url: type.googleapis.com/envoy.config.filter.network.wasm.v2.Wasm
-          value:
-            config:
-              configuration: |
-                {
-                  "debug": "false",
-                  "stat_prefix": "istio",
-                }
-              root_id: stats_outbound
-              vm_config:
-                code:
-                  local:
-                    inline_string: envoy.wasm.stats
-                runtime: envoy.wasm.runtime.null
-                vm_id: tcp_stats_outbound
----
-apiVersion: networking.istio.io/v1alpha3
-kind: EnvoyFilter
-metadata:
-  labels:
-    cloudfoundry.org/istio_version: 1.6.4
-    istio.io/rev: default
-  name: metadata-exchange-1.6
-  namespace: istio-system
-spec:
-  configPatches:
-  - applyTo: HTTP_FILTER
-    match:
-      context: ANY
-      listener:
-        filterChain:
-          filter:
-            name: envoy.http_connection_manager
-      proxy:
-        proxyVersion: ^1\.6.*
-    patch:
-      operation: INSERT_BEFORE
-      value:
-        name: istio.metadata_exchange
-        typed_config:
-          '@type': type.googleapis.com/udpa.type.v1.TypedStruct
-          type_url: type.googleapis.com/envoy.extensions.filters.http.wasm.v3.Wasm
-          value:
-            config:
-              configuration: |
-                {}
-              vm_config:
-                code:
-                  local:
-                    inline_string: envoy.wasm.metadata_exchange
-                runtime: envoy.wasm.runtime.null
----
-apiVersion: networking.istio.io/v1alpha3
-kind: EnvoyFilter
-metadata:
-  labels:
-    cloudfoundry.org/istio_version: 1.6.4
-    istio.io/rev: default
-  name: tcp-metadata-exchange-1.6
-  namespace: istio-system
-spec:
-  configPatches:
-  - applyTo: NETWORK_FILTER
-    match:
-      context: SIDECAR_INBOUND
-      listener: {}
-      proxy:
-        proxyVersion: ^1\.6.*
-    patch:
-      operation: INSERT_BEFORE
-      value:
-        name: istio.metadata_exchange
-        typed_config:
-          '@type': type.googleapis.com/udpa.type.v1.TypedStruct
-          type_url: type.googleapis.com/envoy.tcp.metadataexchange.config.MetadataExchange
-          value:
-            protocol: istio-peer-exchange
-  - applyTo: CLUSTER
-    match:
-      cluster: {}
-      context: SIDECAR_OUTBOUND
-      proxy:
-        proxyVersion: ^1\.6.*
-    patch:
-      operation: MERGE
-      value:
-        filters:
-        - name: istio.metadata_exchange
-          typed_config:
-            '@type': type.googleapis.com/udpa.type.v1.TypedStruct
-            type_url: type.googleapis.com/envoy.tcp.metadataexchange.config.MetadataExchange
-            value:
-              protocol: istio-peer-exchange
-  - applyTo: CLUSTER
-    match:
-      cluster: {}
-      context: GATEWAY
-      proxy:
-        proxyVersion: ^1\.6.*
-    patch:
-      operation: MERGE
-      value:
-        filters:
-        - name: istio.metadata_exchange
-          typed_config:
-            '@type': type.googleapis.com/udpa.type.v1.TypedStruct
-            type_url: type.googleapis.com/envoy.tcp.metadataexchange.config.MetadataExchange
-            value:
-              protocol: istio-peer-exchange
----
-apiVersion: networking.istio.io/v1alpha3
-kind: EnvoyFilter
-metadata:
-  labels:
-    cloudfoundry.org/istio_version: 1.6.4
-    istio.io/rev: default
-  name: stats-filter-1.6
-  namespace: istio-system
-spec:
-  configPatches:
-  - applyTo: HTTP_FILTER
-    match:
-      context: SIDECAR_OUTBOUND
-      listener:
-        filterChain:
-          filter:
-            name: envoy.http_connection_manager
-            subFilter:
-              name: envoy.router
-      proxy:
-        proxyVersion: ^1\.6.*
-    patch:
-      operation: INSERT_BEFORE
-      value:
-        name: istio.stats
-        typed_config:
-          '@type': type.googleapis.com/udpa.type.v1.TypedStruct
-          type_url: type.googleapis.com/envoy.extensions.filters.http.wasm.v3.Wasm
-          value:
-            config:
-              configuration: |
-                {
-                  "debug": "false",
-                  "stat_prefix": "istio"
-                }
-              root_id: stats_outbound
-              vm_config:
-                code:
-                  local:
-                    inline_string: envoy.wasm.stats
-                runtime: envoy.wasm.runtime.null
-                vm_id: stats_outbound
-  - applyTo: HTTP_FILTER
-    match:
-      context: SIDECAR_INBOUND
-      listener:
-        filterChain:
-          filter:
-            name: envoy.http_connection_manager
-            subFilter:
-              name: envoy.router
-      proxy:
-        proxyVersion: ^1\.6.*
-    patch:
-      operation: INSERT_BEFORE
-      value:
-        name: istio.stats
-        typed_config:
-          '@type': type.googleapis.com/udpa.type.v1.TypedStruct
-          type_url: type.googleapis.com/envoy.extensions.filters.http.wasm.v3.Wasm
-          value:
-            config:
-              configuration: |
-                {
-                  "debug": "false",
-                  "stat_prefix": "istio"
-                }
-              root_id: stats_inbound
-              vm_config:
-                code:
-                  local:
-                    inline_string: envoy.wasm.stats
-                runtime: envoy.wasm.runtime.null
-                vm_id: stats_inbound
-  - applyTo: HTTP_FILTER
-    match:
-      context: GATEWAY
-      listener:
-        filterChain:
-          filter:
-            name: envoy.http_connection_manager
-            subFilter:
-              name: envoy.router
-      proxy:
-        proxyVersion: ^1\.6.*
-    patch:
-      operation: INSERT_BEFORE
-      value:
-        name: istio.stats
-        typed_config:
-          '@type': type.googleapis.com/udpa.type.v1.TypedStruct
-          type_url: type.googleapis.com/envoy.extensions.filters.http.wasm.v3.Wasm
-          value:
-            config:
-              configuration: |
-                {
-                  "debug": "false",
-                  "stat_prefix": "istio",
-                  "disable_host_header_fallback": true
-                }
-              root_id: stats_outbound
-              vm_config:
-                code:
-                  local:
-                    inline_string: envoy.wasm.stats
-                runtime: envoy.wasm.runtime.null
-                vm_id: stats_outbound
----
-apiVersion: networking.istio.io/v1alpha3
-kind: EnvoyFilter
-metadata:
-  labels:
-    cloudfoundry.org/istio_version: 1.6.4
-    istio.io/rev: default
-  name: tcp-stats-filter-1.6
-  namespace: istio-system
-spec:
-  configPatches:
-  - applyTo: NETWORK_FILTER
-    match:
-      context: SIDECAR_INBOUND
-      listener:
-        filterChain:
-          filter:
-            name: envoy.tcp_proxy
-      proxy:
-        proxyVersion: ^1\.6.*
-    patch:
-      operation: INSERT_BEFORE
-      value:
-        name: istio.stats
-        typed_config:
-          '@type': type.googleapis.com/udpa.type.v1.TypedStruct
-          type_url: type.googleapis.com/envoy.extensions.filters.network.wasm.v3.Wasm
-          value:
-            config:
-              configuration: |
-                {
-                  "debug": "false",
-                  "stat_prefix": "istio"
-                }
-              root_id: stats_inbound
-              vm_config:
-                code:
-                  local:
-                    inline_string: envoy.wasm.stats
-                runtime: envoy.wasm.runtime.null
-                vm_id: tcp_stats_inbound
-  - applyTo: NETWORK_FILTER
-    match:
-      context: SIDECAR_OUTBOUND
-      listener:
-        filterChain:
-          filter:
-            name: envoy.tcp_proxy
-      proxy:
-        proxyVersion: ^1\.6.*
-    patch:
-      operation: INSERT_BEFORE
-      value:
-        name: istio.stats
-        typed_config:
-          '@type': type.googleapis.com/udpa.type.v1.TypedStruct
-          type_url: type.googleapis.com/envoy.extensions.filters.network.wasm.v3.Wasm
-          value:
-            config:
-              configuration: |
-                {
-                  "debug": "false",
-                  "stat_prefix": "istio"
-                }
-              root_id: stats_outbound
-              vm_config:
-                code:
-                  local:
-                    inline_string: envoy.wasm.stats
-                runtime: envoy.wasm.runtime.null
-                vm_id: tcp_stats_outbound
-  - applyTo: NETWORK_FILTER
-    match:
-      context: GATEWAY
-      listener:
-        filterChain:
-          filter:
-            name: envoy.tcp_proxy
-      proxy:
-        proxyVersion: ^1\.6.*
-    patch:
-      operation: INSERT_BEFORE
-      value:
-        name: istio.stats
-        typed_config:
-          '@type': type.googleapis.com/udpa.type.v1.TypedStruct
-          type_url: type.googleapis.com/envoy.extensions.filters.network.wasm.v3.Wasm
-          value:
-            config:
-              configuration: |
-                {
-                  "debug": "false",
-                  "stat_prefix": "istio"
-                }
-              root_id: stats_outbound
-              vm_config:
-                code:
-                  local:
-                    inline_string: envoy.wasm.stats
-                runtime: envoy.wasm.runtime.null
-                vm_id: tcp_stats_outbound
----
 apiVersion: v1
 kind: Namespace
 metadata:
   labels:
-    cloudfoundry.org/istio_version: 1.6.4
+    cloudfoundry.org/istio_version: 1.7.1
   name: istio-system
 ---
 apiVersion: security.istio.io/v1beta1
 kind: PeerAuthentication
 metadata:
   labels:
-    cloudfoundry.org/istio_version: 1.6.4
+    cloudfoundry.org/istio_version: 1.7.1
   name: default
   namespace: istio-system
 spec:

--- a/config/istio/upgrade-istio-sidecars-job.yml
+++ b/config/istio/upgrade-istio-sidecars-job.yml
@@ -1,7 +1,7 @@
 #@ load("@ytt:data", "data")
 
 #@ def build_version():
-#@   return "1.6.4"
+#@   return "1.7.1"
 #@ end
 
 ---


### PR DESCRIPTION
Co-authored-by: Clay Kauzlaric <ckauzlaric@vmware.com>
Co-authored-by: Kauana Dos Santos <kdossantos@vmware.com>

## WHAT is this change about?
Bumping to new version of istio. We had to make a small change in the istio-values. The accessLogEncodings parameter is on the meshConfig struct now, now the Proxyconfig.
[#174638038](https://www.pivotaltracker.com/story/show/174638038)

## Does this PR introduce a change to `config/values.yml`?
No

## Acceptance Steps
```gherkin
Given a deployed cf-for-k8s enviroment
When I inspect pods in the istio-system namespace 
Then I see the label cloudfoundry.org/istio_version: 1.7.0
```

To examine a pod in the `istio-system` namespace, use:
`kubectl get pods -n istio-system <pod-name> -oyaml | grep istio_version`

## Tag your pair, your PM, and/or team
@kauana @ndhanushkodi @keshav-pivotal 
