### PR TITLE
Improve run-cats ci task.

### DIFF
--- a/ci/tasks/run-cats/task.sh
+++ b/ci/tasks/run-cats/task.sh
@@ -84,9 +84,15 @@ pushd cf-acceptance-tests
     -randomizeAllSpecs \
     -flakeAttempts=${NUM_FLAKE_ATTEMPTS} \
     -nodes=${NUM_NODES}
-  # As of 2020-08-02, we're seeing CATS failures when using >6 nodes
-  # CATS run time looks like
+  # Around 2020-08-02, we saw CATS failures when using >6 nodes.
+  #
+  # Proportional CATS run time looks like
   # nodes | run time
-  #     6 | 20min
+  #     6 | x minutes
+  #     3 | 1.5x minutes
+  #     1 | 4x minutes
+  #
+  # For current CATS runtime using GKE and 6 nodes, see:
+  # https://release-integration.ci.cf-app.com/teams/main/pipelines/cf-for-k8s-main/jobs/run-cats
 
 popd

--- a/ci/tasks/run-cats/task.sh
+++ b/ci/tasks/run-cats/task.sh
@@ -5,8 +5,10 @@ CONFIG_DIR="$(pwd)/config"
 mkdir -p ${CONFIG_DIR}
 CATS_CONFIG_FILE="${CONFIG_DIR}/cats_config.json"
 
-DNS_DOMAIN=$(cat env-metadata/dns-domain.txt)
-CF_ADMIN_PASSWORD="$(cat env-metadata/cf-admin-password.txt)"
+if [[ -e env-metadata ]]; then
+  DNS_DOMAIN=$(cat env-metadata/dns-domain.txt)
+  CF_ADMIN_PASSWORD="$(cat env-metadata/cf-admin-password.txt)"
+fi
 
 set +x
 echo '{}' | jq \

--- a/ci/tasks/run-cats/task.sh
+++ b/ci/tasks/run-cats/task.sh
@@ -8,12 +8,15 @@ CATS_CONFIG_FILE="${CONFIG_DIR}/cats_config.json"
 if [[ -e env-metadata ]]; then
   DNS_DOMAIN=$(cat env-metadata/dns-domain.txt)
   CF_ADMIN_PASSWORD="$(cat env-metadata/cf-admin-password.txt)"
+
+  CF_APPS_DOMAIN="apps.${DNS_DOMAIN}"
+  CF_API_DOMAIN="api.${DNS_DOMAIN}"
 fi
 
 set +x
 echo '{}' | jq \
---arg cf_api_url "api.${DNS_DOMAIN}" \
---arg cf_apps_url "apps.${DNS_DOMAIN}" \
+--arg cf_api_url "${CF_API_DOMAIN}" \
+--arg cf_apps_url "${CF_APPS_DOMAIN}" \
 --arg cf_admin_password "${CF_ADMIN_PASSWORD}" \
 --argjson cf_push_timeout "${CF_PUSH_TIMEOUT}" \
 --argjson default_timeout "${DEFAULT_TIMEOUT}" \
@@ -77,9 +80,6 @@ pushd cf-acceptance-tests
   # As of 2020-08-02, we're seeing CATS failures when using >6 nodes
   # CATS run time looks like
   # nodes | run time
-  #     1 | 47min
-  #     3 | 17min
-  #     6 | 11min
-  #    12 | fails
+  #     6 | 20min
 
 popd

--- a/ci/tasks/run-cats/task.sh
+++ b/ci/tasks/run-cats/task.sh
@@ -35,6 +35,13 @@ echo '{}' | jq \
 --argjson include_services "${INCLUDE_SERVICES}" \
 --argjson include_tasks "${INCLUDE_TASKS}" \
 --argjson include_v3 "${INCLUDE_V3}" \
+--argjson ruby_buildpack "${RUBY_BUILDPACK}" \
+--argjson python_buildpack "${PYTHON_BUILDPACK}" \
+--argjson go_buildpack "${GO_BUILDPACK}" \
+--argjson java_buildpack "${JAVA_BUILDPACK}" \
+--argjson nodejs_buildpack "${NODEJS_BUILDPACK}" \
+--argjson php_buildpack "${PHP_BUILDPACK}" \
+--argjson binary_buildpack "${BINARY_BUILDPACK}" \
 '{
   "api": $cf_api_url,
   "admin_user": "admin",
@@ -59,13 +66,13 @@ echo '{}' | jq \
   "include_tasks": $include_tasks,
   "include_v3": $include_v3,
   "infrastructure": "kubernetes",
