### PR TITLE
Enable proxy protocol for Ingress Envoy

### DIFF
--- a/config/istio/use-proxy-protocol.yml
+++ b/config/istio/use-proxy-protocol.yml
@@ -1,0 +1,21 @@
+#@ load("@ytt:data", "data")
+#@ if data.values.enable_proxy_protocol:
+---
+apiVersion: networking.istio.io/v1alpha3
+kind: EnvoyFilter
+metadata:
+  name: proxy-protocol
+  namespace: istio-system
+spec:
+  workloadSelector:
+    labels:
+      istio: ingressgateway
+  configPatches:
+  - applyTo: LISTENER
+    patch:
+      operation: MERGE
+      value:
+        listener_filters:
+        - name: envoy.listener.proxy_protocol
+        - name: envoy.listener.tls_inspector
+#@ end

--- a/config/values/00-values.yml
+++ b/config/values/00-values.yml
@@ -77,6 +77,7 @@ use_external_dns_for_wildcard: false
 enable_automount_service_account_token: false
 metrics_server_prefer_internal_kubelet_address: false
 use_first_party_jwt_tokens: false
+enable_proxy_protocol: false
 
 #! configuration for the CF blobstore
 blobstore:

--- a/sample-cf-install-values.yml
+++ b/sample-cf-install-values.yml
@@ -112,6 +112,7 @@ use_external_dns_for_wildcard: true
 enable_automount_service_account_token: true
 metrics_server_prefer_internal_kubelet_address: true
 use_first_party_jwt_tokens: true
+enable_proxy_protocol: true
 
 load_balancer:
   enable: false


### PR DESCRIPTION
> Thanks for contributing to cf-for-k8s!
> We've designed this PR template to speed up the PR review and merge process - please use it.

## WHAT is this change about?
Some Load Balancers like AWS ELB replace the client IP by their own IP. In that case the feature "X-Forwarded-For" cannot be used because the X-Forwarded-For-Header contains the IP of the Load Balancer. By using the proxy protocol between LB and Ingress Envoy the client IP will be set in the X-Forwarded-For-Header by Envoy. This feature must be enabled on both sides. But per default for Envoy the proxy protocol is not enabled. With this change the proxy protocol can be enabled for Envoy by applying an EnvoyFilter.


## Does this PR introduce a change to `config/values.yml`?
Yes

## Acceptance Steps
1. Enable the proxy protocol on your LB (not transparent like AWS ELB).
2. Set enable_proxy_protocol value to true.
3. Check that the X-Forwarded-For-Header in a cf app contains the client IP.

## Tag your pair, your PM, and/or team
@stefanlay


## Things to remember
Feature request: https://github.com/cloudfoundry/cf-for-k8s/issues/561
