### PR TITLE
Merge Istio sidecar and app stats

### DIFF
--- a/build/istio/istioctl-values.yaml
+++ b/build/istio/istioctl-values.yaml
@@ -40,6 +40,7 @@ spec:
       rewriteAppHTTPProbe: true
     meshConfig:
       accessLogEncoding: 'JSON'
+      enablePrometheusMerge: true
       enableAutoMtls: true
       accessLogFile: "/dev/stdout"
       accessLogFormat: >-


### PR DESCRIPTION

> Thanks for contributing to cf-for-k8s!
>
> We've designed this PR template to speed up the PR review and merge process - please use it.

## WHAT is this change about?
Enable Prometheus stats merge for sidecar and app metrics

* this feature is enabled by default thus no config changes
* we are committing this to ensure this behavior for future Istio versions

## Does this PR introduce a change to `config/values.yml`?
No

## Acceptance Steps
Works as before

## Tag your pair, your PM, and/or team
@cloudfoundry/cf-for-k8s-networking 
