### PR TITLE
add networking metrics docs

### DIFF
--- a/docs/platform_operators/networking-metrics.md
+++ b/docs/platform_operators/networking-metrics.md
@@ -1,0 +1,63 @@
+# Networking Metrics
+
+The networking plane emits several useful metrics that can be used to understand
+the health of the platform. These metrics can be consumed by Prometheus and
+graphed with Grafana, but the installation and configuration of those tools are
+outside of the scope of this document.
+
+## Istio Emitted Metrics
+
+More information on Istio metrics can be found
+[here](https://istio.io/latest/docs/reference/config/policy-and-telemetry/metrics/).
+
+Here are the most relevant:
+
+* `istio_requests_total` (integer) -- Total number of requests
+* `istio_request_duration` (histogram) -- Duration of requests
+* `istio_request_bytes` (histogram) -- Size of requests
+* `istio_response_bytes` (histogram) -- Size of responses
+
+## Envoy Emitted Metrics
+
+Note that these metrics are emitted for both the ingress gateways, and the
+sidecars, so they will need to be filtered.
+
+The full list of metrics envoy supports are listed
+[here](https://www.envoyproxy.io/docs/envoy/latest/configuration/upstream/cluster_manager/cluster_stats),
+however Envoy as configured by Istio does not emit all of those listed.
+
+Here are a few we find valuable:
+
+* `envoy_cluster_upstream_rq_<status word>` (integer) -- Number of requests in that
+  status (i.e. `cancelled`, `completed`, `total`)
+* `envoy_cluster_upstream_rq_<http status code>` (integer) -- Number of requests
+  that had that status code (i.e. `200`, `404`, `503`)
+
+## General resource metrics that may be valuable
+
+As you might expect, data and control plane components emit the standard set of
+resource usage metrics, including the following
+
+* `container_cpu_usage_seconds` (integer)
+* `container_memory_usage_bytes` (integer)
+
+## Sample Prometheus Queries
+
+P95 Request duration:
+```
+histogram_quantile(0.95, sum(rate(istio_request_duration_milliseconds_bucket[5m])) by (le))
+```
+
+Global requests per second:
+```
+round(sum(irate(istio_requests_total{reporter="destination"}[1m])), 0.001)
+```
+
+CPU Usage per 1k requests per second for ingressgateways
+```
+(sum(irate(container_cpu_usage_seconds_total{pod=~"istio-ingressgateway-.*",container="istio-proxy"}[1m])) / (round(sum(irate(istio_requests_total{source_workload="istio-ingressgateway", reporter="source"}[1m])), 0.001)/1000))
+```
+
+Additional helpful queries can be lifted from the [Istio preconfigured grafana
+dashboards](https://istio.io/latest/docs/ops/integrations/grafana/).
+

--- a/docs/platform_operators/networking-metrics.md
+++ b/docs/platform_operators/networking-metrics.md
@@ -1,80 +1,203 @@
 # Networking Metrics
 
-The networking plane emits several useful metrics that can be used to understand
-the health of the platform. These metrics can be consumed by Prometheus and
-graphed with Grafana, but the installation and configuration of those tools are
-outside of the scope of this document.
+The networking control plane emits metrics that can be used to understand the
+health of the platform. These metrics can be consumed by Prometheus and graphed
+with Grafana, but the installation and configuration of those tools is outside
+the scope of this document.
 
-## Istio Emitted Metrics
+## Official Resources
 
-More information on Istio metrics can be found
-[here](https://istio.io/latest/docs/reference/config/policy-and-telemetry/metrics/).
+There is existing official documentation on what metrics each component exposes.
 
-Here are the most relevant:
+* [Istio metrics](https://istio.io/latest/docs/reference/config/policy-and-telemetry/metrics/)
+* [Istio preconfigured grafana dashboards](https://istio.io/latest/docs/ops/integrations/grafana/)
+  * These dashboards have helpful Prometheus queries and demonstrate what the
+    Istio community finds valuable to monitor when running Istio.
+* [Full list of Envoy metrics](https://www.envoyproxy.io/docs/envoy/latest/configuration/upstream/cluster_manager/cluster_stats)
+  * However, Envoy as configured by Istio does not emit all of the ones listed.
+* [More Envoy metrics docs](https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/statistics#server%5C)
 
-* `istio_requests_total` (integer) -- Total number of requests
-* `istio_request_duration` (histogram) -- Duration of requests
-* `istio_request_bytes` (histogram) -- Size of requests
-* `istio_response_bytes` (histogram) -- Size of responses
+# Is the platform healthy?
 
-## Envoy Emitted Metrics
+One goal you might have when monitoring is to ensure that requests are being
+served and that the components are not becoming overloaded.
 
-Note that these metrics are emitted for both the ingress gateways, and the
-sidecars, so they will need to be filtered.
+## Dataplane Monitoring
+Significant changes in the number or size of requests is a sign that load on the
+cluster is changing and the ingress-gateways might need to be scaled. Because
+Istio configures Envoy to output data plane metrics, it is possible to measure
+the global dataplane load across all Envoys.
 
-The full list of metrics envoy supports are listed
-[here](https://www.envoyproxy.io/docs/envoy/latest/configuration/upstream/cluster_manager/cluster_stats),
-however Envoy as configured by Istio does not emit all of those listed.
+1. The following query will return the rate of requests per second across all
+   Envoy proxies configured by Istio:
+   ```
+   round(sum(irate(istio_requests_total{reporter="destination"}[1m])), 0.001)
+   ```
+1. The following query will return the 95th percentile of request latency in
+   milliseconds across all Envoy proxies configured by Istio:
+   ```
+   histogram_quantile(0.95, sum(rate(istio_request_duration_milliseconds_bucket[5m])) by (le))
+   ```
+1. The following query will return the 95th percentile of HTTP request body size
+   across all Envoy proxies configured by Istio:
+   ```
+   histogram_quantile(0.95, sum(rate(istio_request_bytes_bucket[5m])) by (le))
+   ```
+1. The following query will return the 95th percentile of HTTP response body size
+   across all Envoy proxies configured by Istio:
+   ```
+   histogram_quantile(0.95, sum(rate(istio_response_bytes_bucket[5m])) by (le))
+   ```
 
-Here are a few we find valuable:
+In addition to measuring the load, it can be useful to watch out for spikes in
+the rate of error codes or cancelled requests:
 
-* `envoy_cluster_upstream_rq_<status word>` (integer) -- Number of requests in that
-  status (i.e. `cancelled`, `completed`, `total`)
-* `envoy_cluster_upstream_rq_<http status code>` (integer) -- Number of requests
-  that had that status code (i.e. `200`, `404`, `503`)
+1. The following query will return the current rate of requests per second that have a
+   particular status (e.g. `cancelled`, `completed`, `total`):
+   ```
+   round(sum(irate(envoy_cluster_upstream_rq_<status word>[1m])), 0.001)
+   ```
+1. The following query will return the current rate of requests per second that have a
+   particular status code (e.g. `200`, `404`, `503`):
+   ```
+   round(sum(irate(envoy_cluster_upstream_rq_<http status code>[1m])), 0.001)
+   ```
+
+Note that these metrics are emitted for both the ingress-gateways, and the
+sidecars, so if you want to monitor the sidecars and the ingress-gateways
+separately, then the metrics will need to be filtered.
+For example, the following query will return the rate of `503`s per second across
+all the ingress-gateways:
+```
+sum(irate(envoy_cluster_upstream_rq_503{namespace="istio-system"}[1m]))
+```
 
 ## Gateway Health Metrics
+Monitoring the self-reported state of the ingress-gateways is on way to
+determine the health of the ingress-gateways. The relevant metrics for that
+monitoring are:
 
-There are a few metrics available that are useful in determining the health of
-the ingressgateways.
+1. The following query will return the time since each ingress-gateway last
+   restarted:
+   ```
+   envoy_server_uptime{pod_name=~"istio-ingressgateway-.*"}
+   ```
 
-* `envoy_server_uptime{pod_name=~"istio-ingressgateway-.*"}`
-* `envoy_server_live{pod_name=~"istio-ingressgateway-.*"}`
-* `envoy_server_state{pod_name=~"istio-ingressgateway-.*"}`
-  * This metric has values:
-    0: live
-    1: draining
-    2: pre-initializing
-    3: initializing
+1. The following query will return the current state of each ingress-gateway:
+   ```
+   envoy_server_state{pod_name=~"istio-ingressgateway-.*"}
+   ```
+   * This `envoy_server_state` has the following values:
+     * 0: live
+     * 1: draining
+     * 2: pre-initializing
+     * 3: initializing
+   * When no upgrade is running and no scaling has be initiated, the
+     ingress-gateways should be in state `0: live`. During an upgrade, some pods
+     would be spinning up (in states `2: pre-initializing` and `3:
+     initializing`) and others would be `1: draining` to make room for the new
+     pods.
 
-You can learn more about these metrics in the [envoy
-documentation](https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/statistics#server%5C)
+1. The following query will return the current number of live ingress-gateways:
+   ```
+   sum(envoy_server_live{pod_name=~"istio-ingressgateway-.*"})
+   ```
+## General Resource Metrics
+For all the components, you can monitor the standard set of resource usage
+metrics, such as the following queries that measure efficiency:
 
-## General resource metrics that may be valuable
+1. The following query will return the ingress-gateway CPU usage per thousand requests per second:
+   ```
+   sum(irate(container_cpu_usage_seconds_total{pod=~"istio-ingressgateway-.*",container="istio-proxy"}[1m]))
+   / (round(
+        sum(irate(
+          istio_requests_total{source_workload="istio-ingressgateway", reporter="source"}[1m])),
+        0.001)
+      / 1000)
+   ```
+1. The following query will return the ingress-gateway memory usage per thousand requests per second:
+   ```
+   sum(irate(container_memory_usage_bytes{pod=~"istio-ingressgateway-.*",container="istio-proxy"}[1m]))
+   / (round(
+        sum(irate(
+          istio_requests_total{source_workload="istio-ingressgateway", reporter="source"}[1m])),
+        0.001)
+      / 1000)
+   ```
 
-As you might expect, data and control plane components emit the standard set of
-resource usage metrics, including the following
+# Control Plane Latency
 
-* `container_cpu_usage_seconds` (integer)
-* `container_memory_usage_bytes` (integer)
+The path from making a configuration change using the CF CLI to that change
+being applied in Envoy (especially the Envoy ingress-gateways) has a series of
+steps. It is recommended to monitor each step separately in order to ensure that
+control plane latency is not too high overall and to make fixing latency
+problems easier. This section will cover metrics relevant to monitoring each
+step.
 
-## Sample Prometheus Queries
+Because most steps involve the K8s API, we will first cover the K8s API metrics that are
+relevant to all those steps.
 
-P95 Request duration:
-```
-histogram_quantile(0.95, sum(rate(istio_request_duration_milliseconds_bucket[5m])) by (le))
-```
+## K8s API Metrics
 
-Global requests per second:
-```
-round(sum(irate(istio_requests_total{reporter="destination"}[1m])), 0.001)
-```
+All of the metrics beginning with `apiserver_request_`  measure the load on the
+K8s API server.
 
-CPU Usage per 1k requests per second for ingressgateways
-```
-(sum(irate(container_cpu_usage_seconds_total{pod=~"istio-ingressgateway-.*",container="istio-proxy"}[1m])) / (round(sum(irate(istio_requests_total{source_workload="istio-ingressgateway", reporter="source"}[1m])), 0.001)/1000))
-```
+1. The following query measures the current latency on the various API server
+   actions (e.g. CREATE, WATCH) and resources (e.g. pods):
+   ```
+   apiserver_request_duration_seconds_bucket
+   ```
 
-Additional helpful queries can be lifted from the [Istio preconfigured grafana
-dashboards](https://istio.io/latest/docs/ops/integrations/grafana/).
+1. The following query will return the number of requests per second
+   to the API server over the range of a minute, rounded to the nearest
+   thousandth:
+   ```
+   round(sum(irate(apiserver_request_total[1m])), 0.001)
+   ```
 
+1. The following query will return errors from the API server such as HTTP 5xx
+   errors:
+   ```
+   rate(apiserver_request_count{code=~"^(?:5..)$"}[5m]) / rate(apiserver_request_count[5m])
+   ```
+   * `(?:5..)` can be replaced with other status codes numbers (e.g. `(?:4..)`
+     for HTTP 4xx errors).
+
+1. The following query will return the 95th percentile latency for all
+   Kubernetes resources and verbs:
+   ```
+   histogram_quantile(0.95,
+   sum(rate(apiserver_request_duration_seconds_bucket[5m])) by (le, resource,
+   subresource, verb))
+   ```
+   * It is also possible to select specific resources such as virtual services
+     by adding the resource name to the metric.  For example, the query below
+     will return the 95th precentile request duration latency for
+     VirtualServices only.
+     ```
+     histogram_quantile(0.95,
+     sum(rate(apiserver_request_duration_seconds_bucket{resource="virtualservices"}[5m]))
+     by (le, resource, subresource, verb))
+     ```
+
+## CC API
+The CC API creates or updates a Route CR to reflect changes requested by a CF
+CLI command. The CC API does not emit metrics, so K8s API metrics related to
+Route CRs are the most relevant.
+
+## Route Controller
+The Route Controller consumes Route CRs and outputs Istio configuration as other
+CRs. There are no metrics output by Route Controller at this time, so the most
+relevant metrics are emitted by the K8s API.
+
+## Istio Metrics
+Istio consumes its config as VirtualService CRs and emits configuration to each
+Envoy via XDS. In addition to K8s API metrics related to VirtualServices, istiod
+outputs several relevant metrics:
+
+1. The following query will return the 99th percentile latency of Istio sending
+   configuration to Envoy (measured from when Istio is ready to send a new
+   configuration to when Envoy acknowledges the configuration):
+   ```
+   histogram_quantile(0.99, sum(rate(pilot_proxy_convergence_time_bucket[1m])) by (le))
+   ```

--- a/docs/platform_operators/networking-metrics.md
+++ b/docs/platform_operators/networking-metrics.md
@@ -33,6 +33,23 @@ Here are a few we find valuable:
 * `envoy_cluster_upstream_rq_<http status code>` (integer) -- Number of requests
   that had that status code (i.e. `200`, `404`, `503`)
 
+## Gateway Health Metrics
+
+There are a few metrics available that are useful in determining the health of
+the ingressgateways.
+
+* `envoy_server_uptime{pod_name=~"istio-ingressgateway-.*"}`
+* `envoy_server_live{pod_name=~"istio-ingressgateway-.*"}`
+* `envoy_server_state{pod_name=~"istio-ingressgateway-.*"}`
+  * This metric has values:
+    0: live
+    1: draining
+    2: pre-initializing
+    3: initializing
+
+You can learn more about these metrics in the [envoy
+documentation](https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/statistics#server%5C)
+
 ## General resource metrics that may be valuable
 
 As you might expect, data and control plane components emit the standard set of


### PR DESCRIPTION
[#174239599](https://www.pivotaltracker.com/story/show/174239599)

## WHAT is this change about?
Adds a doc describing metrics of interest to operators who would like to observe their platform's networking performance

## Does this PR introduce a change to `config/values.yml`?
No

## Acceptance Steps

```
AS an operator
WHEN I view these docs
THEN I am enlightened
```

## Tag your pair, your PM, and/or team
@ndhanushkodi @cloudfoundry/cf-for-k8s-networking 