### PR TITLE
Fix yq syntax in deploy doc

### DIFF
--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -205,7 +205,7 @@ Currently, we test the following two container registries:
 
    ```console
    cf auth admin <cf-values.yml.cf-admin_password>
-   # or using yq: cf auth admin "$(yq -r '.cf_admin_password' ${TMP_DIR}/cf-values.yml)"
+   # or using yq: cf auth admin "$(yq r ${TMP_DIR}/cf-values.yml 'cf_admin_password')"
    ```
 
 1. Create an org/space for your app:


### PR DESCRIPTION
Signed-off-by: Paul Czarkowski <username.taken@gmail.com>

## WHAT is this change about?

[yq syntax](https://mikefarah.gitbook.io/yq/commands/read) was wrong in the docs 




## Does this PR introduce a change to `config/values.yml`?

no 

## Acceptance Steps

validate the YQ command as specified.
