### PR TITLE
Docs: Add information on scaling networking components

### DIFF
--- a/docs/platform_operators/scaling-networking.md
+++ b/docs/platform_operators/scaling-networking.md
@@ -13,6 +13,9 @@ environment, simply:
 1. Adjust the values to your liking
 1. Append `-f scaling-networking.yml` to the ytt command you run for deployment
 
+The number of ingressgateway replicas depends on load profile of your cluster. 
+The number istiod replicas depends istiod replicas the number of application instances.
+
 ```
 #@ load("@ytt:overlay", "overlay")
 #@ load("@ytt:json", "json")

--- a/docs/platform_operators/scaling-networking.md
+++ b/docs/platform_operators/scaling-networking.md
@@ -1,0 +1,126 @@
+# Scaling Networking
+
+## Local Development
+If you would like to scale the networking components of cf-for-k8s to accommodate
+for local development on a laptop, simply deploy following the deployment docs.
+By default, cf-for-k8s is shipped for a kick-the-tires experience.
+
+## Larger Scale Deployments
+If you would like to scale up the networking components for a larger scale
+environment, simply:
+1. Copy the following example into a `scaling-networking.yml` file
+1. Adjust the values to your liking
+1. Append `-f scaling-networking.yml` to the ytt command you run for deployment
+
+```
+#@ load("@ytt:overlay", "overlay")
+#@ load("@ytt:json", "json")
+
+#! Modify these values to adjust scaling characteristics
+
+#@ ingress_replicas = 2
+#@ ingress_cpu_request = "1"
+#@ ingress_cpu_limit = "2"
+#@ ingress_mem_request = "1Gi"
+#@ ingress_mem_limit = "2Gi"
+
+#@ istiod_replicas = 2
+#@ istiod_cpu_request = "1"
+#@ istiod_cpu_limit = "2"
+#@ istiod_mem_request = "1Gi"
+#@ istiod_mem_limit = "2Gi"
+
+#@ routecontroller_replicas = 2
+#@ routecontroller_cpu_request = "200m"
+#@ routecontroller_cpu_limit = "400m"
+#@ routecontroller_mem_request = "32Mi"
+#@ routecontroller_mem_limit = "1024Mi"
+
+#@ sidecar_cpu_request = "100m"
+#@ sidecar_cpu_limit = "2000m"
+#@ sidecar_mem_request = "128Mi"
+#@ sidecar_mem_limit = "1024Mi"
+
+#! DO NOT MODIFY BELOW THIS LINE
+
+#@ def modify_configmap(data):
+#@   decoded = json.decode(data)
+#@   decoded["global"]["proxy"]["resources"] = {
+#@     "limits": {
+#@       "cpu": sidecar_cpu_limit,
+#@       "memory": sidecar_mem_limit,
+#@     },
+#@     "requests": {
+#@       "cpu": sidecar_cpu_request,
+#@       "memory": sidecar_mem_request,
+#@     },
+#@   }
+#@   return json.encode(decoded)
+#@ end
+
+#@overlay/match by=overlay.subset({"kind": "ConfigMap", "metadata":{"name":"istio-sidecar-injector"}}),expects=1
+---
+data:
+  #@overlay/replace via=lambda a,_: modify_configmap(a)
+  values:
+
+#@overlay/match by=overlay.subset({"kind": "DaemonSet", "metadata":{"name":"istio-ingressgateway"}}),expects=1
+---
+#@overlay/replace
+kind: Deployment
+spec:
+  #@overlay/match missing_ok=True
+  replicas: #@ ingress_replicas
+  template:
+    spec:
+      containers:
+      #@overlay/match by="name", expects=1
+      - name: istio-proxy
+        #@overlay/match missing_ok=True
+        resources:
+          limits:
+            cpu: #@ ingress_cpu_limit
+            memory: #@ ingress_mem_limit
+          requests:
+            cpu: #@ ingress_cpu_request
+            memory: #@ ingress_mem_request
+
+#@overlay/match by=overlay.subset({"kind": "Deployment", "metadata":{"name":"istiod"}}),expects=1
+---
+spec:
+  #@overlay/replace
+  replicas: #@ istiod_replicas
+  template:
+    spec:
+      containers:
+      #@overlay/match by="name", expects=1
+      - name: discovery
+        #@overlay/match missing_ok=True
+        #@overlay/replace
+        resources:
+          limits:
+            cpu: #@ istiod_cpu_limit
+            memory: #@ istiod_mem_limit
+          requests:
+            cpu: #@ istiod_cpu_request
+            memory: #@ istiod_mem_request
+
+#@overlay/match by=overlay.subset({"kind": "Deployment", "metadata": { "name": "routecontroller"}}),expects=1
+---
+spec:
+  #@overlay/replace
+  replicas: #@ routecontroller_replicas
+  template:
+    spec:
+      containers:
+      #@overlay/match by="name", expects=1
+      - name: routecontroller
+        #@overlay/match missing_ok=True
+        resources:
+          limits:
+            cpu: #@ routecontroller_cpu_limit
+            memory: #@ routecontroller_mem_limit
+          requests:
+            cpu: #@ routecontroller_cpu_request
+            memory: #@ routecontroller_mem_request
+```

--- a/docs/platform_operators/scaling-networking.md
+++ b/docs/platform_operators/scaling-networking.md
@@ -1,7 +1,7 @@
 # Scaling Networking
 
 ## Local Development
-If you would like cf-for-k8s to be right-sized for local development on a laptop, 
+If you would like cf-for-k8s to be right-sized for local development on a laptop,
 you can ignore this page and follow the regular deployment docs as by default
 cf-for-k8s is configured for a small footprint deployment. This documentation
 describes how to scale the cf-for-k8s networking components for production use cases.
@@ -13,8 +13,14 @@ environment, simply:
 1. Adjust the values to your liking
 1. Append `-f scaling-networking.yml` to the ytt command you run for deployment
 
-The number of ingressgateway replicas depends on load profile of your cluster. 
-The number istiod replicas depends istiod replicas the number of application instances.
+The number of ingressgateway replicas depends on load profile of your cluster.
+
+The number istiod replicas depends on the number of application instances.
+
+We recommend two routecontrollers for high availability, but you likely won't
+need more than that.
+
+Sidecar resource usage depends on the load profile of your AIs.
 
 ```
 #@ load("@ytt:overlay", "overlay")
