### PR TITLE
Revert "Merge pull request #512 from cloudfoundry/disablePrometheusMerge"

### DIFF
--- a/build/istio/istioctl-values.yaml
+++ b/build/istio/istioctl-values.yaml
@@ -40,7 +40,7 @@ spec:
       rewriteAppHTTPProbe: true
     meshConfig:
       accessLogEncoding: 'JSON'
-      enablePrometheusMerge: false
+      enablePrometheusMerge: true
       enableAutoMtls: true
       accessLogFile: "/dev/stdout"
       accessLogFormat: >-

--- a/config/istio/istio-generated/xxx-generated-istio.yaml
+++ b/config/istio/istio-generated/xxx-generated-istio.yaml
@@ -7756,7 +7756,7 @@ data:
           address: zipkin.istio-system:9411
     disableMixerHttpReports: true
     enableAutoMtls: true
-    enablePrometheusMerge: false
+    enablePrometheusMerge: true
     rootNamespace: istio-system
     trustDomain: cluster.local
   meshNetworks: 'networks: {}'
@@ -8453,6 +8453,9 @@ spec:
   template:
     metadata:
       annotations:
+        prometheus.io/path: /stats/prometheus
+        prometheus.io/port: "15090"
+        prometheus.io/scrape: "true"
         sidecar.istio.io/inject: "false"
       labels:
         app: istio-ingressgateway
@@ -8730,6 +8733,8 @@ spec:
   template:
     metadata:
       annotations:
+        prometheus.io/port: "15014"
+        prometheus.io/scrape: "true"
         sidecar.istio.io/inject: "false"
       labels:
         app: istiod


### PR DESCRIPTION
This reverts commit d0fafb31bdfe70a17b1928c9d21c6469a341a30b, reversing changes made to ade4b94637c2ecc922d988e484b357230a03b5a6.

## WHAT is this change about?
We're enabling this back, because we cannot make Prometheus scrape metrics over mTLS because of https://github.com/istio/istio/issues/27824 

## Does this PR introduce a change to `config/values.yml`?
No

## Acceptance Steps
Tests should pass

## Tag your pair, your PM, and/or team
@cloudfoundry/cf-for-k8s-networking 