### PR TITLE
Tiny: fix markdown mistake in docs

### DIFF
--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -240,4 +240,4 @@ Use the following resources to enable additional features in cf-for-k8s:
 - [Setup an external blobstore](platform_operators/external-blobstore.md)
 
 ## Roadmap and milestones
-You can find the project roadmap (github project) [here](https://github.com/cloudfoundry/cf-for-k8s/projects/4) and our upcoming milestones [here]](https://github.com/cloudfoundry/cf-for-k8s/milestones). Feel free to ask questions in the [#cf-for-k8s channel](https://cloudfoundry.slack.com/archives/CH9LF6V1P) in the CloudFoundry slack or submit new feature requests or issues on this repo.
+You can find the project roadmap (github project) [here](https://github.com/cloudfoundry/cf-for-k8s/projects/4) and our upcoming milestones [here](https://github.com/cloudfoundry/cf-for-k8s/milestones). Feel free to ask questions in the [#cf-for-k8s channel](https://cloudfoundry.slack.com/archives/CH9LF6V1P) in the CloudFoundry slack or submit new feature requests or issues on this repo.


### PR DESCRIPTION
## WHAT is this change about?
Teeny tiny one character fix to a markdown mistake in the deploy docs.

## Does this PR introduce a change to `config/values.yml`?
No

## Acceptance Steps
When I read the deploy docs on GitHub, the link to the milestones is clickable.