@@ -22,11 +28,11 @@ The number istiod replicas depends istiod replicas the number of application ins
 
 #! Modify these values to adjust scaling characteristics
 
-#@ ingress_replicas = 2
-#@ ingress_cpu_request = "1"
-#@ ingress_cpu_limit = "2"
-#@ ingress_mem_request = "1Gi"
-#@ ingress_mem_limit = "2Gi"
+#@ ingress_gateway_replicas = 2
+#@ ingress_gateway_cpu_request = "1"
+#@ ingress_gateway_cpu_limit = "2"
+#@ ingress_gateway_mem_request = "1Gi"
+#@ ingress_gateway_mem_limit = "2Gi"
 
 #@ istiod_replicas = 2
 #@ istiod_cpu_request = "1"
@@ -74,7 +80,7 @@ data:
 kind: Deployment
 spec:
   #@overlay/match missing_ok=True
-  replicas: #@ ingress_replicas
+  replicas: #@ ingress_gateway_replicas
   template:
     spec:
       containers:
@@ -83,11 +89,11 @@ spec:
         #@overlay/match missing_ok=True
         resources:
           limits:
-            cpu: #@ ingress_cpu_limit
-            memory: #@ ingress_mem_limit
+            cpu: #@ ingress_gateway_cpu_limit
+            memory: #@ ingress_gateway_mem_limit
           requests:
-            cpu: #@ ingress_cpu_request
-            memory: #@ ingress_mem_request
+            cpu: #@ ingress_gateway_cpu_request
+            memory: #@ ingress_gateway_mem_request
 
 #@overlay/match by=overlay.subset({"kind": "Deployment", "metadata":{"name":"istiod"}}),expects=1
 ---

--- a/docs/platform_operators/scaling-networking.md
+++ b/docs/platform_operators/scaling-networking.md
@@ -22,7 +22,7 @@ need more than that.
 
 Sidecar resource usage depends on the load profile of your AIs.
 
-```
+```yaml
 #@ load("@ytt:overlay", "overlay")
 #@ load("@ytt:json", "json")
 

--- a/docs/platform_operators/scaling-networking.md
+++ b/docs/platform_operators/scaling-networking.md
@@ -1,9 +1,10 @@
 # Scaling Networking
 
 ## Local Development
-If you would like to scale the networking components of cf-for-k8s to accommodate
-for local development on a laptop, simply deploy following the deployment docs.
-By default, cf-for-k8s is shipped for a kick-the-tires experience.
+If you would like cf-for-k8s to be right-sized for local development on a laptop, 
+you can ignore this page and follow the regular deployment docs as by default
+cf-for-k8s is configured for a small footprint deployment. This documentation
+describes how to scale the cf-for-k8s networking components for production use cases.
 
 ## Larger Scale Deployments
 If you would like to scale up the networking components for a larger scale


### PR DESCRIPTION
## WHAT is this change about?
We are adding a doc to explain how operators might write an overlay to scale networking components. We include an example overlay file and encourage it's use.

We would appreciate your feedback on this. Is this what you are looking for, based on the conclusions in this [doc](https://docs.google.com/document/d/1VwOdsKXUhC47Xw7Cutj7Fx-NuYTSV-diZB8Qkt61xfw/edit#heading=h.jrqmnlxmgtza)?

[#174613651](https://www.pivotaltracker.com/story/show/174613651)

## Does this PR introduce a change to `config/values.yml`?
No

## Acceptance Steps
```gherkin
Given cf-for-k8s repo
When I look at platform operator docs
Then I see a document on how to scale networking components
```

## Tag your pair, your PM, and/or team
@XanderStrike @cloudfoundry/cf-for-k8s-networking 