### PR TITLE
doc: cluster requires network policy support

### DIFF
--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -37,6 +37,7 @@ To deploy cf-for-k8s as is, the cluster should:
 - be running Kubernetes version within range 1.16.x to 1.19.x
 - have a minimum of 5 nodes
 - have a minimum of 4 CPU, 15GB memory per node
+- have a CNI plugin (Container Network Interface plugin) that supports network policies (otherwise, the NetworkPolicy resources applied by cf-for-k8s will have no effect)
 - support `LoadBalancer` services
 - most IaaSes come with `metrics-server`, but if yours does not come with one (for example, if you are using `kind`), you will need to include `add_metrics_server_components: true` in your values file.
 - defines a default StorageClass


### PR DESCRIPTION
Co-authored-by: Clay Kauzlaric <ckauzlaric@vmware.com>



## WHAT is this change about?
To document that clusters should require Network Policy support

## Does this PR introduce a change to `config/values.yml`?
No

## Acceptance Steps
When I read the docs to deploy cf-for-k8s,
I can understand that my cluster needs to have a CNI that supports network policy.

## Tag your pair, your PM, and/or team
@KauzClay @keshav-pivotal @shalako 


