### PR TITLE
FIX: Update the eirini image SHAs

### DIFF
--- a/build/eirini/osl-compliant-image-override.yml
+++ b/build/eirini/osl-compliant-image-override.yml
@@ -3,17 +3,17 @@ kind: Config
 minimumRequiredVersion: 0.22.0
 overrides:
   - image: eirini/opi@sha256:1b2b281949197294954ab035749fcaa1b1e93591b2c028747e217e539a27a65b
-    newImage: index.docker.io/cloudfoundry/eirini-opi-cf-for-k8s@sha256:4936d0a6012b6a06f9a09b7fcdf7aaf2884e7339a10828fc25c01771c4fa5c83
+    newImage: index.docker.io/cloudfoundry/eirini-opi-cf-for-k8s@sha256:1ad949284c2c1f182bbd56bd1eae8202030fdef3afced39a4105a8403ebf0beb
     preresolved: true
   - image: eirini/event-reporter@sha256:9743bb498c4c4f89e8e38a61ba594ef9af00dbaa99a2eb081b2ddabe69cb72ca
-    newImage: index.docker.io/cloudfoundry/eirini-event-reporter-cf-for-k8s@sha256:fec0d3138a373d4d19bf5d08dad8b4fc42b40ca4dc8d8bef33ceb5ca5dc407d3
+    newImage: index.docker.io/cloudfoundry/eirini-event-reporter-cf-for-k8s@sha256:1798ea550cfb7b1457698dc9a9766ad5333da05c1e0cd29e748b7db34e648e1b
     preresolved: true
   - image: eirini/eirini-controller@sha256:c802ca5623b970686c77e5497a43daebc4911306d8043e4ecfda4746d20383eb
-    newImage: index.docker.io/cloudfoundry/eirini-eirini-controller-cf-for-k8s@sha256:d0a2cca1b32f412f38677302db8189d46bdb42a7efa04c1457476ecb066c68d1
+    newImage: index.docker.io/cloudfoundry/eirini-eirini-controller-cf-for-k8s@sha256:8651c21931d6a13a0ec2f74c11402086b1cd30cb2e8c2c6fba400abe493c33a8
     preresolved: true
   - image: eirini/task-reporter@sha256:fe45f32d739213e301eaaea152db505225c9d17a6ca8b7502f3a14d2e2f5bf69
-    newImage: index.docker.io/cloudfoundry/eirini-task-reporter-cf-for-k8s@sha256:3d7a67628f67255cd86f106ff2a729a743cb790b55c309a1155621f4d574a109
+    newImage: index.docker.io/cloudfoundry/eirini-task-reporter-cf-for-k8s@sha256:2715ac192d671788f2512cf116ac9b483402e477af3d9481724cc40134363d61
     preresolved: true
   - image: eirini/instance-index-env-injector@sha256:fa7bef28c805e8fd23d23d9d4312eab6ac92eff69817b2312db2bf71daedb496
-    newImage: index.docker.io/cloudfoundry/eirini-instance-index-env-injector-cf-for-k8s@sha256:141ac75dc212fff1909a7fd155449ff4eeea0d8f9d7dc4a75d81ca46753e7e72
+    newImage: index.docker.io/cloudfoundry/eirini-instance-index-env-injector-cf-for-k8s@sha256:42ab156d08756e46e7ebfa280e55c51305648aa133587d262e19fcd30ea0ae64
     preresolved: true

--- a/config/eirini/_ytt_lib/eirini/rendered.yml
+++ b/config/eirini/_ytt_lib/eirini/rendered.yml
@@ -1125,8 +1125,8 @@ metadata:
     kbld.k14s.io/images: |
       - Metas:
         - Type: preresolved
-          URL: index.docker.io/cloudfoundry/eirini-opi-cf-for-k8s@sha256:4936d0a6012b6a06f9a09b7fcdf7aaf2884e7339a10828fc25c01771c4fa5c83
-        URL: index.docker.io/cloudfoundry/eirini-opi-cf-for-k8s@sha256:4936d0a6012b6a06f9a09b7fcdf7aaf2884e7339a10828fc25c01771c4fa5c83
+          URL: index.docker.io/cloudfoundry/eirini-opi-cf-for-k8s@sha256:1ad949284c2c1f182bbd56bd1eae8202030fdef3afced39a4105a8403ebf0beb
+        URL: index.docker.io/cloudfoundry/eirini-opi-cf-for-k8s@sha256:1ad949284c2c1f182bbd56bd1eae8202030fdef3afced39a4105a8403ebf0beb
   name: eirini
   namespace: cf-system
 spec:
