### PR TITLE
ENH: Add SAN definitions to generated certs

### DIFF
--- a/hack/generate-values.sh
+++ b/hack/generate-values.sh
@@ -130,6 +130,8 @@ variables:
   options:
     ca: default_ca
     common_name: "*.apps.${DOMAIN}"
+    alternative_names:
+    - "*.apps.${DOMAIN}"
     extended_key_usage:
     - server_auth
 - name: internal_certificate
@@ -137,6 +139,8 @@ variables:
   options:
     ca: default_ca
     common_name: "*.cf-system.svc.cluster.local"
+    alternative_names:
+    - "*.cf-system.svc.cluster.local"
     extended_key_usage:
     - client_auth
     - server_auth


### PR DESCRIPTION
## WHAT is this change about?
We are moving into a world where HTTP clients and servers expect all certificates to include their common name in the list of subject alternative names. We should get ahead of this by ensuring that all certificates we generate conform to this pattern.

## Does this PR introduce a change to `config/values.yml`?
No

## Acceptance Steps
Deploy, push an app, and attempt to communicate with that app over TLS with a client that enforces the requirement that the server certificate includes their common name in the list of subject alternative names.

## Tag your pair, your PM, and/or team
@paulcwarren @julian-hj 