### PR TITLE
Expect ingressgateway to be either a Deployment or DaemonSet

### DIFF
--- a/build/istio/istioctl-values.yaml
+++ b/build/istio/istioctl-values.yaml
@@ -15,7 +15,7 @@ spec:
             maxReplicas: 1
           service:
             externalTrafficPolicy: Local
-            ports: # TODO: remove when https://github.com/istio/istio/issues/24432 fixed
+            ports: #! TODO: remove when https://github.com/istio/istio/issues/24432 fixed
             - name: status-port
               port: 15021
               targetPort: 15021

--- a/config/istio/external-routing.yml
+++ b/config/istio/external-routing.yml
@@ -27,8 +27,12 @@ data:
   tls.key: #@ data.values.workloads_certificate.key
   tls.crt: #@ data.values.workloads_certificate.crt
 
-#! the following overlay ensures the above Secret is created before the ingressgateway Deployment since we're not using SDS
-#@overlay/match by=overlay.subset({"kind":"DaemonSet","metadata":{"name":"istio-ingressgateway"}})
+#! the following overlay ensures the above Secret is created before the ingressgateway since we're not using SDS
+#! ingressgateway can be either a Deployment or a DaemonSet
+#@ deployment = overlay.subset({"kind": "Deployment", "metadata":{"name":"istio-ingressgateway"}})
+#@ daemonset = overlay.subset({"kind": "DaemonSet", "metadata":{"name":"istio-ingressgateway"}})
+#@ match_ingress_gateway=overlay.or_op(deployment, daemonset)
+#@overlay/match by=match_ingress_gateway
 ---
 metadata:
   #@overlay/match missing_ok=True


### PR DESCRIPTION
- Deployments should be an option too if user wants to scale their cluster up and having an istio-ingressgateway per node is too much.


[#171678788](https://www.pivotaltracker.com/story/show/171678788)

Co-authored-by: Leah Hanson <lhanson@pivotal.io>

## Does this PR introduce a change to `config/values.yml`?
> No. 

## Acceptance Steps
**When** I configure the istio-ingressgateway to be a Deployment
**Then** I expect the deployment to be successful

## Tag your pair, your PM, and/or team
@astrieanna 