@@ -1139,7 +1139,7 @@ spec:
         name: eirini
     spec:
       containers:
-      - image: index.docker.io/cloudfoundry/eirini-opi-cf-for-k8s@sha256:4936d0a6012b6a06f9a09b7fcdf7aaf2884e7339a10828fc25c01771c4fa5c83
+      - image: index.docker.io/cloudfoundry/eirini-opi-cf-for-k8s@sha256:1ad949284c2c1f182bbd56bd1eae8202030fdef3afced39a4105a8403ebf0beb
         imagePullPolicy: IfNotPresent
         name: opi
         ports:
@@ -1208,8 +1208,8 @@ metadata:
     kbld.k14s.io/images: |
       - Metas:
         - Type: preresolved
-          URL: index.docker.io/cloudfoundry/eirini-eirini-controller-cf-for-k8s@sha256:d0a2cca1b32f412f38677302db8189d46bdb42a7efa04c1457476ecb066c68d1
-        URL: index.docker.io/cloudfoundry/eirini-eirini-controller-cf-for-k8s@sha256:d0a2cca1b32f412f38677302db8189d46bdb42a7efa04c1457476ecb066c68d1
+          URL: index.docker.io/cloudfoundry/eirini-eirini-controller-cf-for-k8s@sha256:8651c21931d6a13a0ec2f74c11402086b1cd30cb2e8c2c6fba400abe493c33a8
+        URL: index.docker.io/cloudfoundry/eirini-eirini-controller-cf-for-k8s@sha256:8651c21931d6a13a0ec2f74c11402086b1cd30cb2e8c2c6fba400abe493c33a8
   name: eirini-controller
   namespace: cf-system
 spec:
@@ -1222,7 +1222,7 @@ spec:
         name: eirini-controller
     spec:
       containers:
-      - image: index.docker.io/cloudfoundry/eirini-eirini-controller-cf-for-k8s@sha256:d0a2cca1b32f412f38677302db8189d46bdb42a7efa04c1457476ecb066c68d1
+      - image: index.docker.io/cloudfoundry/eirini-eirini-controller-cf-for-k8s@sha256:8651c21931d6a13a0ec2f74c11402086b1cd30cb2e8c2c6fba400abe493c33a8
         imagePullPolicy: IfNotPresent
         name: eirini-controller
         resources:
@@ -1254,8 +1254,8 @@ metadata:
     kbld.k14s.io/images: |
       - Metas:
         - Type: preresolved
-          URL: index.docker.io/cloudfoundry/eirini-event-reporter-cf-for-k8s@sha256:fec0d3138a373d4d19bf5d08dad8b4fc42b40ca4dc8d8bef33ceb5ca5dc407d3
-        URL: index.docker.io/cloudfoundry/eirini-event-reporter-cf-for-k8s@sha256:fec0d3138a373d4d19bf5d08dad8b4fc42b40ca4dc8d8bef33ceb5ca5dc407d3
+          URL: index.docker.io/cloudfoundry/eirini-event-reporter-cf-for-k8s@sha256:1798ea550cfb7b1457698dc9a9766ad5333da05c1e0cd29e748b7db34e648e1b
+        URL: index.docker.io/cloudfoundry/eirini-event-reporter-cf-for-k8s@sha256:1798ea550cfb7b1457698dc9a9766ad5333da05c1e0cd29e748b7db34e648e1b
   name: eirini-events
   namespace: cf-system
 spec:
@@ -1268,7 +1268,7 @@ spec:
         name: eirini-events
     spec:
       containers:
-      - image: index.docker.io/cloudfoundry/eirini-event-reporter-cf-for-k8s@sha256:fec0d3138a373d4d19bf5d08dad8b4fc42b40ca4dc8d8bef33ceb5ca5dc407d3
+      - image: index.docker.io/cloudfoundry/eirini-event-reporter-cf-for-k8s@sha256:1798ea550cfb7b1457698dc9a9766ad5333da05c1e0cd29e748b7db34e648e1b
         imagePullPolicy: IfNotPresent
         name: event-reporter
         resources:
