### PR TITLE
Use the capi-database-encryption-key-secret in capi-k8s-release

### DIFF
--- a/config/capi/_ytt_lib/capi-k8s-release/templates/ccng-config.lib.yml
+++ b/config/capi/_ytt_lib/capi-k8s-release/templates/ccng-config.lib.yml
@@ -45,10 +45,12 @@ instance_file_descriptor_limit: 16384
 
 request_timeout_in_seconds: 900
 
+#! TODO: this appears unused
 bulk_api:
   auth_user: TODO
   auth_password: TODO
 
+#! TODO: remove this for k8s since we're using mTLS for securing this communication
 internal_api:
   auth_user: TODO
   auth_password: TODO
@@ -69,12 +71,12 @@ info:
   version: 0
   support_address: ""
   description: ""
-  app_ssh_endpoint: TODO.TODO
-  app_ssh_host_key_fingerprint: "placeholder"
-  app_ssh_oauth_client: "placeholder"
   min_cli_version: ""
   min_recommended_cli_version: ""
-
+  #! app SSH is not yet supported in cf-for-k8s
+  app_ssh_endpoint: "7.0.1"
+  app_ssh_host_key_fingerprint: "7.0.1"
+  app_ssh_oauth_client: ""
 
 directories:
   tmpdir: /tmp/
@@ -125,20 +127,14 @@ internal_route_vip_range: ""
 
 login:
   url: #@ "https://login.{}".format(data.values.system_domain)
-#! TODO: change the UAA's Kube DNS name when the service is named correctly later
 uaa:
   url: #@ "https://uaa.{}".format(data.values.system_domain)
   internal_url: #@ "http://uaa.{}.svc.cluster.local:8080".format(data.values.system_namespace)
   resource_id: cloud_controller,cloud_controller_service_permissions
   client_timeout: 60
 
-routing_api:
-  url: #@ "https://api.{}/routing".format(data.values.system_domain)
-  routing_client_name: "TODO"
-  routing_client_secret: "TODO"
-
 credential_references:
-  interpolate_service_bindings: true
+  interpolate_service_bindings: false
 
 #! App staging parameters
 staging:
@@ -146,6 +142,7 @@ staging:
   minimum_staging_memory_mb: 1024
   minimum_staging_disk_mb: 4096
   minimum_staging_file_descriptor_limit: 16384
+  #! TODO: make this optional until the related features are implemented/supported
   auth:
     user: TODO
     password: TODO
@@ -153,7 +150,6 @@ staging:
 default_health_check_timeout: 60
 maximum_health_check_timeout: 180
 
-runtimes_file: "/dev/null"
 stacks_file: config/stacks.yml
 
 shared_isolation_segment_name: shared
@@ -173,11 +169,6 @@ resource_pool:
     path_style: true
   minimum_size: 65536
   maximum_size: 536870912
-
-  cdn:
-    uri:
-    key_pair_id:
-    private_key: ""
 
   fog_aws_storage_options: {}
 
@@ -213,11 +204,6 @@ droplets:
     region: #@ data.values.blobstore.region
     path_style: true
 
-  cdn:
-    uri:
-    key_pair_id:
-    private_key: ""
-
   fog_aws_storage_options: {}
   max_staged_droplets_stored: 5
 
@@ -232,21 +218,13 @@ buildpacks:
     region: #@ data.values.blobstore.region
     path_style: true
 
-  cdn:
-    uri:
-    key_pair_id:
-    private_key: ""
-
   fog_aws_storage_options: {}
 
-db_encryption_key: TODO
-
 database_encryption:
-  keys: {"encryption_key_0":"TODO"}
-  current_key_label: "encryption_key_0"
+  current_key_label: encryption_key_0
   pbkdf2_hmac_iterations: 2048
 
-disable_custom_buildpacks: false
+disable_custom_buildpacks: true
 
 broker_client_timeout_seconds: 60
 broker_client_default_async_poll_interval_seconds: 60
@@ -256,17 +234,13 @@ renderer:
   default_results_per_page: 50
   max_inline_relations_depth: 2
 
-uaa_client_name: "cc-service-dashboards"
-uaa_client_secret: TODO
-uaa_client_scope: openid,cloud_controller_service_permissions.read
-
 cloud_controller_username_lookup_client_name: "cloud_controller_username_lookup"
 
 cc_service_key_client_name: "cc_service_key_client"
 cc_service_key_client_secret: TODO
 
-allow_app_ssh_access: true
-default_app_ssh_access: true
+allow_app_ssh_access: false
+default_app_ssh_access: false
 
 skip_cert_verify: false
 
@@ -287,16 +261,10 @@ security_event_logging:
   enabled: false
   file: "/dev/null"
 
-system_hostnames: ["api", "uaa", "login", "doppler", "loggregator", "hm9000", "credhub"]
+system_hostnames: ["api", "uaa", "login", "log-cache"]
 
 bits_service:
   enabled: false
-  public_endpoint: #@ "https://bits.{}".format(data.values.system_domain)
-  private_endpoint: https://TODO.TODO
-  username: TODO
-  password: TODO
-
-  ca_cert_path: "/dev/null"
 
 rate_limiter:
   enabled: false
