### PR TITLE
add additional authorities to cf_api_controllers UAA client

### DIFF
--- a/config/uaa/uaa.yml
+++ b/config/uaa/uaa.yml
@@ -132,7 +132,7 @@ oauth:
       authorities: scim.userids
       authorized-grant-types: client_credentials
     cf_api_controllers:
-      authorities: cloud_controller.write,cloud_controller.update_build_state
+      authorities: cloud_controller.write,cloud_controller.read,cloud_controller.update_build_state,cloud_controller.admin_read_only
       authorized-grant-types: client_credentials
   #@overlay/match missing_ok=True
   user:


### PR DESCRIPTION
## WHAT is this change about?
We are in the process of adding a controller to reconcile routes between the Cloud Controller and Kubernetes APIs and the controller needs to be able to read all routes, spaces, and domains on the platform.

CAPI Story: [#174502491](https://www.pivotaltracker.com/story/show/174502491)

## Does this PR introduce a change to `config/values.yml`?
No

## Acceptance Steps
For what it's worth, I tested this against a dev branch of capi-k8s-release and verified that our route sync controller could successfully list routes from the CF API once the client had these authorities. If you want to test it more manually you could...

1. Get the client secret value from your values file from `cf_api_controllers_client_secret`. Save this in `$CLIENT_SECRET`
1. Authenticate with the CF CLI using client credentials: `cf auth cf_api_controllers $CLIENT_SECRET --client-credentials`
1. `cf curl /v3/routes` should succeed

## Tag your pair, your PM, and/or team
@cloudfoundry/cf-capi 
