### PR TITLE
Allow docker auth for smoke tests

### DIFF
--- a/tests/smoke/smoke_test.go
+++ b/tests/smoke/smoke_test.go
@@ -108,7 +108,14 @@ var _ = Describe("Smoke Tests", func() {
 			appName = generator.PrefixedRandomName(NamePrefix, "app")
 
 			By("pushing an app and checking that the CF CLI command succeeds")
-			cfPush := cf.Cf("push", appName, "-o", "cfrouting/httpbin")
+
+			var cfPush *Session
+			dockerUsername, userExists := os.LookupEnv("CF_DOCKER_USERNAME")
+			if userExists {
+				cfPush = cf.Cf("push", appName, "-o", "cfrouting/httpbin", "--docker-username", dockerUsername)
+			} else {
+				cfPush = cf.Cf("push", appName, "-o", "cfrouting/httpbin")
+			}
 			Eventually(cfPush).Should(Exit(0))
 
 			By("querying the app")


### PR DESCRIPTION

> Thanks for contributing to cf-for-k8s!
>
> We've designed this PR template to speed up the PR review and merge process - please use it.

## WHAT is this change about?
This passes through environment variables to the smoke tests for dockerhub authentication. Related to https://github.com/cloudfoundry/cf-for-k8s/issues/580.

## Does this PR introduce a change to `config/values.yml`?
No

## Acceptance Steps
> _Please replace this with a series of instructions (eg kubectl or cf cli commands) for how our Product Manager can verify that your changes were properly integrated._

## Tag your pair, your PM, and/or team
> _Optional but it's helpful to tag a few other folks on your team or your team alias in case we need to follow up later._


## Things to remember
- Make sure this PR is based off the `develop` branch
- Include any links to related PRs, issues, stories, slack discussions, etc... that will help establish context.
- Is there anything else of note that the reviewers should know about this change?
- Our CI uses concourse task files from HEAD of the `develop` branch. If your PR includes/requires CI changes, please ping the RelInt interrupt and they'll help apply the CI changes for you.
- Checkout the [contributing guidelines](https://github.com/cloudfoundry/cf-for-k8s/blob/develop/community/CONTRIBUTING.md)
