### PR TITLE
Rename allow-istio-control-plane network policy

### DIFF
--- a/config/networking/network-policies.yaml
+++ b/config/networking/network-policies.yaml
@@ -71,7 +71,7 @@ spec:
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
-  name: allow-istio-control-plane
+  name: only-allow-istio-control-plane
   namespace: #@ system_namespace()
 spec:
   podSelector: {}
@@ -93,7 +93,7 @@ spec:
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
-  name: allow-istio-control-plane
+  name: only-allow-istio-control-plane
   namespace: cf-db
 spec:
   podSelector: {}
@@ -116,7 +116,7 @@ spec:
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
-  name: allow-istio-control-plane
+  name: only-allow-istio-control-plane
   namespace: cf-blobstore
 spec:
   podSelector: {}


### PR DESCRIPTION
* We decided that renaming this network policy to
"only-allow-istio-control-plane" because it better describes what this
policy does. It is a policy that allows traffic from the istio to all
pods in a namespace.

[174810340](https://www.pivotaltracker.com/story/show/174810340)

Co-authored-by: Rodolfo Sanchez <srodolfo@vmware.com>



> Thanks for contributing to cf-for-k8s!
>
> We've designed this PR template to speed up the PR review and merge process - please use it.

## WHAT is this change about?
> Rename a network-policy to better describe the scope of it

## Does this PR introduce a change to `config/values.yml`?
> no 

## Acceptance Steps
```
When I have a cluster with cf-for-k8s 
And I get the network policies in all namespaces `kubectl get netpol -A  | grep allow-istio-control-plane`
Then I can see network policies called only-allow-istio-control-plane.
And I do not see network policies called allow-istio-control-plane 
```

## Tag your pair, your PM, and/or team
@cloudfoundry/cf-for-k8s-networking 


