### PR TITLE
Disable prometheus metrics merging

### DIFF
--- a/build/istio/istioctl-values.yaml
+++ b/build/istio/istioctl-values.yaml
@@ -40,7 +40,7 @@ spec:
       rewriteAppHTTPProbe: true
     meshConfig:
       accessLogEncoding: 'JSON'
-      enablePrometheusMerge: true
+      enablePrometheusMerge: false
       enableAutoMtls: true
       accessLogFile: "/dev/stdout"
       accessLogFormat: >-

--- a/config/istio/istio-generated/xxx-generated-istio.yaml
+++ b/config/istio/istio-generated/xxx-generated-istio.yaml
@@ -7756,7 +7756,7 @@ data:
           address: zipkin.istio-system:9411
     disableMixerHttpReports: true
     enableAutoMtls: true
-    enablePrometheusMerge: true
+    enablePrometheusMerge: false
     rootNamespace: istio-system
     trustDomain: cluster.local
   meshNetworks: 'networks: {}'
@@ -8453,9 +8453,6 @@ spec:
   template:
     metadata:
       annotations:
-        prometheus.io/path: /stats/prometheus
-        prometheus.io/port: "15090"
-        prometheus.io/scrape: "true"
         sidecar.istio.io/inject: "false"
       labels:
         app: istio-ingressgateway
@@ -8733,8 +8730,6 @@ spec:
   template:
     metadata:
       annotations:
-        prometheus.io/port: "15014"
-        prometheus.io/scrape: "true"
         sidecar.istio.io/inject: "false"
       labels:
         app: istiod


### PR DESCRIPTION
[#175148731](https://www.pivotaltracker.com/story/show/175148731)

Co-authored-by: Mikael Manukyan <mmanukyan@vmware.com>

## WHAT is this change about?

Removes the merging of sidecar and workload stats, the metrics team will scrape each container independently.

- this caused some problems for the metrics team
- namely, it causes metrics to be emitted in plaintext

## Does this PR introduce a change to `config/values.yml`?
Nope

## Acceptance Steps
N/A

## Tag your pair, your PM, and/or team
@mike1808 @cloudfoundry/cf-for-k8s-networking 
