### PR TITLE
ENH: Allow operators to provide PEM-encoded certs

### DIFF
--- a/config/eirini/eirini.yml
+++ b/config/eirini/eirini.yml
@@ -17,9 +17,9 @@ metadata:
   name: eirini-internal-tls-certs
   namespace: #@ system_namespace()
 data:
-  tls.crt: #@ data.values.internal_certificate.crt
-  tls.key: #@ data.values.internal_certificate.key
-  tls.ca: #@ data.values.internal_certificate.ca
+  tls.crt: #@ base64.encode(data.values.internal_certificate.crt)
+  tls.key: #@ base64.encode(data.values.internal_certificate.key)
+  tls.ca: #@ base64.encode(data.values.internal_certificate.ca)
 
 #! Allow app traffic from the istio-ingressgateway
 ---

--- a/config/eirini/eirini.yml
+++ b/config/eirini/eirini.yml
@@ -16,10 +16,10 @@ kind: Secret
 metadata:
   name: eirini-internal-tls-certs
   namespace: #@ system_namespace()
-data:
-  tls.crt: #@ base64.encode(data.values.internal_certificate.crt)
-  tls.key: #@ base64.encode(data.values.internal_certificate.key)
-  tls.ca: #@ base64.encode(data.values.internal_certificate.ca)
+stringData:
+  tls.crt: #@ data.values.internal_certificate.crt
+  tls.key: #@ data.values.internal_certificate.key
+  tls.ca: #@ data.values.internal_certificate.ca
 
 #! Allow app traffic from the istio-ingressgateway
 ---

--- a/config/istio/external-routing.yml
+++ b/config/istio/external-routing.yml
@@ -1,3 +1,4 @@
+#@ load("@ytt:base64", "base64")
 #@ load("@ytt:data", "data")
 #@ load("@ytt:overlay", "overlay")
 #@ load("/namespaces.star", "system_namespace", "workloads_namespace")
@@ -12,8 +13,8 @@ metadata:
   annotations:
     kapp.k14s.io/change-rule.istio-ingressgateway: "upsert before upserting istio.io/ingressgateway"
 data:
-  tls.key: #@ data.values.system_certificate.key
-  tls.crt: #@ data.values.system_certificate.crt
+  tls.key: #@ base64.encode(data.values.system_certificate.key)
+  tls.crt: #@ base64.encode(data.values.system_certificate.crt)
 
 ---
 apiVersion: v1
@@ -24,8 +25,8 @@ metadata:
   annotations:
     kapp.k14s.io/change-rule.istio-ingressgateway: "upsert before upserting istio.io/ingressgateway"
 data:
-  tls.key: #@ data.values.workloads_certificate.key
-  tls.crt: #@ data.values.workloads_certificate.crt
+  tls.key: #@ base64.encode(data.values.workloads_certificate.key)
+  tls.crt: #@ base64.encode(data.values.workloads_certificate.crt)
 
 #! the following overlay ensures the above Secret is created before the ingressgateway Deployment since we're not using SDS
 #@overlay/match by=overlay.subset({"kind":"DaemonSet","metadata":{"name":"istio-ingressgateway"}})

--- a/config/istio/external-routing.yml
+++ b/config/istio/external-routing.yml
@@ -1,4 +1,3 @@
-#@ load("@ytt:base64", "base64")
 #@ load("@ytt:data", "data")
 #@ load("@ytt:overlay", "overlay")
 #@ load("/namespaces.star", "system_namespace", "workloads_namespace")
@@ -12,9 +11,9 @@ metadata:
   namespace: istio-system
   annotations:
     kapp.k14s.io/change-rule.istio-ingressgateway: "upsert before upserting istio.io/ingressgateway"
-data:
-  tls.key: #@ base64.encode(data.values.system_certificate.key)
-  tls.crt: #@ base64.encode(data.values.system_certificate.crt)
+stringData:
+  tls.key: #@ data.values.system_certificate.key
+  tls.crt: #@ data.values.system_certificate.crt
 
 ---
 apiVersion: v1
