### PR TITLE
Fork and patch Eirini to loosen UID requirement

### DIFF
--- a/build/eirini/osl-compliant-image-override.yml
+++ b/build/eirini/osl-compliant-image-override.yml
@@ -3,17 +3,17 @@ kind: Config
 minimumRequiredVersion: 0.22.0
 overrides:
   - image: eirini/opi@sha256:658f14a51c0a77fbc685f867a54ca56504993f299c43d1a63de757206484506b
-    newImage: index.docker.io/relintdockerhubpushbot/cf-for-k8s-eirini-opi@sha256:4a438c75a0b923a6f043d8f60052c9f3c079768e1a9557d2aa42956ca134be47
+    newImage: index.docker.io/relintdockerhubpushbot/cf-for-k8s-eirini-opi@sha256:d20c957c36644e8f9878bfee1633f319b2e94c82b66b16f9565b5796ed20817b
     preresolved: true
   - image: eirini/event-reporter@sha256:8971db664d1ccfe7df0f624ebaa71c14f90181fb2f29d0cbbc5275f08b208ff1
-    newImage: index.docker.io/relintdockerhubpushbot/cf-for-k8s-eirini-event-reporter@sha256:e001382be607454912e7310e19b0e02545a68694a92888b5ffd98399efd2d251
+    newImage: index.docker.io/relintdockerhubpushbot/cf-for-k8s-eirini-event-reporter@sha256:b06e19ac5232a1077474933e412143f1e4449df94b5899d1e6b29fa823c92b3f
     preresolved: true
   - image: eirini/eirini-controller@sha256:8bce7ed08c3914edee916012e0277012d8d3a54e90bc563bc822c2006d26cf7d
-    newImage: index.docker.io/relintdockerhubpushbot/cf-for-k8s-eirini-eirini-controller@sha256:67c0749667d926270c55a627b7c1af47bbbfdf49981b098cc3a153f2a098208e
+    newImage: index.docker.io/relintdockerhubpushbot/cf-for-k8s-eirini-eirini-controller@sha256:52a7892033893d3d09b2582ae3d562433b30372dcb3678a37e0efd73d174d342
     preresolved: true
   - image: eirini/task-reporter@sha256:4c105c94d1dad2c9e81ad440335d5561c32e2822372643f55c70d5cff9d5603f
-    newImage: index.docker.io/relintdockerhubpushbot/cf-for-k8s-eirini-task-reporter@sha256:82a8b38ee4d3c1eb924b7356fe5d1f9493a9c47d0b63dbecc4eef4d982402e03
+    newImage: index.docker.io/relintdockerhubpushbot/cf-for-k8s-eirini-task-reporter@sha256:b6173cbf13ecff7f789acc9fb38667caacbdef8a7ee5e0667e7c1470564fa5da
     preresolved: true
   - image: eirini/instance-index-env-injector@sha256:b33fe1df8112c59f5cac6a3a73a063b31c1089ac3bf76e5091de34103432111f
-    newImage: index.docker.io/relintdockerhubpushbot/cf-for-k8s-eirini-instance-index-env-injector@sha256:e0dffee2efbe7cba308fc9adf247ef9b232260becc801bf67c75f8c81d4af3af
+    newImage: index.docker.io/relintdockerhubpushbot/cf-for-k8s-eirini-instance-index-env-injector@sha256:ad9adc876d588fbc6b0592a1f8a9b24efd41e8dcd06ae2244192a7651499def8
     preresolved: true

--- a/ci/pipelines/build-eirini-images.yml
+++ b/ci/pipelines/build-eirini-images.yml
@@ -7,8 +7,8 @@ resources:
 - name: eirini
   type: git
   source:
-    uri: git@github.com:cloudfoundry-incubator/eirini.git
-    branch: 1.9.0
+    uri: git@github.com:Birdrock/eirini.git
+    branch: 1.9.0-backport-stop-hardcoding-uid-2000
     private_key: ((cf_for_k8s_readonly_deploy_key.private_key))
 - name: eirini-release
   type: github-release
@@ -66,7 +66,7 @@ jobs:
         path: /bin/echo
         args:
         - -e
