### PR TITLE
guide the explorer to use the v7 of `cf`

### DIFF
--- a/docs/getting-started-tutorial.md
+++ b/docs/getting-started-tutorial.md
@@ -22,7 +22,7 @@ You’ll also need a few CLIs before you start:
 - [BOSH CLI](https://bosh.io/docs/cli-v2-install/#install); a handy tool to generate self signed certs and passwords, used by generate-values
 - [git](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git); the tool we use to interact with the cf-for-k8s repository
 - a [Dockerhub](https://hub.docker.com) account; cf-for-k8s will use this account to store your application images
-- [cf](https://docs.cloudfoundry.org/cf-cli/install-go-cli.html), the cli used to interact with Cloud Foundry 
+- [cf](https://docs.cloudfoundry.org/cf-cli/install-go-cli.html), the cli used to interact with Cloud Foundry (install v7)
 
 ## Installing Cf-for-K8s
 


### PR DESCRIPTION
by using v6 of cf you will face a none explanatory error: `Staging through the v2 API is disabled`
https://github.com/cloudfoundry/cf-for-k8s/issues/540#issuecomment-773184268



> Thanks for contributing to cf-for-k8s!
>
> We've designed this PR template to speed up the PR review and merge process - please use it.

## WHAT is this change about?
> _Please describe the change here_
The change is to guide the explorer to use v7 of `cf` or they will face an issue 
## Does this PR introduce a change to `config/values.yml`?
> _Simply answer Yes or No. You can also review [this "cf-for-k8s values for contributors" doc](https://docs.google.com/document/d/1Y3jAx48TCGIQdzOFmzqp_R_0WT8Hfjx9oyqs2Tk0Otw/edit#) for up-to-date principles and guidelines for contributing values changes_
No
## Acceptance Steps
> _Please replace this with a series of instructions (eg kubectl or cf cli commands) for how our Product Manager can verify that your changes were properly integrated._

## Tag your pair, your PM, and/or team
> _Optional but it's helpful to tag a few other folks on your team or your team alias in case we need to follow up later._


## Things to remember
- Make sure this PR is based off the `master` branch
- Include any links to related PRs, issues, stories, slack discussions, etc... that will help establish context.
- Is there anything else of note that the reviewers should know about this change?
- Our CI uses concourse task files from HEAD of the `develop` branch. If your PR includes/requires CI changes, please ping the RelInt interrupt and they'll help apply the CI changes for you.
- Checkout the [contributing guidelines](https://github.com/cloudfoundry/cf-for-k8s/blob/develop/community/CONTRIBUTING.md)