-  "ruby_buildpack_name": "paketo-buildpacks/ruby",
-  "python_buildpack_name": "paketo-community/python",
-  "go_buildpack_name": "paketo-buildpacks/go",
-  "java_buildpack_name": "paketo-buildpacks/java",
-  "nodejs_buildpack_name": "paketo-buildpacks/nodejs",
-  "php_buildpack_name": "paketo-buildpacks/php",
-  "binary_buildpack_name": "paketo-buildpacks/procfile"
+  "ruby_buildpack_name": $ruby_buildpack,
+  "python_buildpack_name": $python_buildpack,
+  "go_buildpack_name": $go_buildpack,
+  "java_buildpack_name": $java_buildpack,
+  "nodejs_buildpack_name": $nodejs_buildpack,
+  "php_buildpack_name": $php_buildpack,
+  "binary_buildpack_name": $binary_buildpack
 }' > "${CATS_CONFIG_FILE}"
 # `cf_push_timeout` and `default_timeout` are set fairly arbitrarily
 

--- a/ci/tasks/run-cats/task.sh
+++ b/ci/tasks/run-cats/task.sh
@@ -35,13 +35,13 @@ echo '{}' | jq \
 --argjson include_services "${INCLUDE_SERVICES}" \
 --argjson include_tasks "${INCLUDE_TASKS}" \
 --argjson include_v3 "${INCLUDE_V3}" \
---argjson ruby_buildpack "${RUBY_BUILDPACK}" \
---argjson python_buildpack "${PYTHON_BUILDPACK}" \
---argjson go_buildpack "${GO_BUILDPACK}" \
---argjson java_buildpack "${JAVA_BUILDPACK}" \
---argjson nodejs_buildpack "${NODEJS_BUILDPACK}" \
---argjson php_buildpack "${PHP_BUILDPACK}" \
---argjson binary_buildpack "${BINARY_BUILDPACK}" \
+--arg ruby_buildpack "${RUBY_BUILDPACK}" \
+--arg python_buildpack "${PYTHON_BUILDPACK}" \
+--arg go_buildpack "${GO_BUILDPACK}" \
+--arg java_buildpack "${JAVA_BUILDPACK}" \
+--arg nodejs_buildpack "${NODEJS_BUILDPACK}" \
+--arg php_buildpack "${PHP_BUILDPACK}" \
+--arg binary_buildpack "${BINARY_BUILDPACK}" \
 '{
   "api": $cf_api_url,
   "admin_user": "admin",

--- a/ci/tasks/run-cats/task.yml
+++ b/ci/tasks/run-cats/task.yml
@@ -7,8 +7,6 @@ image_resource:
     repository: relintdockerhubpushbot/cf-for-k8s-ci
 
 inputs:
-- name: cf-for-k8s
-  optional: true # Should remove as this is unused in sh file.
 - name: cf-for-k8s-ci
 - name: env-metadata
   optional: true

--- a/ci/tasks/run-cats/task.yml
+++ b/ci/tasks/run-cats/task.yml
@@ -8,11 +8,15 @@ image_resource:
 
 inputs:
 - name: cf-for-k8s
+  optional: true # Should remove as this is unused in sh file.
 - name: cf-for-k8s-ci
 - name: env-metadata
+  optional: true
 - name: cf-acceptance-tests
 
 params:
+  DNS_DOMAIN:
+  CF_ADMIN_PASSWORD:
   NUM_FLAKE_ATTEMPTS: 2
   NUM_NODES: 6
   SKIP_SSL_VALIDATION: true

--- a/ci/tasks/run-cats/task.yml
+++ b/ci/tasks/run-cats/task.yml
@@ -37,6 +37,13 @@ params:
   INCLUDE_SERVICES: false
   INCLUDE_TASKS: false
   INCLUDE_V3: false
+  RUBY_BUILDPACK: paketo-buildpacks/ruby
+  PYTHON_BUILDPACK: paketo-community/python
+  GO_BUILDPACK: paketo-buildpacks/go
+  JAVA_BUILDPACK: paketo-buildpacks/java
+  NODEJS_BUILDPACK: paketo-buildpacks/nodejs
+  PHP_BUILDPACK: paketo-buildpacks/php
+  BINARY_BUILDPACK: paketo-buildpacks/procfile
 
 run:
   path: cf-for-k8s-ci/ci/tasks/run-cats/task.sh

--- a/ci/tasks/run-cats/task.yml
+++ b/ci/tasks/run-cats/task.yml
@@ -15,7 +15,8 @@ inputs:
 - name: cf-acceptance-tests
 
 params:
-  DNS_DOMAIN:
+  CF_APPS_DOMAIN:
+  CF_API_DOMAIN:
   CF_ADMIN_PASSWORD:
   NUM_FLAKE_ATTEMPTS: 2
   NUM_NODES: 6


### PR DESCRIPTION
- Add the option to provide DNS_DOMAIN and CF_ADMIN_PASSWORD as Concourse
params.


## Does this PR introduce a change to `config/values.yml`?
> No

## Acceptance Steps
> Run cats ci task and it continues to work.

## Tag your pair, your PM, and/or team
> @jamespollard8 