-        - git@github.com:cloudfoundry/cf-for-k8s.git 85228baffd607dac652170a20c282715a05e105f ci/templates/build-eirini-images.yml \e[31mdirty\e[0m
+        - git@github.com:cloudfoundry/cf-for-k8s.git 6abae6fcfdc78c97176a5b0053c7241d5f28b9b2 ci/templates/build-eirini-images.yml \e[31mdirty\e[0m
   - get: eirini
   - get: eirini-release
     trigger: true
@@ -153,7 +153,7 @@ jobs:
         path: /bin/echo
         args:
         - -e
-        - git@github.com:cloudfoundry/cf-for-k8s.git 85228baffd607dac652170a20c282715a05e105f ci/templates/build-eirini-images.yml \e[31mdirty\e[0m
+        - git@github.com:cloudfoundry/cf-for-k8s.git 6abae6fcfdc78c97176a5b0053c7241d5f28b9b2 ci/templates/build-eirini-images.yml \e[31mdirty\e[0m
   - get: eirini
   - get: eirini-release
     trigger: true
@@ -240,7 +240,7 @@ jobs:
         path: /bin/echo
         args:
         - -e
-        - git@github.com:cloudfoundry/cf-for-k8s.git 85228baffd607dac652170a20c282715a05e105f ci/templates/build-eirini-images.yml \e[31mdirty\e[0m
+        - git@github.com:cloudfoundry/cf-for-k8s.git 6abae6fcfdc78c97176a5b0053c7241d5f28b9b2 ci/templates/build-eirini-images.yml \e[31mdirty\e[0m
   - get: eirini
   - get: eirini-release
     trigger: true
@@ -327,7 +327,7 @@ jobs:
         path: /bin/echo
         args:
         - -e
-        - git@github.com:cloudfoundry/cf-for-k8s.git 85228baffd607dac652170a20c282715a05e105f ci/templates/build-eirini-images.yml \e[31mdirty\e[0m
+        - git@github.com:cloudfoundry/cf-for-k8s.git 6abae6fcfdc78c97176a5b0053c7241d5f28b9b2 ci/templates/build-eirini-images.yml \e[31mdirty\e[0m
   - get: eirini
   - get: eirini-release
     trigger: true
@@ -414,7 +414,7 @@ jobs:
         path: /bin/echo
         args:
         - -e
-        - git@github.com:cloudfoundry/cf-for-k8s.git 85228baffd607dac652170a20c282715a05e105f ci/templates/build-eirini-images.yml \e[31mdirty\e[0m
+        - git@github.com:cloudfoundry/cf-for-k8s.git 6abae6fcfdc78c97176a5b0053c7241d5f28b9b2 ci/templates/build-eirini-images.yml \e[31mdirty\e[0m
   - get: eirini
   - get: eirini-release
     trigger: true

--- a/ci/templates/build-eirini-images.yml
+++ b/ci/templates/build-eirini-images.yml
@@ -7,8 +7,8 @@ resources:
 - name: eirini
   type: git
   source:
-    uri: git@github.com:cloudfoundry-incubator/eirini.git
-    branch: #@ eirini_tag
+    uri: git@github.com:Birdrock/eirini.git
+    branch: 1.9.0-backport-stop-hardcoding-uid-2000
     private_key: ((cf_for_k8s_readonly_deploy_key.private_key))
 
 - name: eirini-release

--- a/config/eirini/_ytt_lib/eirini/rendered.yml
+++ b/config/eirini/_ytt_lib/eirini/rendered.yml
@@ -1134,8 +1134,8 @@ metadata:
     kbld.k14s.io/images: |
       - Metas:
         - Type: preresolved
-          URL: index.docker.io/relintdockerhubpushbot/cf-for-k8s-eirini-opi@sha256:4a438c75a0b923a6f043d8f60052c9f3c079768e1a9557d2aa42956ca134be47
-        URL: index.docker.io/relintdockerhubpushbot/cf-for-k8s-eirini-opi@sha256:4a438c75a0b923a6f043d8f60052c9f3c079768e1a9557d2aa42956ca134be47
+          URL: index.docker.io/relintdockerhubpushbot/cf-for-k8s-eirini-opi@sha256:d20c957c36644e8f9878bfee1633f319b2e94c82b66b16f9565b5796ed20817b
+        URL: index.docker.io/relintdockerhubpushbot/cf-for-k8s-eirini-opi@sha256:d20c957c36644e8f9878bfee1633f319b2e94c82b66b16f9565b5796ed20817b
   name: eirini
   namespace: cf-system
 spec:
@@ -1149,7 +1149,7 @@ spec:
         name: eirini
     spec:
       containers:
-      - image: index.docker.io/relintdockerhubpushbot/cf-for-k8s-eirini-opi@sha256:4a438c75a0b923a6f043d8f60052c9f3c079768e1a9557d2aa42956ca134be47
+      - image: index.docker.io/relintdockerhubpushbot/cf-for-k8s-eirini-opi@sha256:d20c957c36644e8f9878bfee1633f319b2e94c82b66b16f9565b5796ed20817b
         imagePullPolicy: Always
         name: opi
         ports:
@@ -1218,8 +1218,8 @@ metadata:
     kbld.k14s.io/images: |
       - Metas:
         - Type: preresolved
-          URL: index.docker.io/relintdockerhubpushbot/cf-for-k8s-eirini-eirini-controller@sha256:67c0749667d926270c55a627b7c1af47bbbfdf49981b098cc3a153f2a098208e
-        URL: index.docker.io/relintdockerhubpushbot/cf-for-k8s-eirini-eirini-controller@sha256:67c0749667d926270c55a627b7c1af47bbbfdf49981b098cc3a153f2a098208e
+          URL: index.docker.io/relintdockerhubpushbot/cf-for-k8s-eirini-eirini-controller@sha256:52a7892033893d3d09b2582ae3d562433b30372dcb3678a37e0efd73d174d342
+        URL: index.docker.io/relintdockerhubpushbot/cf-for-k8s-eirini-eirini-controller@sha256:52a7892033893d3d09b2582ae3d562433b30372dcb3678a37e0efd73d174d342
   name: eirini-controller
   namespace: cf-system
 spec:
@@ -1232,7 +1232,7 @@ spec:
         name: eirini-controller
     spec:
       containers:
-      - image: index.docker.io/relintdockerhubpushbot/cf-for-k8s-eirini-eirini-controller@sha256:67c0749667d926270c55a627b7c1af47bbbfdf49981b098cc3a153f2a098208e
+      - image: index.docker.io/relintdockerhubpushbot/cf-for-k8s-eirini-eirini-controller@sha256:52a7892033893d3d09b2582ae3d562433b30372dcb3678a37e0efd73d174d342
         imagePullPolicy: Always
         name: eirini-controller
         resources:
@@ -1264,8 +1264,8 @@ metadata:
     kbld.k14s.io/images: |
       - Metas:
         - Type: preresolved
-          URL: index.docker.io/relintdockerhubpushbot/cf-for-k8s-eirini-event-reporter@sha256:e001382be607454912e7310e19b0e02545a68694a92888b5ffd98399efd2d251
-        URL: index.docker.io/relintdockerhubpushbot/cf-for-k8s-eirini-event-reporter@sha256:e001382be607454912e7310e19b0e02545a68694a92888b5ffd98399efd2d251
+          URL: index.docker.io/relintdockerhubpushbot/cf-for-k8s-eirini-event-reporter@sha256:b06e19ac5232a1077474933e412143f1e4449df94b5899d1e6b29fa823c92b3f
+        URL: index.docker.io/relintdockerhubpushbot/cf-for-k8s-eirini-event-reporter@sha256:b06e19ac5232a1077474933e412143f1e4449df94b5899d1e6b29fa823c92b3f
   name: eirini-events
   namespace: cf-system
 spec:
@@ -1278,7 +1278,7 @@ spec:
         name: eirini-events
     spec:
       containers:
-      - image: index.docker.io/relintdockerhubpushbot/cf-for-k8s-eirini-event-reporter@sha256:e001382be607454912e7310e19b0e02545a68694a92888b5ffd98399efd2d251
+      - image: index.docker.io/relintdockerhubpushbot/cf-for-k8s-eirini-event-reporter@sha256:b06e19ac5232a1077474933e412143f1e4449df94b5899d1e6b29fa823c92b3f
         imagePullPolicy: Always
         name: event-reporter
         resources:
@@ -1327,8 +1327,8 @@ metadata:
     kbld.k14s.io/images: |
       - Metas:
         - Type: preresolved
-          URL: index.docker.io/relintdockerhubpushbot/cf-for-k8s-eirini-instance-index-env-injector@sha256:e0dffee2efbe7cba308fc9adf247ef9b232260becc801bf67c75f8c81d4af3af
-        URL: index.docker.io/relintdockerhubpushbot/cf-for-k8s-eirini-instance-index-env-injector@sha256:e0dffee2efbe7cba308fc9adf247ef9b232260becc801bf67c75f8c81d4af3af
+          URL: index.docker.io/relintdockerhubpushbot/cf-for-k8s-eirini-instance-index-env-injector@sha256:ad9adc876d588fbc6b0592a1f8a9b24efd41e8dcd06ae2244192a7651499def8
+        URL: index.docker.io/relintdockerhubpushbot/cf-for-k8s-eirini-instance-index-env-injector@sha256:ad9adc876d588fbc6b0592a1f8a9b24efd41e8dcd06ae2244192a7651499def8
   name: instance-index-env-injector
   namespace: cf-system
 spec:
@@ -1343,7 +1343,7 @@ spec:
         name: instance-index-env-injector
     spec:
       containers:
-      - image: index.docker.io/relintdockerhubpushbot/cf-for-k8s-eirini-instance-index-env-injector@sha256:e0dffee2efbe7cba308fc9adf247ef9b232260becc801bf67c75f8c81d4af3af
+      - image: index.docker.io/relintdockerhubpushbot/cf-for-k8s-eirini-instance-index-env-injector@sha256:ad9adc876d588fbc6b0592a1f8a9b24efd41e8dcd06ae2244192a7651499def8
         imagePullPolicy: Always
         name: instance-index-env-injector
         ports:
@@ -1377,8 +1377,8 @@ metadata:
     kbld.k14s.io/images: |
       - Metas:
         - Type: preresolved
-          URL: index.docker.io/relintdockerhubpushbot/cf-for-k8s-eirini-task-reporter@sha256:82a8b38ee4d3c1eb924b7356fe5d1f9493a9c47d0b63dbecc4eef4d982402e03
-        URL: index.docker.io/relintdockerhubpushbot/cf-for-k8s-eirini-task-reporter@sha256:82a8b38ee4d3c1eb924b7356fe5d1f9493a9c47d0b63dbecc4eef4d982402e03
+          URL: index.docker.io/relintdockerhubpushbot/cf-for-k8s-eirini-task-reporter@sha256:b6173cbf13ecff7f789acc9fb38667caacbdef8a7ee5e0667e7c1470564fa5da
+        URL: index.docker.io/relintdockerhubpushbot/cf-for-k8s-eirini-task-reporter@sha256:b6173cbf13ecff7f789acc9fb38667caacbdef8a7ee5e0667e7c1470564fa5da
   name: eirini-task-reporter
   namespace: cf-system
 spec:
@@ -1391,7 +1391,7 @@ spec:
         name: eirini-task-reporter
     spec:
       containers:
-      - image: index.docker.io/relintdockerhubpushbot/cf-for-k8s-eirini-task-reporter@sha256:82a8b38ee4d3c1eb924b7356fe5d1f9493a9c47d0b63dbecc4eef4d982402e03
+      - image: index.docker.io/relintdockerhubpushbot/cf-for-k8s-eirini-task-reporter@sha256:b6173cbf13ecff7f789acc9fb38667caacbdef8a7ee5e0667e7c1470564fa5da
         imagePullPolicy: Always
         name: task-reporter
         resources:


### PR DESCRIPTION
## WHAT is this change about?
This PR configures cf-for-k8s to use a forked and patched version of Eirini images that loosens the UID requirement. It removes the UID 2000 requirement, while still requiring non-root through the security context

## Does this PR introduce a change to `config/values.yml`?
No.

## Acceptance Steps
Deploy with a stack that has a non-2000 (non-root) UID. The reference set we used is contained in this PR: https://github.com/cloudfoundry/cf-for-k8s/pull/487

## Tag your pair, your PM, and/or team
@paulcwarren @acosta11 