@@ -24,9 +23,9 @@ metadata:
   namespace: istio-system
   annotations:
     kapp.k14s.io/change-rule.istio-ingressgateway: "upsert before upserting istio.io/ingressgateway"
-data:
-  tls.key: #@ base64.encode(data.values.workloads_certificate.key)
-  tls.crt: #@ base64.encode(data.values.workloads_certificate.crt)
+stringData:
+  tls.key: #@ data.values.workloads_certificate.key
+  tls.crt: #@ data.values.workloads_certificate.crt
 
 #! the following overlay ensures the above Secret is created before the ingressgateway Deployment since we're not using SDS
 #@overlay/match by=overlay.subset({"kind":"DaemonSet","metadata":{"name":"istio-ingressgateway"}})

--- a/config/logging/logging.yml
+++ b/config/logging/logging.yml
@@ -1,6 +1,5 @@
 #@ load("@ytt:data", "data")
 #@ load("@ytt:library", "library")
-#@ load("@ytt:overlay", "overlay")
 #@ load("@ytt:template", "template")
 #@ load("/namespaces.star", "system_namespace")
 
@@ -11,4 +10,3 @@ system_namespace: #@ system_namespace()
 
 #@ logging = library.get("cf-k8s-logging")
 --- #@ template.replace(logging.with_data_values(logging_values()).eval())
-

--- a/config/minio/minio.yml
+++ b/config/minio/minio.yml
@@ -1,4 +1,3 @@
-#@ load("@ytt:base64", "base64")
 #@ load("@ytt:data", "data")
 #@ load("@ytt:library", "library")
 #@ load("@ytt:overlay", "overlay")
@@ -26,9 +25,12 @@ metadata:
 
 #@overlay/match by=overlay.subset({"kind": "Secret", "metadata": {"name": "cf-blobstore-minio"}})
 ---
+#@overlay/match missing_ok=True
+stringData:
+  accesskey: #@ must_exist(data.values, "blobstore.access_key_id")
+  secretkey: #@ must_exist(data.values, "blobstore.secret_access_key")
+#@overlay/remove
 data:
-  accesskey: #@ base64.encode(must_exist(data.values, "blobstore.access_key_id"))
-  secretkey: #@ base64.encode(must_exist(data.values, "blobstore.secret_access_key"))
 
 --- #@ template.replace(overlay.apply(library.get("minio").eval(), add_cf_blobstore_namespace()))
 

--- a/config/postgres/postgres.yml
+++ b/config/postgres/postgres.yml
@@ -1,5 +1,4 @@
 #@ load("@ytt:assert", "assert")
-#@ load("@ytt:base64", "base64")
 #@ load("@ytt:data", "data")
 #@ load("@ytt:library", "library")
 #@ load("@ytt:overlay", "overlay")
@@ -29,11 +28,11 @@ kind: Secret
 metadata:
   name: cf-db-admin-secret
   namespace: cf-db
-data:
+stringData:
   #@ if len(data.values.cf_db.admin_password) == 0:
   #@  assert.fail("cf_db.admin_password cannot be empty")
   #@ end
-  postgresql-password: #@ base64.encode(data.values.cf_db.admin_password)
+  postgresql-password: #@ data.values.cf_db.admin_password
 
 ---
 apiVersion: v1
@@ -41,23 +40,23 @@ kind: Secret
 metadata:
   name: cf-db-credentials
   namespace: cf-db
-data:
+stringData:
   #@ if len(data.values.capi.database.user) == 0:
   #@  assert.fail("capi.database.user cannot be empty")
   #@ end
-  ccdb-username: #@ base64.encode(data.values.capi.database.user)
+  ccdb-username: #@ data.values.capi.database.user
   #@ if len(data.values.capi.database.password) == 0:
   #@  assert.fail("capi.database.password cannot be empty")
   #@ end
-  ccdb-password: #@ base64.encode(data.values.capi.database.password)
+  ccdb-password: #@ data.values.capi.database.password
   #@ if len(data.values.uaa.database.user) == 0:
   #@  assert.fail("uaa.database.user cannot be empty")
   #@ end