@@ -1317,8 +1317,8 @@ metadata:
     kbld.k14s.io/images: |
       - Metas:
         - Type: preresolved
-          URL: index.docker.io/cloudfoundry/eirini-instance-index-env-injector-cf-for-k8s@sha256:141ac75dc212fff1909a7fd155449ff4eeea0d8f9d7dc4a75d81ca46753e7e72
-        URL: index.docker.io/cloudfoundry/eirini-instance-index-env-injector-cf-for-k8s@sha256:141ac75dc212fff1909a7fd155449ff4eeea0d8f9d7dc4a75d81ca46753e7e72
+          URL: index.docker.io/cloudfoundry/eirini-instance-index-env-injector-cf-for-k8s@sha256:42ab156d08756e46e7ebfa280e55c51305648aa133587d262e19fcd30ea0ae64
+        URL: index.docker.io/cloudfoundry/eirini-instance-index-env-injector-cf-for-k8s@sha256:42ab156d08756e46e7ebfa280e55c51305648aa133587d262e19fcd30ea0ae64
   name: instance-index-env-injector
   namespace: cf-system
 spec:
@@ -1333,7 +1333,7 @@ spec:
         name: instance-index-env-injector
     spec:
       containers:
-      - image: index.docker.io/cloudfoundry/eirini-instance-index-env-injector-cf-for-k8s@sha256:141ac75dc212fff1909a7fd155449ff4eeea0d8f9d7dc4a75d81ca46753e7e72
+      - image: index.docker.io/cloudfoundry/eirini-instance-index-env-injector-cf-for-k8s@sha256:42ab156d08756e46e7ebfa280e55c51305648aa133587d262e19fcd30ea0ae64
         imagePullPolicy: IfNotPresent
         name: instance-index-env-injector
         ports:
@@ -1367,8 +1367,8 @@ metadata:
     kbld.k14s.io/images: |
       - Metas:
         - Type: preresolved
-          URL: index.docker.io/cloudfoundry/eirini-task-reporter-cf-for-k8s@sha256:3d7a67628f67255cd86f106ff2a729a743cb790b55c309a1155621f4d574a109
-        URL: index.docker.io/cloudfoundry/eirini-task-reporter-cf-for-k8s@sha256:3d7a67628f67255cd86f106ff2a729a743cb790b55c309a1155621f4d574a109
+          URL: index.docker.io/cloudfoundry/eirini-task-reporter-cf-for-k8s@sha256:2715ac192d671788f2512cf116ac9b483402e477af3d9481724cc40134363d61
+        URL: index.docker.io/cloudfoundry/eirini-task-reporter-cf-for-k8s@sha256:2715ac192d671788f2512cf116ac9b483402e477af3d9481724cc40134363d61
   name: eirini-task-reporter
   namespace: cf-system
 spec:
@@ -1381,7 +1381,7 @@ spec:
         name: eirini-task-reporter
     spec:
       containers:
-      - image: index.docker.io/cloudfoundry/eirini-task-reporter-cf-for-k8s@sha256:3d7a67628f67255cd86f106ff2a729a743cb790b55c309a1155621f4d574a109
+      - image: index.docker.io/cloudfoundry/eirini-task-reporter-cf-for-k8s@sha256:2715ac192d671788f2512cf116ac9b483402e477af3d9481724cc40134363d61
         imagePullPolicy: IfNotPresent
         name: task-reporter
         resources:


### PR DESCRIPTION
This PR achieves what #578 was supposed to.

- the eirini images this replaces were accidentally still based off our
  fork of eirini from before v2.0.0

This also depends on commit e193bcc , which moved the pipeline off of our temporary eirini 1.9.0+ branch (done while we were waiting for eirini 2.0.0 to ship).

[#175238690](https://www.pivotaltracker.com/story/show/175238690)

Co-authored-by: James Pollard <pollardja@vmware.com>

## Acceptance Steps
- sufficient for smoke tests and CATs to pass, given how this changes the images for running apps.



