### PR TITLE
reformat version in upgrade job

### DIFF
--- a/build/istio/build.sh
+++ b/build/istio/build.sh
@@ -7,4 +7,4 @@ ${SCRIPT_DIR}/generate.sh "$@" | kbld -f - > "${SCRIPT_DIR}/../../config/istio/i
 
 # save the current Istio version in the networking configs
 ISTIO_VERSION="$(< "${SCRIPT_DIR}/values.yaml" yq -r .istio_version)"
-sed -r -i'' 's/(return)(.*)$/\1 "'${ISTIO_VERSION}'"/' "${SCRIPT_DIR}/../../config/istio/upgrade-istio-sidecars-job.yml"
+sed -r -i'' 's/(return)(.*\..*\..*)$/\1 "'${ISTIO_VERSION}'"/' "${SCRIPT_DIR}/../../config/istio/upgrade-istio-sidecars-job.yml"

--- a/config/istio/upgrade-istio-sidecars-job.yml
+++ b/config/istio/upgrade-istio-sidecars-job.yml
@@ -65,7 +65,7 @@ subjects:
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: #@ "restart-workloads-for-istio" + build_version()
+  name: #@ "restart-workloads-for-istio" + build_version().replace(".", "-")
   namespace: #@ workloads_namespace()
   labels:
     cloudfoundry.org/istio_version: #@ build_version()


### PR DESCRIPTION
Co-authored-by: Kauana dos Santos <kdossantos@vmware.com>

## WHAT is this change about?
We want to avoid having `.`s in pod names because some platforms don't
allow that.

[#175169873](https://www.pivotaltracker.com/story/show/175169873)


## Does this PR introduce a change to `config/values.yml`?
No

## Acceptance Steps
**When** I have a cluster with cf-for-k8s deployed
**And** I describe the `restart-sidecar-job` with `k get po -n cf-workloads | grep "restart"`
**Then** I see that the pod name is `restart-workloads-for-istio1-7-1-<hash>` and **not** `restart-workloads-for-istio1.7.1-<hash>`

## Tag your pair, your PM, and/or team
@kauana @cloudfoundry/cf-for-k8s-networking 