### PR TITLE
Run Istio Ingressgateway pod as root

### DIFF
--- a/build/istio/overlays/ingressgateway-as-root.yaml
+++ b/build/istio/overlays/ingressgateway-as-root.yaml
@@ -1,0 +1,15 @@
+#@ load("@ytt:overlay", "overlay")
+#@ load("@ytt:data", "data")
+
+#@ deployment = overlay.subset({"kind": "Deployment", "metadata":{"name":"istio-ingressgateway"}})
+#@ daemonset = overlay.subset({"kind": "DaemonSet", "metadata":{"name":"istio-ingressgateway"}})
+#@ match_ingress_gateway=overlay.or_op(deployment, daemonset)
+
+#@overlay/match by=match_ingress_gateway
+---
+spec:
+  template:
+    spec:
+      #@overlay/replace
+      securityContext:
+        runAsNonRoot: false

--- a/config/istio/istio-generated/xxx-generated-istio.yaml
+++ b/config/istio/istio-generated/xxx-generated-istio.yaml
@@ -8649,10 +8649,7 @@ spec:
           name: dockercontainers
           readOnly: true
       securityContext:
-        fsGroup: 1337
-        runAsGroup: 1337
-        runAsNonRoot: true
-        runAsUser: 1337
+        runAsNonRoot: false
       serviceAccountName: istio-ingressgateway-service-account
       terminationGracePeriodSeconds: 80
       volumes:


### PR DESCRIPTION
## WHAT is this change about?

We need to run Ingressgateway as root to allow fluent-bit sidecar to access Docker container logs as only root user can view them. 

It's required for `cf logs` command to show access logs of the app.

[#175210582](https://www.pivotaltracker.com/story/show/175210582)

Closes #520 


## Does this PR introduce a change to `config/values.yml`?
No

## Acceptance Steps
`cf logs <app_name>` shows the access logs of the app

## Tag your pair, your PM, and/or team
@cloudfoundry/cf-for-k8s-networking 

