### PR TITLE
DOCS: add statement to clarify internal database and blobstore usage

### DIFF
--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -265,7 +265,7 @@ Use the following resources to enable additional features in cf-for-k8s:
 - [Setup ingress certs with letsencrypt](platform_operators/setup-ingress-certs-with-letsencrypt.md)
 - [Setup static loadbalancer IP](platform_operators/setup-static-loadbalancer-ip.md)
 - [Setup an external database](platform_operators/external-databases.md), which we recommend for Production environments
-- [Setup an external blobstore](platform_operators/external-blobstore.md)
+- [Setup an external blobstore](platform_operators/external-blobstore.md), which we recommend for Production environments
 
 ## Roadmap and milestones
 You can find the project roadmap (github project) [here](https://github.com/cloudfoundry/cf-for-k8s/projects/4) and our upcoming milestones [here](https://github.com/cloudfoundry/cf-for-k8s/milestones). Feel free to ask questions in the [#cf-for-k8s channel](https://cloudfoundry.slack.com/archives/CH9LF6V1P) in the CloudFoundry slack or submit new feature requests or issues on this repo.

--- a/docs/platform_operators/external-blobstore.md
+++ b/docs/platform_operators/external-blobstore.md
@@ -1,5 +1,9 @@
 # Using an external blobstore
 
+The out-of-the-box blobstore is in support of the kick-the-tyres user and should just work.
+
+For all other users we recommend configuring your deployment with an external blobstore.
+
 1. Create the necessary buckets using `aws-cli`:
 
     ```

--- a/docs/platform_operators/external-databases.md
+++ b/docs/platform_operators/external-databases.md
@@ -1,5 +1,8 @@
 # Using external databases
 
+The included postgres database is in support of the kick-the-tyres user and should just work.
+
+For all other users we recommend configuring your deployment with an external database.
 
 You can use an external database for the CF API and UAA by providing following values:
 


### PR DESCRIPTION
Clarify that the internal database and blobstore and intended for the kick-the-tyres user only. 

All other users should configure their deployment with external database and blobstore.

[#175406567](https://www.pivotaltracker.com/story/show/175406567)