### PR TITLE
175210100 update secret rotation branch

### DIFF
--- a/ci/pipelines/cf-for-k8s-stability-tests.yml
+++ b/ci/pipelines/cf-for-k8s-stability-tests.yml
@@ -178,7 +178,7 @@ jobs:
 
           bosh interpolate --path /cf_admin_password cf-install-values.yml > env-metadata/cf-admin-password.txt
           echo "${DNS_DOMAIN}" > env-metadata/dns-domain.txt
-          grep -E "capi_db_encryption_key|db_admin_password|capi_db_password|uaa_db_password|blobstore_secret_key|cf_admin_password" "/tmp/${cluster_name}.${DOMAIN}/cf-vars.yaml" > env-metadata/cf-vars.yaml
+          grep -E "capi_db_encryption_key|capi_db_password|uaa_db_password|blobstore_secret_key|cf_admin_password" "/tmp/${cluster_name}.${DOMAIN}/cf-vars.yaml" > env-metadata/cf-vars.yaml
 
   - task: push-test-app
     file: cf-for-k8s-ci/ci/tasks/push-test-app/task.yml

--- a/docs/platform_operators/rotating-secrets-and-certs.md
+++ b/docs/platform_operators/rotating-secrets-and-certs.md
@@ -42,8 +42,6 @@ use either the old password or the new one, and will fail.
 
 * `cf_admin_password` - manual upgrade works, CI/upgrade fails
 
-* `cf_db.admin_password` - manual upgrade works, CI/upgrade works
-
 * `uaa.database.password` - manual upgrade works, CI/upgrade fails: "Error unmarshalling the following into a cloud controller error: no healthy upstream"
 
 ## Notes on Currently Supported Rotations

--- a/docs/platform_operators/rotating-secrets-and-certs.md
+++ b/docs/platform_operators/rotating-secrets-and-certs.md
@@ -2,7 +2,35 @@
 Most secrets in cf-for-k8s can be rotated by simply changing the values in your `cf-values.yml` file and running a standard deploy using ytt and kapp. The rotation is complete when the kapp deploy succeeds.
 
 ## Exceptions
