### PR TITLE
Update getting-started-tutorial.md

### DIFF
--- a/docs/getting-started-tutorial.md
+++ b/docs/getting-started-tutorial.md
@@ -91,6 +91,13 @@ $ cf api api.vcap.me --skip-ssl-validation
 $ cf auth admin $(yq read ${TMP_DIR}/cf-values.yml 'cf_admin_password')
 ```
 
+If **`yq` v4** is used, you can use the following format instead:
+
+```
+$ cf api api.vcap.me --skip-ssl-validation
+$ cf auth admin $(yq e '.cf_admin_password' ${TMP_DIR}/cf-values.yml)
+```
+
 ## Experiencing your first `cf push`
 
 Before we can push an application we need to create an organization and space for your application to exist in.


### PR DESCRIPTION
**yq v4** has removed support for `yq read` command and is replaced by `eval` with some change in the syntax.
The change is explained here https://mikefarah.gitbook.io/yq/upgrading-from-v3



> Thanks for contributing to cf-for-k8s!
>
> We've designed this PR template to speed up the PR review and merge process - please use it.

## WHAT is this change about?
> Update for the getting-started-tutorial.md to fix syntax change for `yq` that's breaking the authentication to cf api

## Does this PR introduce a change to `config/values.yml`?
> No

## Acceptance Steps
> Doc change

