### PR TITLE
Update Istio sidecar fluent-bit image

### DIFF
--- a/build/istio/values.yaml
+++ b/build/istio/values.yaml
@@ -8,4 +8,4 @@
 istio_version: 1.6.4
 
 fluentbit:
-  image: gcr.io/cf-networking-images/cf-k8s-networking/fluentbit@sha256:9d0f364a682b1903b1230d836d2270f86f29b2904ea5b2b8ee3ea9132a9ab9d7
+  image: gcr.io/cf-networking-images/cf-k8s-networking/fluentbit@sha256:308df04536d069ca56e11c085c887c677147d0b8d42d274f74655737f7317c78

--- a/config/istio/istio-generated/xxx-generated-istio.yaml
+++ b/config/istio/istio-generated/xxx-generated-istio.yaml
@@ -5348,6 +5348,8 @@ kind: DaemonSet
 metadata:
   annotations:
     kbld.k14s.io/images: |
+      - Metas: null
+        URL: gcr.io/cf-networking-images/cf-k8s-networking/fluentbit@sha256:308df04536d069ca56e11c085c887c677147d0b8d42d274f74655737f7317c78
       - Metas:
         - Tag: 1.6.4
           Type: resolved
@@ -5540,7 +5542,7 @@ spec:
         - mountPath: /etc/istio/ingressgateway-ca-certs
           name: ingressgateway-ca-certs
           readOnly: true
-      - image: gcr.io/cf-networking-images/cf-k8s-networking/fluentbit@sha256:9d0f364a682b1903b1230d836d2270f86f29b2904ea5b2b8ee3ea9132a9ab9d7
+      - image: gcr.io/cf-networking-images/cf-k8s-networking/fluentbit@sha256:308df04536d069ca56e11c085c887c677147d0b8d42d274f74655737f7317c78
         name: fluent-bit
         resources:
           limits:


### PR DESCRIPTION
## WHAT is this change about?
Update Istio sidecar's fluent-bit image digest

## Does this PR introduce a change to config/values.yml?
No

## Acceptance Steps
Deploy succeeds and you can view access logs for the apps

## Tag your pair, your PM, and/or team
@cloudfoundry/cf-for-k8s-networking