-  uaadb-username: #@ base64.encode(data.values.uaa.database.user)
+  uaadb-username: #@ data.values.uaa.database.user
   #@ if len(data.values.uaa.database.password) == 0:
   #@  assert.fail("uaa.database.password cannot be empty")
   #@ end
-  uaadb-password: #@ base64.encode(data.values.uaa.database.password)
+  uaadb-password: #@ data.values.uaa.database.password
 
 #@overlay/match by=overlay.subset({"kind": "ConfigMap", "metadata":{"name":"cf-db-postgresql-init-scripts"}})
 ---

--- a/config/uaa/uaa.yml
+++ b/config/uaa/uaa.yml
@@ -1,3 +1,4 @@
+#@ load("@ytt:base64", "base64")
 #@ load("@ytt:data", "data")
 #@ load("@ytt:library", "library")
 #@ load("@ytt:overlay", "overlay")
@@ -246,8 +247,8 @@ metadata:
   namespace: #@ system_namespace()
 type: Opaque
 data:
-  uaa.key: #@ data.values.internal_certificate.key
-  uaa.crt: #@ data.values.internal_certificate.crt
+  uaa.key: #@ base64.encode(data.values.internal_certificate.key)
+  uaa.crt: #@ base64.encode(data.values.internal_certificate.crt)
 
 #@ def uaa_client_credential_data(client_name, credential):
 oauth:

--- a/config/uaa/uaa.yml
+++ b/config/uaa/uaa.yml
@@ -1,4 +1,3 @@
-#@ load("@ytt:base64", "base64")
 #@ load("@ytt:data", "data")
 #@ load("@ytt:library", "library")
 #@ load("@ytt:overlay", "overlay")
@@ -246,9 +245,9 @@ metadata:
   name: uaa-certs
   namespace: #@ system_namespace()
 type: Opaque
-data:
-  uaa.key: #@ base64.encode(data.values.internal_certificate.key)
-  uaa.crt: #@ base64.encode(data.values.internal_certificate.crt)
+stringData:
+  uaa.key: #@ data.values.internal_certificate.key
+  uaa.crt: #@ data.values.internal_certificate.crt
 
 #@ def uaa_client_credential_data(client_name, credential):
 oauth:

--- a/config/values/00-values.yml
+++ b/config/values/00-values.yml
@@ -14,21 +14,21 @@ load_balancer:
   static_ip: ""
 
 system_certificate:
-  #! Base64-encoded certificate for the wildcard
-  #! subdomain of the system domain (e.g., CN=*.system.cf.example.com)
+  #! Certificate for the wildcard subdomain of the system domain
+  #! For example, CN=*.system.cf.example.com
   crt: ""
-  #! Base64-encoded private key for the system certificate
+  #! Private key for the system certificate
   key: ""
-  #! Base64-encoded CA certificate used to sign the system certifcate
+  #! CA certificate used to sign the system certifcate
   ca: ""
 
 workloads_certificate:
-  #! Base64-encoded certificate for the wildcard
-  #! subdomain of the system domain (e.g., CN=*.apps.cf.example.com)
+  #! Certificate for the wildcard subdomain of the apps domain
+  #! For example, CN=*.apps.cf.example.com
   crt: ""
-  #! Base64-encoded private key for the workloads certificate
+  #! Private key for the workloads certificate
   key: ""
-  #! Base64-encoded CA certificate used to sign the workloads certifcate
+  #! CA certificate used to sign the workloads certifcate
   ca: ""
 
 #! When true, automatically upgrades incoming HTTP connections to HTTPS

--- a/config/values/20-secrets-config-values.yml
+++ b/config/values/20-secrets-config-values.yml
@@ -10,12 +10,12 @@ cf_db:
   admin_password: ""
 
 internal_certificate:
-  #! Base64-encoded certificate for the wildcard
-  #! subdomain of the system domain (e.g., CN=*.cf-system.svc.cluster.local)
+  #! Certificate for the wildcard subdomain of the internal system domain
+  #! CN=*.cf-system.svc.cluster.local
   crt: ""
