### PR TITLE
add cf_api_backup_metadata_generator UAA client

### DIFF
--- a/config/capi/capi.yml
+++ b/config/capi/capi.yml
@@ -54,6 +54,8 @@ uaa:
       secret_name: cloud-controller-username-lookup-client-secret
     cf_api_controllers:
       secret_name: cf-api-controllers-client-secret
+    cf_api_backup_metadata_generator:
+      secret_name: cf-api-backup-metadata-generator-secret
 
 kpack:
   registry:
@@ -118,6 +120,15 @@ metadata:
 type: Opaque
 stringData:
   password: #@ data.values.capi.cf_api_controllers_client_secret
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: cf-api-backup-metadata-generator-client-secret
+  namespace: #@ system_namespace()
+type: Opaque
+stringData:
+  password: #@ data.values.capi.cf_api_backup_metadata_generator_client_secret
 ---
 apiVersion: v1
 kind: Secret

--- a/config/get_missing_parameters.star
+++ b/config/get_missing_parameters.star
@@ -43,6 +43,7 @@ app_registry.username
 blobstore.secret_access_key
 capi.cc_username_lookup_client_secret
 capi.cf_api_controllers_client_secret
+capi.cf_api_backup_metadata_generator_client_secret
 capi.database.encryption_key
 capi.database.password
 cf_admin_password

--- a/config/uaa/uaa.yml
+++ b/config/uaa/uaa.yml
@@ -134,6 +134,9 @@ oauth:
     cf_api_controllers:
       authorities: cloud_controller.write,cloud_controller.read,cloud_controller.update_build_state,cloud_controller.admin_read_only
       authorized-grant-types: client_credentials
+    cf_api_backup_metadata_generator:
+      authorities: cloud_controller.read,cloud_controller.admin_read_only
+      authorized-grant-types: client_credentials
   #@overlay/match missing_ok=True
   user:
     authorities:
@@ -277,6 +280,7 @@ scim:
 --- #@ uaa_client_credential("cf", "", "uaa-cf-client-secret")
 --- #@ uaa_client_credential("cloud_controller_username_lookup", data.values.capi.cc_username_lookup_client_secret, "uaa-cloud-controller-username-lookup-client-secret")
 --- #@ uaa_client_credential("cf_api_controllers", data.values.capi.cf_api_controllers_client_secret, "uaa-cf-api-controllers-client-secret")
+--- #@ uaa_client_credential("cf_api_backup_metadata_generator", data.values.capi.cf_api_backup_metadata_generator_client_secret, "uaa-cf-api-backup-metadata-generator-client-secret")
 
 ---
 apiVersion: v1
@@ -319,6 +323,11 @@ spec:
           mountPath: #@ "{}/cf_api_controllers_client_credentials.yml".format(secrets_dir)
           subPath: client_credentials.yml
           readOnly: true
+        #@overlay/append
+        - name: cf-api-backup-metadata-generator-client-credentials-file
+          mountPath: #@ "{}/cf_api_backup_metadata_generator_client_credentials.yml".format(secrets_dir)
+          subPath: client_credentials.yml
+          readOnly: true
       volumes:
       #@overlay/append
       - name: cf-admin-user-credentials-file
@@ -336,3 +345,7 @@ spec:
       - name: cf-api-controllers-client-credentials-file
         secret:
           secretName: uaa-cf-api-controllers-client-secret
+      #@overlay/append
+      - name: cf-api-backup-metadata-generator-client-credentials-file
+        secret:
+          secretName: uaa-cf-api-backup-metadata-generator-client-secret

--- a/config/values/20-secrets-config-values.yml
+++ b/config/values/20-secrets-config-values.yml
@@ -3,6 +3,7 @@
 ---
 capi:
   cf_api_controllers_client_secret: ""
+  cf_api_backup_metadata_generator_client_secret: ""
   cc_username_lookup_client_secret: ""
 
 #! control optional deployment of a database for CF

--- a/docs/platform_operators/config-values.md
+++ b/docs/platform_operators/config-values.md
@@ -12,6 +12,7 @@ Default values are set in files like `config/values/00-values.yml`
 | blobstore.secret_access_key | Blobstore secret access key | Yes | no value | Potrzebie |
 | capi.cc_username_lookup_client_secret | CF API client secret | Yes | no value | o/L4Zsu6ZAgw4+Qj |
 | capi.cf_api_controllers_client_secret | API controller client secret | Yes | no value | q/3PZsu6ZAgw4+Qj |
+| capi.cf_api_backup_metadata_generator_client_secret | Backup metadata utility client secret | Yes | no value | q/3PZsu6ZAgw4+Qj |
 | capi.database.adapter | database adapter for use by capi | No | postgres | postgres | mysql |
 | capi.database.ca_cert | authority of the certificate used for tls connections to the database | No | no value |  |
 | capi.database.encryption_key | key used to encrypt database records at rest | Yes | no value | YqEgP7KxSjUmQTSX9drTkQLye8wrqrP4 |

--- a/hack/generate-values.sh
+++ b/hack/generate-values.sh
@@ -109,6 +109,8 @@ variables:
   type: password
 - name: cf_api_controllers_client_secret
   type: password
+- name: cf_api_backup_metadata_generator_client_secret
+  type: password
 - name: default_ca
   type: certificate
   options:
@@ -177,6 +179,7 @@ cf_db:
 capi:
   cc_username_lookup_client_secret: $(bosh interpolate ${VARS_FILE} --path=/cc_username_lookup_client_secret)
   cf_api_controllers_client_secret: $(bosh interpolate ${VARS_FILE} --path=/cf_api_controllers_client_secret)
