### PR TITLE
Bump capi-k8s-release to fix docker lifecycle apps

### DIFF
--- a/config/capi/_ytt_lib/capi-k8s-release/templates/nginx-configmap.yml
+++ b/config/capi/_ytt_lib/capi-k8s-release/templates/nginx-configmap.yml
@@ -72,7 +72,7 @@ data:
       server {
           listen 9023;
 
-          location /internal/v4/ {
+          location /internal/ {
             access_log  /cloud_controller_ng/nginx-access.log;
             proxy_buffering             off;
             proxy_set_header            Host $host;

--- a/config/capi/_ytt_lib/capi-k8s-release/values/images.yml
+++ b/config/capi/_ytt_lib/capi-k8s-release/values/images.yml
@@ -1,9 +1,9 @@
 #@data/values
 ---
 images:
-  ccng: gcr.io/cf-capi-arya/dev-ccng@sha256:fda89ac251d0b0aa6185b4b46d42a11113fafff4a6aa2fbc99c4227fc14f35b9
-  cf_api_controllers: gcr.io/cf-capi-arya/dev-controllers@sha256:7e63bb428b1bb713a5358c0feb67ae9d04feba216153570e68853257220d05a6
+  ccng: cloudfoundry/cloud-controller-ng@sha256:1146cc37b1ef2d7eaea30e279b6a5483d0d54e145805c20f6d94494992868c64
+  cf_api_controllers: cloudfoundry/cf-api-controllers@sha256:9b9e7205d2c941d984a09e968329cec4af8a003cf1b9a72c19b5ec481d55c8d1
   cf_autodetect_builder: cloudfoundry/cnb:0.0.94-bionic@sha256:5b03a853e636b78c44e475bbc514e2b7b140cc41cca8ab907e9753431ae8c0b0
   nginx: cloudfoundry/capi-nginx@sha256:25997cca011ed0761955754a68931f7b1694e487bffba73c6ac8dbcd084f5dee
-  package_image_uploader: gcr.io/cf-capi-arya/dev-package-image-uploader@sha256:1119b111ede474c1a89ef7c0ba917940e29761162593f71981a119e6b90d5a51
+  package_image_uploader: cloudfoundry/cf-api-package-image-uploader@sha256:aae727a0960d10ce644035dee7041f7e882c7c58a37992252002ce7c95d8804d
   statsd_exporter: oratos/statsd_exporter:v0.15.0@sha256:10a64dc4ad0a3e3fe88372f0481dea5c02595c38d168617836a99a649d3ac407

--- a/vendir.lock.yml
+++ b/vendir.lock.yml
@@ -2,8 +2,8 @@ apiVersion: vendir.k14s.io/v1alpha1
 directories:
 - contents:
   - git:
-      commitTitle: Temporarily use image we built ourselves...
-      sha: e3449f8ecfb6dc3b7b29bf0bbdfdc38e25f78373
+      commitTitle: images.yml updated by CI...
+      sha: 55d974641474c68db77f2f60d1ca3ccbdef2ab17
     path: .
   path: config/capi/_ytt_lib/capi-k8s-release
 - contents:

--- a/vendir.yml
+++ b/vendir.yml
@@ -8,7 +8,7 @@ directories:
   - path: .
     git:
       url: https://github.com/cloudfoundry/capi-k8s-release
-      ref: upgrade-kpack-0.1.2-174413920
+      ref: ci-passed
     includePaths:
     - templates/**/*
     - values/**/*


### PR DESCRIPTION
## WHAT is this change about?
Accidentally regressed functionality in our first attempt to restrict access to CC's internal endpoints which we introduced in an earlier PR. This regression prevents docker lifecycle apps from working (i.e. `cf push dockerapp -o <some_docker_image>`)

It is worth noting that this change updates vendir to revert capi-k8s-release to pointing at our `ci-passed` branch which we originally intended to be consumed before all of our various feature PRs we had recently (using image registry for packages, restricting internal endpoint access, and upgrading to latest kpack). The branch in its current state for this PR includes all the changes from those other PRs still of course as well as the fix for docker lifecycle apps.

## Does this PR introduce a change to `config/values.yml`?
No

## Acceptance Steps
1. Confirm that `cf push buildpackapp` still works and the resulting app is routable
1. Confirm that `cf push dockerapp -o <some_docker_image>` still works and the resulting app is routable

## Tag your pair, your PM, and/or team
@cloudfoundry/cf-capi