-As of September 2020, it is currently not possible to rotate `app_registry` credentials. Future work on this will be tracked by https://www.pivotaltracker.com/story/show/173090115
+
+The following fields currently cannot be rotated:
+
+* `blobstore.secret_access_key`
+* `capi.database.encryption_key`
+* `capi.database.password`
+* `cf_admin_password`
+* `cf_db.admin_password`
+* `uaa.database.password`
+
+For example, rotating the cloud controller db encryption key is a breaking change. Rotating the key will 
+require a recreating your environment (including deleting database contents) in order to prevent decryption errors when fetching
+previously-saved data.
+
+If you find you must rotate one of the above fields: 
+
+1. Delete your cf with `kapp delete -a cf`
+1. Then, in your `cf-values.yaml`, you will need to update the properties that need rotating.
+1. Enter your updated values and rerun `kapp deploy -a cf ...`. 
+
+## Specific Issues
+
+
+* [Rotating non-admin user/role credentials in postgres fails](https://github.com/cloudfoundry/cf-for-k8s/issues/216) 
+
+* [Support rotation of `blobstore.secret_access_key`](https://github.com/cloudfoundry/cf-for-k8s/issues/527)
+
+
+## Notes on Currently Supported Rotations
 
 ### Rotating Ingress Certificates
 To rotate the application domain certificate or system domain certificate, you
@@ -17,21 +45,3 @@ successfully rotated in the Istio Ingress Gateway.
 If you have multiple app domains, they all share the `workloads_certificate`.
 You cannot rotate the app domains' certificates separately because there is only
 one certificate.
-
-
-### Cloud Controller Database Encryption Key
-
-Prior to cf-for-k8s 1.0, rotating the cloud controller db encryption key is a breaking change. Rotating the key will 
-require a recreating your environment (including deleting database contents) in order to prevent decryption errors when fetching
-previously-saved data.
-
-If you find you must rotate the encryption key, 
-
-1. Delete your cf with `kapp delete -a cf`
-1. Then, in your `cf-values.yaml`, you will need to update the following property:
-```
-capi:
-  database:
-    encryption_key: [KEY]
-```
-1. Enter a secure value for [KEY] and deploy. 

--- a/docs/platform_operators/rotating-secrets-and-certs.md
+++ b/docs/platform_operators/rotating-secrets-and-certs.md
@@ -34,4 +34,4 @@ capi:
   database:
     encryption_key: [KEY]
 ```
-1.Enter a secure value for [KEY] and deploy. 
+1. Enter a secure value for [KEY] and deploy. 

--- a/docs/platform_operators/rotating-secrets-and-certs.md
+++ b/docs/platform_operators/rotating-secrets-and-certs.md
@@ -24,10 +24,29 @@ If you find you must rotate one of the above fields:
 
 ## Specific Issues
 
+### Outright Errors
 
 * [Rotating non-admin user/role credentials in postgres fails](https://github.com/cloudfoundry/cf-for-k8s/issues/216) 
 
 * [Support rotation of `blobstore.secret_access_key`](https://github.com/cloudfoundry/cf-for-k8s/issues/527)
+
+* [Support rotation of `capi.database.encryption_key`](https://github.com/cloudfoundry/cf-for-k8s/issues/529)
+
+* [Support rotation of `capi.database.password`](https://github.com/cloudfoundry/cf-for-k8s/issues/530)
+
+### Concourse/CI Issues
+
+The following fields can be modified and are updated eventually, but
+`uptimer`-type checking in the pipelines are currently configured to
+use either the old password or the new one, and will fail.
+
+* `cf_admin_password` - manual upgrade works, CI/upgrade fails
+
+* `db_admin_password` - manual upgrade works, CI/upgrade works
+
+* `uaa_db_password` - manual upgrade works, CI/upgrade fails: "Error unmarshalling the following into a cloud controller error: no healthy upstream"
+
+
 
 
 ## Notes on Currently Supported Rotations

--- a/docs/platform_operators/rotating-secrets-and-certs.md
+++ b/docs/platform_operators/rotating-secrets-and-certs.md
@@ -8,9 +8,6 @@ The following fields currently cannot be rotated:
 * `blobstore.secret_access_key`
 * `capi.database.encryption_key`
 * `capi.database.password`
-* `cf_admin_password`
-* `cf_db.admin_password`
-* `uaa.database.password`
 
 For example, rotating the cloud controller db encryption key is a breaking change. Rotating the key will 
 require a recreating your environment (including deleting database contents) in order to prevent decryption errors when fetching

--- a/docs/platform_operators/rotating-secrets-and-certs.md
+++ b/docs/platform_operators/rotating-secrets-and-certs.md
@@ -42,12 +42,9 @@ use either the old password or the new one, and will fail.
 
 * `cf_admin_password` - manual upgrade works, CI/upgrade fails
 
-* `db_admin_password` - manual upgrade works, CI/upgrade works
+* `cf_db.admin_password` - manual upgrade works, CI/upgrade works
 
-* `uaa_db_password` - manual upgrade works, CI/upgrade fails: "Error unmarshalling the following into a cloud controller error: no healthy upstream"
-
-
-
+* `uaa.database.password` - manual upgrade works, CI/upgrade fails: "Error unmarshalling the following into a cloud controller error: no healthy upstream"
 
 ## Notes on Currently Supported Rotations
 


### PR DESCRIPTION
## WHAT is this change about?

Document which fields currently are not correctly rotated, and point to bugs.

Additionally, point out which fields are rotated, but cause a CI job to fail when they're changed due to the way the job is written.

## Does this PR introduce a change to `config/values.yml`?
No

## Acceptance Steps
Mostly, verify that the updater jobs in CI, like `cf-for-k8s-stability-tests/validate-values-rotation-redeploy` passes. 

Note that this is mostly a documentation change. It can be verified by changing one of the fields listed in [the rotation doc](https://github.com/cloudfoundry/cf-for-k8s/blob/175210100-update-secret-rotation-branch/docs/platform_operators/rotating-secrets-and-certs.md#specific-issues), redeploy, and verify the foundation still works.

## Tag your pair, your PM, and/or team
@jamespollard8 


## Things to remember
[x] - Make sure this PR is based off the `develop` branch
[x] - Include any links to related PRs, issues, stories, slack discussions, etc... that will help establish context.
-- None

