### PR TITLE
fix secret_name for cf_api_backup_metadata_generator client

### DIFF
--- a/config/capi/capi.yml
+++ b/config/capi/capi.yml
@@ -55,7 +55,7 @@ uaa:
     cf_api_controllers:
       secret_name: cf-api-controllers-client-secret
     cf_api_backup_metadata_generator:
-      secret_name: cf-api-backup-metadata-generator-secret
+      secret_name: cf-api-backup-metadata-generator-client-secret
 
 kpack:
   registry:


### PR DESCRIPTION
## WHAT is this change about?
This is a followup PR for a mistake made in https://github.com/cloudfoundry/cf-for-k8s/pull/555.

It includes a pending change to the cf-api-controllers deployment so that this is adequately tested by CI
It is OK if that change is reverted since it will come through via a vendir sync in the future and works fine without it for now.

That can either be done through CI naturally as it bumps to the latest capi-k8s-release or manually while merging this.

## Does this PR introduce a change to `config/values.yml`?
No

## Acceptance Steps
Same as https://github.com/cloudfoundry/cf-for-k8s/pull/555. You should be able to do something like this and see it work after the deploy has succeeded:

```
kubectl exec -n cf-system cf-api-controllers-6cb4d79d5c-z6ntn -c backup-metadata-generator -- "/cnb/process/generate-metadata"
```

CAKE Story: [#175469923](https://www.pivotaltracker.com/story/show/175469923)