-  #! Base64-encoded private key for the internal certificate
+  #! Private key for the internal certificate
   key: ""
-  #! Base64-encoded CA certificate used to sign the internal certifcate
+  #! CA certificate used to sign the internal certifcate
   ca: ""
 
 uaa:

--- a/docs/platform_operators/deploy-parameters.md
+++ b/docs/platform_operators/deploy-parameters.md
@@ -5,12 +5,12 @@
 | cf_admin_password | password for admin user in plain text | Yes | no value | 2fK2zLXPgvmsESrB87sADZQvdLeY5Kv4 | |
 | load_balancer.enable | Enable IaaS provisioned load balancer | No | true |  |  |
 | load_balancer.static_ip | reserved static ip for LoadBalancer | No | no value | "192.168.0.0" | |
-| system_certificate.crt | Base64-encoded certificate for the wildcard - subdomain of the system domain | Yes | no value | CN=*.system.cf.example.com |  |
-| system_certificate.key | Base64-encoded private key for the system certificate | Yes | no value |  |  |
-| system_certificate.ca | Base64-encoded CA certificate used to sign the system certifcate | Yes | no value |  |  |
-| workloads_certificate.crt | Base64-encoded certificate for the wildcard - subdomain of the system domain | Yes | no value | CN=*.apps.cf.example.com |  |
-| workloads_certificate.key | Base64-encoded private key for the workloads certificate | Yes | no value |  |  |
-| workloads_certificate.ca | Base64-encoded CA certificate used to sign the workloads certifcate | Yes | no value |  |  |
+| system_certificate.crt | Certificate for the wildcard - subdomain of the system domain | Yes | no value | CN=*.system.cf.example.com |  |
+| system_certificate.key | Private key for the system certificate | Yes | no value |  |  |
+| system_certificate.ca | CA certificate used to sign the system certifcate | Yes | no value |  |  |
+| workloads_certificate.crt | Certificate for the wildcard - subdomain of the system domain | Yes | no value | CN=*.apps.cf.example.com |  |
+| workloads_certificate.key | Private key for the workloads certificate | Yes | no value |  |  |
+| workloads_certificate.ca | CA certificate used to sign the workloads certifcate | Yes | no value |  |  |
 | gateway.https_only | When true, automatically upgrades incoming HTTP connections to HTTPS gateway | Yes | true |  |  |
 | capi.database.adapter | database adapter for use by capi | Yes | no value | postgres | mysql |
 | capi.database.encryption_key | key used to encrypt database records at rest | Yes | no value | YqEgP7KxSjUmQTSX9drTkQLye8wrqrP4 |  |

--- a/docs/platform_operators/setup-ingress-certs-with-letsencrypt.md
+++ b/docs/platform_operators/setup-ingress-certs-with-letsencrypt.md
@@ -38,11 +38,6 @@ _acme-challenge.SYS_DOMAIN.	TXT    kyfxzsAirB79lsk173jkdlamxiryqloy
 dig _acme-challenge.$SYS_DOMAIN TXT
 ```
 5. In the certbot console, press enter once the TXT change is propagated to nameservers. `certbot` will verify that you own the server and create the necessary files.
-6. Base64 encode the generated fullchain cert and private key and then remove the line breaks
-```
-openssl base64 -in /tmp/certbot/cfg/live/$SYS_DOMAIN/fullchain.pem | tr -d '\n' > /tmp/sys-fullchain.pem
-openssl base64 -in /tmp/certbot/cfg/live/$SYS_DOMAIN/privkey.pem | tr -d '\n' > /tmp/sys-privkey.pem
-```
 
 ### Apps domain
 Let's now create apps domain certs
@@ -63,11 +58,6 @@ certbot --server https://acme-v02.api.letsencrypt.org/directory -d "*.$APPS_DOMA
 # example of the TXT in your DNS
 _acme-challenge.$APPS_DOMAIN.	TXT    kyfxzsAirB79lsk173jkdlamxiryqloy
 ```
