### PR TITLE
ENH: use an annotated minio image

### DIFF
--- a/build/minio/build.sh
+++ b/build/minio/build.sh
@@ -7,4 +7,5 @@ echo "Generating Minio resource definitions..."
 
 helm template cf-blobstore --namespace=cf-blobstore -f "${SCRIPT_DIR}/values.yml" "${SCRIPT_DIR}/_vendir/stable/minio/" |
   ytt --ignore-unknown-comments -f - -f "${SCRIPT_DIR}/scrub_default_creds.yml" |
-  kbld -f - > "${SCRIPT_DIR}/../../config/minio/_ytt_lib/minio/rendered.yml"
+  kbld -f "${SCRIPT_DIR}/osl-compliant-image-override.yml" -f - \
+  > "${SCRIPT_DIR}/../../config/minio/_ytt_lib/minio/rendered.yml"

--- a/build/minio/osl-compliant-image-override.yml
+++ b/build/minio/osl-compliant-image-override.yml
@@ -1,0 +1,7 @@
+apiVersion: kbld.k14s.io/v1alpha1
+kind: Config
+minimumRequiredVersion: 0.22.0
+overrides:
+  - image: minio/minio:RELEASE.2020-06-14T18-32-17Z
+    newImage: cloudfoundry/minio-cf-for-k8s@sha256:5cb64001e21d6e3adb05717ca49aca34d52f576cf8365af28860d4afad383ea4
+    preresolved: true

--- a/config/minio/_ytt_lib/minio/rendered.yml
+++ b/config/minio/_ytt_lib/minio/rendered.yml
@@ -214,10 +214,9 @@ metadata:
   annotations:
     kbld.k14s.io/images: |
       - Metas:
-        - Tag: RELEASE.2020-06-14T18-32-17Z
-          Type: resolved
-          URL: minio/minio:RELEASE.2020-06-14T18-32-17Z
-        URL: index.docker.io/minio/minio@sha256:35d654988af3b5761162d5ce06243c1517ec34beeae271c8b5983b5082968858
+        - Type: preresolved
+          URL: cloudfoundry/minio-cf-for-k8s@sha256:5cb64001e21d6e3adb05717ca49aca34d52f576cf8365af28860d4afad383ea4
+        URL: cloudfoundry/minio-cf-for-k8s@sha256:5cb64001e21d6e3adb05717ca49aca34d52f576cf8365af28860d4afad383ea4
   labels:
     app: minio
     chart: minio-5.0.30
@@ -262,7 +261,7 @@ spec:
               name: cf-blobstore-minio
         - name: MINIO_API_READY_DEADLINE
           value: 5s
-        image: index.docker.io/minio/minio@sha256:35d654988af3b5761162d5ce06243c1517ec34beeae271c8b5983b5082968858
+        image: cloudfoundry/minio-cf-for-k8s@sha256:5cb64001e21d6e3adb05717ca49aca34d52f576cf8365af28860d4afad383ea4
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 1


### PR DESCRIPTION
- the image came from minio/minio:RELEASE.2020-06-14T18-32-17Z and has
been annotated and moved into the not-rate-limited cloudfoundry
dockerhub

## Does this PR introduce a change to `config/values.yml`?
Nope

## Acceptance Steps
Smoke tests (PR tests) pass
and
The minio image used in cf-for-k8s rendered templates comes from cloudfoundry docker hub and has deplab annotations on it when you `docker inspect` the image