+  cf_api_backup_metadata_generator_client_secret: $(bosh interpolate ${VARS_FILE} --path=/cf_api_backup_metadata_generator_client_secret)
   database:
     password: $(bosh interpolate ${VARS_FILE} --path=/capi_db_password)
     encryption_key: $(bosh interpolate ${VARS_FILE} --path=/capi_db_encryption_key)

--- a/sample-cf-install-values.yml
+++ b/sample-cf-install-values.yml
@@ -25,6 +25,7 @@ cf_db:
 #! The db password shared between CAPI and the database.
 capi:
   cf_api_controllers_client_secret: uaa_cf_api_controllers_client_credentials
+  cf_api_backup_metadata_generator_client_secret: uaa_cf_api_backup_metadata_generator_client_credentials
   cc_username_lookup_client_secret: uaa_cloud_controller_lookup_client_credentials
   database:
     password: ccdb_password

--- a/tests/ytt/missing_attributes_test.go
+++ b/tests/ytt/missing_attributes_test.go
@@ -42,7 +42,7 @@ var _ = Describe("Missing Attributes", func() {
 		})
 
 		It("should list all the required attributes", func() {
-			Expect(ctx).To(ThrowError(`The following required data.values parameters are missing: \["app_domains", "app_registry.hostname", "app_registry.password", "app_registry.repository_prefix", "app_registry.username", "blobstore.secret_access_key", "capi.cc_username_lookup_client_secret", "capi.cf_api_controllers_client_secret", "capi.database.encryption_key", "capi.database.password", "cf_admin_password", "internal_certificate.ca", "internal_certificate.crt", "internal_certificate.key", "system_certificate.crt", "system_certificate.key", "system_domain", "uaa.admin_client_secret", "uaa.database.password", "uaa.encryption_key.passphrase", "uaa.jwt_policy.signing_key", "uaa.login.service_provider.certificate", "uaa.login.service_provider.key", "uaa.login_secret", "workloads_certificate.crt", "workloads_certificate.key"\]`))
+			Expect(ctx).To(ThrowError(`The following required data.values parameters are missing: \["app_domains", "app_registry.hostname", "app_registry.password", "app_registry.repository_prefix", "app_registry.username", "blobstore.secret_access_key", "capi.cc_username_lookup_client_secret", "capi.cf_api_controllers_client_secret", "capi.cf_api_backup_metadata_generator_client_secret", "capi.database.encryption_key", "capi.database.password", "cf_admin_password", "internal_certificate.ca", "internal_certificate.crt", "internal_certificate.key", "system_certificate.crt", "system_certificate.key", "system_domain", "uaa.admin_client_secret", "uaa.database.password", "uaa.encryption_key.passphrase", "uaa.jwt_policy.signing_key", "uaa.login.service_provider.certificate", "uaa.login.service_provider.key", "uaa.login_secret", "workloads_certificate.crt", "workloads_certificate.key"\]`))
 		})
 	})
 
@@ -59,7 +59,7 @@ var _ = Describe("Missing Attributes", func() {
 		})
 
 		It("should complain about missing attributes", func() {
-			Expect(ctx).To(ThrowError(`The following required data.values parameters are missing: \["app_registry.username", "capi.cc_username_lookup_client_secret", "capi.cf_api_controllers_client_secret", "cf_admin_password", "internal_certificate.ca", "internal_certificate.crt", "internal_certificate.key", "system_certificate.key", "uaa.encryption_key.passphrase", "uaa.jwt_policy.signing_key", "uaa.login.service_provider.certificate", "uaa.login.service_provider.key", "uaa.login_secret", "workloads_certificate.crt"\]`))
+			Expect(ctx).To(ThrowError(`The following required data.values parameters are missing: \["app_registry.username", "capi.cc_username_lookup_client_secret", "capi.cf_api_controllers_client_secret", "capi.cf_api_backup_metadata_generator_client_secret", "cf_admin_password", "internal_certificate.ca", "internal_certificate.crt", "internal_certificate.key", "system_certificate.key", "uaa.encryption_key.passphrase", "uaa.jwt_policy.signing_key", "uaa.login.service_provider.certificate", "uaa.login.service_provider.key", "uaa.login_secret", "workloads_certificate.crt"\]`))
 		})
 	})
 

--- a/tests/ytt/uaa/uaa-values.yml
+++ b/tests/ytt/uaa/uaa-values.yml
@@ -44,6 +44,7 @@ uaa:
 capi:
   cc_username_lookup_client_secret:
   cf_api_controllers_client_secret:
+  cf_api_backup_metadata_generator_client_secret:
 
 enable_automount_service_account_token:
 remove_resource_requirements:


### PR DESCRIPTION
## WHAT is this change about?
This adds a UAA client will be used by the cf-api-backup-metadata-container to scrape some metadata about the CF installation to include as part of a Velero backup.

See this doc for more information:
https://docs.google.com/document/d/1aR6_v0wTrSWpH9G2XqHcUTsdCNzP82ZsiWUxiN-4Zno/edit#heading=h.9fh5dt50qkx0

CAKE Story: [#175469923](https://www.pivotaltracker.com/story/show/175469923)

## Does this PR introduce a change to `config/values.yml`?
Yes

## Acceptance Steps
You can test that this client was successfully created by:

1. Authenticating with UAA / CF API
```
cf auth cf_api_backup_metadata_generator <generated-client-secret> --client-credentials
```

2. Curl some endpoints and see them succeed
```
cf curl /v3/spaces
```

cc/ @cloudfoundry/cf-api-kubernetes-evolution @neil-hickey