-4. Base64 encode the generated fullchain cert and private key and then remove the line breaks
-```
-openssl base64 -in /tmp/certbot/cfg/live/$APPS_DOMAIN/fullchain.pem | tr -d '\n' > /tmp/apps-fullchain.pem
-openssl base64 -in /tmp/certbot/cfg/live/$APPS_DOMAIN/privkey.pem | tr -d '\n' > /tmp/apps-privkey.pem
-```
 
 ### Update cf-values yaml
 The following instructions assume you have created `cf-install-values.yml`. Please ensure to copy the file contents into the variables as is.
@@ -77,8 +67,8 @@ The following instructions assume you have created `cf-install-values.yml`. Plea
     Lookup `system_certificate` in `cf-install-values.yml`. You should config variables `crt`, `key` and `ca`. Follow the instructions below,
     ```yaml
     system_certificate:
-      crt: <replace this with the contents of the file /tmp/sys-fullchain.pem>
-      key: <replace this with the contents of the file /tmp/sys-privkey.pem>
+      crt: <replace this with the contents of the file /tmp/certbot/cfg/live/$SYS_DOMAIN/fullchain.pem>
+      key: <replace this with the contents of the file /tmp/certbot/cfg/live/$SYS_DOMAIN/privkey.pem>
       ca: "" #! replace whatever old value with empty string
     ```
     Your final output for `system_certificate` will look something like
@@ -94,8 +84,8 @@ The following instructions assume you have created `cf-install-values.yml`. Plea
    The `workloads_certificate` has sub-keys `crt`, `key`, `ca` under it.
    ```yaml
    workloads_certificate:
-      crt: <replace this with the contents of the file /tmp/apps-fullchain.pem>
-      key: <replace this with the contents of the file /tmp/apps-privkey.pem>
+      crt: <replace this with the contents of the file /tmp/certbot/cfg/live/$APPS_DOMAIN/fullchain.pem>
+      key: <replace this with the contents of the file /tmp/certbot/cfg/live/$APPS_DOMAIN/privkey.pem>
       ca: "" #! replace whatever old value with empty string
    ```
 

--- a/hack/generate-values.sh
+++ b/hack/generate-values.sh
@@ -178,22 +178,31 @@ capi:
     encryption_key: $(bosh interpolate ${VARS_FILE} --path=/capi_db_encryption_key)
 
 system_certificate:
-  #! This certificates and keys are base64 encoded and should be valid for *.system.cf.example.com
-  crt: $(bosh interpolate ${VARS_FILE} --path=/system_certificate/certificate | base64 | tr -d '\n')
-  key: $(bosh interpolate ${VARS_FILE} --path=/system_certificate/private_key | base64 | tr -d '\n')
-  ca: $(bosh interpolate ${VARS_FILE} --path=/system_certificate/ca | base64 | tr -d '\n')
+  #! This certificates and keys should be valid for *.system.cf.example.com
+  crt: |
+$(bosh interpolate ${VARS_FILE} --path=/system_certificate/certificate | grep -Ev '^$' | sed -e 's/^/    /')
+  key: |
+$(bosh interpolate ${VARS_FILE} --path=/system_certificate/private_key | grep -Ev '^$' | sed -e 's/^/    /')
+  ca: |
+$(bosh interpolate ${VARS_FILE} --path=/system_certificate/ca | grep -Ev '^$' | sed -e 's/^/    /')
 
 workloads_certificate:
-  #! This certificates and keys are base64 encoded and should be valid for *.apps.cf.example.com
-  crt: $(bosh interpolate ${VARS_FILE} --path=/workloads_certificate/certificate | base64 | tr -d '\n')
-  key: $(bosh interpolate ${VARS_FILE} --path=/workloads_certificate/private_key | base64 | tr -d '\n')
-  ca: $(bosh interpolate ${VARS_FILE} --path=/workloads_certificate/ca | base64 | tr -d '\n')
+  #! This certificates and keys should be valid for *.apps.cf.example.com
+  crt: |
+$(bosh interpolate ${VARS_FILE} --path=/workloads_certificate/certificate | grep -Ev '^$' | sed -e 's/^/    /')
+  key: |
+$(bosh interpolate ${VARS_FILE} --path=/workloads_certificate/private_key | grep -Ev '^$' | sed -e 's/^/    /')
+  ca: |
+$(bosh interpolate ${VARS_FILE} --path=/workloads_certificate/ca | grep -Ev '^$' | sed -e 's/^/    /')
 
 internal_certificate:
