### PR TITLE
Note that `uaa.database.password` is currently not rotatable

### DIFF
--- a/docs/platform_operators/rotating-secrets-and-certs.md
+++ b/docs/platform_operators/rotating-secrets-and-certs.md
@@ -41,8 +41,6 @@ use either the old password or the new one, and will fail.
 
 * `cf_admin_password` - manual upgrade works, CI/upgrade fails
 
-* `ci/pipelines/cf-for-k8s-stability-tests.yml` - manual upgrade works, CI/upgrade fails: "Error unmarshalling the following into a cloud controller error: no healthy upstream"
-
 ## Notes on Currently Supported Rotations
 
 ### Rotating Ingress Certificates

--- a/docs/platform_operators/rotating-secrets-and-certs.md
+++ b/docs/platform_operators/rotating-secrets-and-certs.md
@@ -31,6 +31,8 @@ If you find you must rotate one of the above fields:
 
 * [Support rotation of `capi.database.password`](https://github.com/cloudfoundry/cf-for-k8s/issues/530)
 
+* [Support rotation of `uaa.database.password`](https://github.com/cloudfoundry/cf-for-k8s/issues/566)
+
 ### Concourse/CI Issues
 
 The following fields can be modified and are updated eventually, but
@@ -39,7 +41,7 @@ use either the old password or the new one, and will fail.
 
 * `cf_admin_password` - manual upgrade works, CI/upgrade fails
 
-* `uaa.database.password` - manual upgrade works, CI/upgrade fails: "Error unmarshalling the following into a cloud controller error: no healthy upstream"
+* `ci/pipelines/cf-for-k8s-stability-tests.yml` - manual upgrade works, CI/upgrade fails: "Error unmarshalling the following into a cloud controller error: no healthy upstream"
 
 ## Notes on Currently Supported Rotations
 


### PR DESCRIPTION
[#175313436](https://www.pivotaltracker.com/story/show/175313436)

Co-authored-by: Andrew Wittrock <awittrock@vmware.com>

## WHAT is this change about?

Continuation of PR #538 

Doc change only to `docs/platform_operators/rotating-secrets-and-certs.md`

## Acceptance Steps
> Read the change
> Agree with them and accept the change or disagree and get back to us

Eric and @Birdrock 

Original story at https://www.pivotaltracker.com/story/show/175210100
