### PR TITLE
Re add logging to smoke test

### DIFF
--- a/tests/smoke/assets/test-node-app/server.js
+++ b/tests/smoke/assets/test-node-app/server.js
@@ -4,4 +4,8 @@ http.createServer(function (request, response) {
    response.end('Hello World\n');
 }).listen(process.env.PORT);
 
-console.log('Console output from test-node-app');
+function logger() {
+    console.log('Console output from test-node-app');
+}
+
+setInterval(logger, 1000);

--- a/tests/smoke/smoke_test.go
+++ b/tests/smoke/smoke_test.go
@@ -100,6 +100,12 @@ var _ = Describe("Smoke Tests", func() {
 			body, err := ioutil.ReadAll(resp.Body)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(string(body)).To(Equal("Hello World\n"))
+
+			By("verifying that the application's logs are available.")
+			Eventually(func() string {
+				cfLogs := cf.Cf("logs", appName, "--recent")
+				return string(cfLogs.Wait().Out.Contents())
+			}, 2*time.Minute, 2*time.Second).Should(ContainSubstring("Console output from test-node-app"))
 		})
 
 		It("creates a routable app pod in Kubernetes from a docker app", func() {


### PR DESCRIPTION
- Make logging happen more frequent to mitigate lossiness

[#175542566](https://www.pivotaltracker.com/story/show/175542566)

Signed-off by: Tim Downey tdowney@vmware.com


## WHAT is this change about?
The smoke test for logging was unrealistic because it only emitted a single log. We made the smoke test app emit 1 log/second to overcome potential lossiness. 

## Does this PR introduce a change to `config/values.yml`?
No

## Acceptance Steps
The smoke tests should be less flaky

## Tag your pair, your PM, and/or team
@tcdowney @angelachin 