-  #! This certificates and keys are base64 encoded and should be valid for *.cf-system.svc.cluster.local
-  crt: $(bosh interpolate ${VARS_FILE} --path=/internal_certificate/certificate | base64 | tr -d '\n')
-  key: $(bosh interpolate ${VARS_FILE} --path=/internal_certificate/private_key | base64 | tr -d '\n')
-  ca: $(bosh interpolate ${VARS_FILE} --path=/internal_certificate/ca | base64 | tr -d '\n')
+  #! This certificates and keys should be valid for *.cf-system.svc.cluster.local
+  crt: |
+$(bosh interpolate ${VARS_FILE} --path=/internal_certificate/certificate | grep -Ev '^$' | sed -e 's/^/    /')
+  key: |
+$(bosh interpolate ${VARS_FILE} --path=/internal_certificate/private_key | grep -Ev '^$' | sed -e 's/^/    /')
+  ca: |
+$(bosh interpolate ${VARS_FILE} --path=/internal_certificate/ca | grep -Ev '^$' | sed -e 's/^/    /')
 
 uaa:
   database:
@@ -201,15 +210,15 @@ uaa:
   admin_client_secret: $(bosh interpolate ${VARS_FILE} --path=/uaa_admin_client_secret)
   jwt_policy:
     signing_key: |
-$(bosh interpolate "${VARS_FILE}" --path=/uaa_jwt_policy_signing_key/private_key | sed -e 's#^#      #')
+$(bosh interpolate "${VARS_FILE}" --path=/uaa_jwt_policy_signing_key/private_key | grep -Ev '^$' | sed -e 's/^/      /')
   encryption_key:
     passphrase: $(bosh interpolate "${VARS_FILE}" --path=/uaa_encryption_key_passphrase)
   login:
     service_provider:
       key: |
-$(bosh interpolate "${VARS_FILE}" --path=/uaa_login_service_provider/private_key | sed -e 's#^#        #')
+$(bosh interpolate "${VARS_FILE}" --path=/uaa_login_service_provider/private_key | grep -Ev '^$' | sed -e 's/^/        /')
       certificate: |
-$(bosh interpolate "${VARS_FILE}" --path=/uaa_login_service_provider/certificate | sed -e 's#^#        #')
+$(bosh interpolate "${VARS_FILE}" --path=/uaa_login_service_provider/certificate | grep -Ev '^$' | sed -e 's/^/        /')
   login_secret: $(bosh interpolate "${VARS_FILE}" --path=/uaa_login_secret)
 EOF
 
@@ -221,7 +230,7 @@ app_registry:
   repository_prefix: gcr.io/$( bosh interpolate ${GCP_SERVICE_ACCOUNT_JSON_FILE} --path=/project_id )/cf-workloads
   username: _json_key
   password: |
-$(cat ${GCP_SERVICE_ACCOUNT_JSON_FILE} | sed -e 's/^/    /')
+$(cat ${GCP_SERVICE_ACCOUNT_JSON_FILE} | grep -Ev '^$' | sed -e 's/^/    /')
 EOF
 
 fi

--- a/sample-cf-install-values.yml
+++ b/sample-cf-install-values.yml
@@ -35,7 +35,7 @@ gateway:
   https_only: true
 
 #! Notes about X.509 certificates:
-#! - the certificates and keys are base64 encoded
+#! - all of the certs should include the common name in the list of subject alternative names
 #! - all of the certs should have KeyUsage that includes server and client authentication
 
 #! certificate, private key, and certificate authority used to identify the CF installation (i.e. the ingress gateway).