@@ -331,6 +299,7 @@ opi:
   enabled: true
   cc_uploader_url: "https://TODO.TODO"
 
+#! TODO: perm is never used - remove this option
 perm:
   enabled: false
 

--- a/config/capi/_ytt_lib/capi-k8s-release/templates/secrets.lib.yml
+++ b/config/capi/_ytt_lib/capi-k8s-release/templates/secrets.lib.yml
@@ -10,6 +10,9 @@
 - name: cf-api-db-password
   secret:
     secretName: #@ data.values.ccdb.password_secret_name
+- name: cf-api-db-encryption-key
+  secret:
+    secretName: #@ data.values.ccdb.encryption_key_secret_name
 - name: cf-api-username-lookup-client-secret
   secret:
     secretName: #@ data.values.uaa.clients.cloud_controller_username_lookup.secret_name
@@ -22,7 +25,8 @@
 
 #@ ccng_config_mount_path = "/config/cloud_controller_ng.yml"
 #@ ccng_secrets_mount_path = "/config/secrets.yml"
-#@ ccdb_mount_path = "/etc/cf-api/ccdb"
+#@ ccdb_password_mount_path = "/etc/cf-api/ccdb_password"
+#@ ccdb_encryption_key_mount_path = "/etc/cf-api/ccdb_encryption_key"
 #@ cf_api_username_lookup_client_secret_mount_path = "/etc/cf-api/username-lookup-client-secret"
 #@ cf_api_blobstore_secret_access_key_mount_path = "/etc/cf-api/blobstore/secret-access-key"
 
@@ -40,7 +44,10 @@
 #! secrets for credentials used in config
 
 - name: cf-api-db-password
-  mountPath: #@ ccdb_mount_path
+  mountPath: #@ ccdb_password_mount_path
+
+- name: cf-api-db-encryption-key
+  mountPath: #@ ccdb_encryption_key_mount_path
 
 - name: cf-api-username-lookup-client-secret
   mountPath: #@ cf_api_username_lookup_client_secret_mount_path
@@ -55,7 +62,13 @@
 cloud_controller_username_lookup_client_secret:  #@ cf_api_username_lookup_client_secret_mount_path + "/password"
 db:
   database:
-    password: #@ ccdb_mount_path + "/password"
+    password: #@ ccdb_password_mount_path + "/password"
+
+db_encryption_key: #@ ccdb_encryption_key_mount_path + "/password"
+database_encryption:
+  keys:
+    encryption_key_0: #@ ccdb_encryption_key_mount_path + "/password"
+
 resource_pool:
   fog_connection:
     aws_secret_access_key: #@ cf_api_blobstore_secret_access_key_mount_path + "/password"

--- a/config/capi/_ytt_lib/capi-k8s-release/values/_default.yml
+++ b/config/capi/_ytt_lib/capi-k8s-release/values/_default.yml
@@ -18,6 +18,7 @@ ccdb:
   database: cloud_controller
   host: capi-database-postgresql
   password_secret_name:
+  encryption_key_secret_name: capi-database-encryption-key-secret
   port: 5432
   user: cloud_controller
   ca_cert: null

--- a/config/capi/capi.yml
+++ b/config/capi/capi.yml
@@ -42,6 +42,7 @@ ccdb:
   port: #@ data.values.capi.database.port
   user: #@ data.values.capi.database.user
   password_secret_name: capi-database-password
+  encryption_key_secret_name: capi-database-encryption-key-secret
   database: #@ data.values.capi.database.name
   ca_cert: #@ data.values.capi.database.ca_cert
 

--- a/vendir.lock.yml
+++ b/vendir.lock.yml
@@ -2,8 +2,8 @@ apiVersion: vendir.k14s.io/v1alpha1
 directories:
 - contents:
   - git:
-      commitTitle: images.yml updated by CI...
-      sha: d84e4bfe8e85a8a37e13b122b38a771e62f5e535
+      commitTitle: Use k8s secret for db_encryption_key and database_encryption...
+      sha: e61fc855257ad1ee5ef12bf47a88d0a9dce7dacb
     path: .
   path: config/capi/_ytt_lib/capi-k8s-release
 - contents:

--- a/vendir.yml
+++ b/vendir.yml
@@ -8,7 +8,7 @@ directories:
   - path: .
     git:
       url: https://github.com/cloudfoundry/capi-k8s-release
-      ref: d84e4bfe8e85a8a37e13b122b38a771e62f5e535
+      ref: e61fc855257ad1ee5ef12bf47a88d0a9dce7dacb
     includePaths:
     - templates/**/*
     - values/**/*


### PR DESCRIPTION
## WHAT is this change about?
> _Please describe the change here_
Use the capi-database-encryption-key-secret in capi to encrypt the database. Formerly we used "TODO"

NOTE: this commit manually bumps to a newer version of capi-k8s-release. Without this manual bump, this PR would cause cf-for-k8s to fail to deploy (due to ytt overlay issues)

## Does this PR introduce a change to `config/values.yml`?
NO

## Acceptance Steps
cf-for-k8s should continue to deploy successfully. There's no external test for the db encryption key. This is a chore on the CAPI/KAT/CAKE side.

## Tag your pair, your PM, and/or team
@njbennett 

Here's our story for this work: https://www.pivotaltracker.com/story/show/175080272