### PR TITLE
Bump supported k8s versions to include v1.20.0

### DIFF
--- a/supported_k8s_versions.yml
+++ b/supported_k8s_versions.yml
@@ -1,3 +1,3 @@
 ---
 oldest_version: "1.16"
-newest_version: "1.19"
+newest_version: "1.20"


### PR DESCRIPTION
Simply bumping this value should trigger testing it in CI via the `newest-kind` job.