@@ -68,7 +68,6 @@ uaa:
   admin_client_secret: uaaadminclientsecret
   #! JWT policy configuration
   jwt_policy:
-    #! This private key should NOT be base64 encoded
     signing_key: jwt_policy_signing_key
   #! Encyption key for encrypting data stored in the database
   encryption_key:
@@ -76,7 +75,6 @@ uaa:
   #! Configuration for UAA's SAML provider
   login:
     service_provider:
-      #! This certificate/key should NOT be base64 encoded
       key: login_service_provider_key
       certificate: login_service_provider_certificate
 

--- a/tests/ytt/uaa/uaa-values.yml
+++ b/tests/ytt/uaa/uaa-values.yml
@@ -8,8 +8,8 @@ data:
   uaa.yml:
 
 internal_certificate:
-  key:
-  crt:
+  key: internal-cert-key
+  crt: internal-cert
 
 uaa:
   login:

--- a/tests/ytt/uaa_test.go
+++ b/tests/ytt/uaa_test.go
@@ -8,7 +8,6 @@ import (
 )
 
 var _ = Describe("UAA", func() {
-
 	var ctx RenderingContext
 	var data map[string]interface{}
 	var templates []string
@@ -26,10 +25,9 @@ var _ = Describe("UAA", func() {
 	})
 
 	Context("given a database configuration", func() {
-
 		BeforeEach(func() {
 			data = map[string]interface{}{
-				"system_namespace":"cf-system",
+				"system_namespace":  "cf-system",
 				"uaa.database.port": "9999",
 				"uaa.database.name": "some-name",
 			}
@@ -41,13 +39,13 @@ var _ = Describe("UAA", func() {
 					WithDeployment("uaa", "cf-system"),
 					WithConfigMap("uaa-config", "cf-system").WithData(
 						gstruct.Keys{"uaa.yml": ContainSubstring("jdbc:postgresql://cf-db-postgresql.cf-db.svc.cluster.local:9999/some-name?sslmode=disable")}),
-			)))
+				),
+			))
 		})
 
 		Context("secured with a certificate", func() {
-
 			BeforeEach(func() {
-				data["uaa.database.ca_cert"]="some-cert"
+				data["uaa.database.ca_cert"] = "some-cert"
 			})
 
 			It("should produce a correctly formatted jdbc connection string", func() {
@@ -56,14 +54,14 @@ var _ = Describe("UAA", func() {
 						WithDeployment("uaa", "cf-system"),
 						WithConfigMap("uaa-config", "cf-system").WithData(
 							gstruct.Keys{"uaa.yml": ContainSubstring("jdbc:postgresql://cf-db-postgresql.cf-db.svc.cluster.local:9999/some-name?sslmode=verify-full&sslfactory=org.postgresql.ssl.DefaultJavaSSLFactory")}),
-					)))
+					),
+				))
 			})
 		})
 
 		Context("for an external database", func() {
-
 			BeforeEach(func() {
-				data["uaa.database.host"]="a.database.some.where"
+				data["uaa.database.host"] = "a.database.some.where"
 			})
 
 			It("should produce a correctly formatted jdbc connection string", func() {
@@ -72,9 +70,9 @@ var _ = Describe("UAA", func() {
 						WithDeployment("uaa", "cf-system"),
 						WithConfigMap("uaa-config", "cf-system").WithData(
 							gstruct.Keys{"uaa.yml": ContainSubstring("jdbc:postgresql://a.database.some.where:9999/some-name?sslmode=disable")}),
-					)))
+					),
+				))
 			})
 		})
 	})
 })
-


### PR DESCRIPTION
## WHAT is this change about?
This change allows operators to provide PEM-encoded system and workloads certificates that are not base64 encoded. It moves the bas64 encoding logic into the templates where the values are provided to components. It also cleans up some cruft in the generated values.yml file. This PR addresses issue #460.

## Does this PR introduce a change to `config/values.yml`?
Yes

## Acceptance Steps
Generate a config values file with system and workloads certificates that are NOT base64 encoded, deploy and run smoke-tests.

## Tag your pair, your PM, and/or team
