### PR TITLE
Fix buildpacks endpoint not accepting zip uploads

### DIFF
--- a/config/capi/_ytt_lib/capi-k8s-release/templates/nginx-configmap.yml
+++ b/config/capi/_ytt_lib/capi-k8s-release/templates/nginx-configmap.yml
@@ -67,6 +67,13 @@ data:
             upload_pass_args on;
             upload_pass_form_field "^resources$";
           }
+
+          location ~ /v3/buildpacks/.*/upload {
+            include public_upload.conf;
+
+            upload_pass_args on;
+            upload_pass_form_field "^resources$";
+          }
       }
 
       server {


### PR DESCRIPTION
## WHAT is this change about?
One option for `cf create-buildpack` is to specify a local file. The current nginx CAPI config for this workflow isn't allowing large uploads which results in a `413` when this method is used.

## Does this PR introduce a change to `config/values.yml`?
No

## Acceptance Steps
```
cf create-buildpack more-foo9 python-runtime-0.0.169.zip
```

Where `python-runtime-0.0.169.zip` is a zipped up version of a buildpack, for example, this [python buildpack tgz](https://github.com/paketo-community/python-runtime/releases/download/v0.0.169/python-runtime-0.0.169.tgz) uncompressed/untarred and then zipped.


## Tag your pair, your PM, and/or team
Co-authored-by: Joe Eltgroth <jeltgroth@vmware.com>

