### PR TITLE
Update deploy-local.md

### DIFF
--- a/docs/deploy-local.md
+++ b/docs/deploy-local.md
@@ -55,7 +55,7 @@ Configuration Notes:
 
    ```console
    # from the cf-for-k8s repo/directory
-   k8s_minor_version="$(yq -r .newest_version supported_k8s_versions.yml)"  # or k8s_minor_version="1.17"
+   k8s_minor_version="$(yq r supported_k8s_versions.yml newest_version)"  # or k8s_minor_version="1.17"
    patch_version=$(wget -q https://registry.hub.docker.com/v1/repositories/kindest/node/tags -O - | \
      jq -r '.[].name' | grep -E "^v${k8s_minor_version}.[0-9]+$" | \
      cut -d. -f3 | sort -rn | head -1)


### PR DESCRIPTION
correct yq syntax



> Thanks for contributing to cf-for-k8s!
>
> We've designed this PR template to speed up the PR review and merge process - please use it.

## WHAT is this change about?
> I found a yq syntax issue in the definition of k8s_minor_version

## Does this PR introduce a change to `config/values.yml`?
> No

## Acceptance Steps
> ➜  cf-for-k8s git:(develop) yq --version
yq version 3.4.1
➜  cf-for-k8s git:(develop) yq -r .newest_version supported_k8s_versions.yml
Error: unknown command "supported_k8s_versions.yml" for "yq"
Run 'yq --help' for usage.
➜  cf-for-k8s git:(develop) yq r supported_k8s_versions.yml newest_version
1.19
➜  cf-for-k8s git:(develop)

## Tag your pair, your PM, and/or team
> N/A

## Things to remember
- Make sure this PR is based off the `develop` branch
- Include any links to related PRs, issues, stories, slack discussions, etc... that will help establish context.
- Is there anything else of note that the reviewers should know about this change?
- Our CI uses concourse task files from HEAD of the `develop` branch. If your PR includes/requires CI changes, please ping the RelInt interrupt and they'll help apply the CI changes for you.
- Checkout the [contributing guidelines](https://github.com/cloudfoundry/cf-for-k8s/blob/develop/community/CONTRIBUTING.md)
