### PR TITLE
Generate the instance index env injector certificate

### DIFF
--- a/config/eirini/eirini.yml
+++ b/config/eirini/eirini.yml
@@ -10,6 +10,17 @@
 #@ eirini = library.get("eirini")
 --- #@ template.replace(eirini.eval())
 
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: instance-index-env-injector-certs
+  namespace: #@ system_namespace()
+stringData:
+  tls.crt: #@ data.values.instance_index_env_injector_certificate.crt
+  tls.key: #@ data.values.instance_index_env_injector_certificate.key
+  tls.ca: #@ data.values.instance_index_env_injector_certificate.ca
+
 #! Allow app traffic from the istio-ingressgateway
 ---
 apiVersion: networking.k8s.io/v1

--- a/config/eirini/set-instance-index-env-injector-webhook-ca.yml
+++ b/config/eirini/set-instance-index-env-injector-webhook-ca.yml
@@ -1,0 +1,12 @@
+#@ load("@ytt:overlay", "overlay")
+#@ load("@ytt:data", "data")
+#@ load("@ytt:base64", "base64")
+
+#@overlay/match by=overlay.subset({"kind": "MutatingWebhookConfiguration", "metadata":{"name": "eirini-x-mutating-hook"}})
+---
+webhooks:
+#@overlay/match by="name"
+- name: instance-index-env-injector.eirini.cloudfoundry.org
+  clientConfig:
+    #@overlay/replace
+    caBundle: #@ base64.encode("{}".format(data.values.instance_index_env_injector_certificate.ca))

--- a/config/get_missing_parameters.star
+++ b/config/get_missing_parameters.star
@@ -59,6 +59,9 @@ cf_admin_password'''.split("\n")
     end
 
     required_parameters += '''\
+instance_index_env_injector_certificate.ca
+instance_index_env_injector_certificate.crt
+instance_index_env_injector_certificate.key
 system_certificate.crt
 system_certificate.key
 system_domain'''.split("\n")

--- a/config/values/20-secrets-config-values.yml
+++ b/config/values/20-secrets-config-values.yml
@@ -10,6 +10,15 @@ capi:
 cf_db:
   admin_password: ""
 
+instance_index_env_injector_certificate:
+  #! Certificate for the instance index env injector mutating webhook in eirini
+  #! CN=*.cf-system.svc
+  crt: ""
+  #! Private key for the instance index env injector certificate
+  key: ""
+  #! CA certificate key used by kube API to verify the instance index env injector webhook handler
+  ca: ""
+
 uaa:
   #! client secret for uaa admin client in plain text
   admin_client_secret: ""

--- a/hack/generate-values.sh
+++ b/hack/generate-values.sh
@@ -136,6 +136,15 @@ variables:
     - "*.apps.${DOMAIN}"
     extended_key_usage:
     - server_auth
+- name: instance_index_env_injector_certificate
+  type: certificate
+  options:
+    ca: default_ca
+    common_name: "*.cf-system.svc"
+    alternative_names:
+    - "*.cf-system.svc"
+    extended_key_usage:
+    - server_auth
 - name: uaa_jwt_policy_signing_key
   type: certificate
   options:
@@ -190,6 +199,15 @@ $(bosh interpolate ${VARS_FILE} --path=/workloads_certificate/certificate | grep
 $(bosh interpolate ${VARS_FILE} --path=/workloads_certificate/private_key | grep -Ev '^$' | sed -e 's/^/    /')
   ca: |
 $(bosh interpolate ${VARS_FILE} --path=/workloads_certificate/ca | grep -Ev '^$' | sed -e 's/^/    /')
+
+instance_index_env_injector_certificate:
+  #! This certificates and keys should be valid for *.cf-system.svc
+  crt: |
+$(bosh interpolate ${VARS_FILE} --path=/instance_index_env_injector_certificate/certificate | grep -Ev '^$' | sed -e 's/^/    /')
+  key: |
+$(bosh interpolate ${VARS_FILE} --path=/instance_index_env_injector_certificate/private_key | grep -Ev '^$' | sed -e 's/^/    /')
+  ca: |
+$(bosh interpolate ${VARS_FILE} --path=/instance_index_env_injector_certificate/ca | grep -Ev '^$' | sed -e 's/^/    /')
 
 uaa:
   database:

--- a/sample-cf-install-values.yml
+++ b/sample-cf-install-values.yml
@@ -54,6 +54,13 @@ workloads_certificate:
   key: workload_private_key
   ca: workload_certificate_ca
 
+#! certificate, private key, and certificate authority used for the instance index env injector mutating webhook in eirini
+#! - should be valid for *.cf-system.svc
+instance_index_env_injector_certificate:
+  crt: &crt instance_index_env_injector_certificate
+  key: &key instance_index_env_injector_private_key
+  ca: instance_index_env_injector_ca
+
 uaa:
   database:
     #! The db password shared between UAA and the database.

--- a/tests/ytt/missing_attributes/missing_attributes_values.yml
+++ b/tests/ytt/missing_attributes/missing_attributes_values.yml
@@ -22,6 +22,9 @@ workloads_certificate:
   #! crt: missing
   key: key
 
+
+#! instance_index_env_injector_certificate: missing completely
+
 uaa:
   database:
     password: blip

--- a/tests/ytt/missing_attributes_test.go
+++ b/tests/ytt/missing_attributes_test.go
@@ -45,7 +45,7 @@ var _ = Describe("Missing Attributes", func() {
 					pathToFile("tests/ytt/quarks_secret/quarks_secret_disabled.yml"))
 			})
 			It("should list all the required attributes", func() {
-				Expect(ctx).To(ThrowError(`The following required data.values parameters are missing: \["app_domains", "app_registry.hostname", "app_registry.password", "app_registry.repository_prefix", "app_registry.username", "blobstore.secret_access_key", "capi.cc_username_lookup_client_secret", "capi.cf_api_controllers_client_secret", "capi.cf_api_backup_metadata_generator_client_secret", "capi.database.encryption_key", "capi.database.password", "cf_admin_password", "system_certificate.crt", "system_certificate.key", "system_domain", "uaa.admin_client_secret", "uaa.database.password", "uaa.encryption_key.passphrase", "uaa.jwt_policy.signing_key", "uaa.login.service_provider.certificate", "uaa.login.service_provider.key", "uaa.login_secret", "workloads_certificate.crt", "workloads_certificate.key"\]`))
+				Expect(ctx).To(ThrowError(`The following required data.values parameters are missing: \["app_domains", "app_registry.hostname", "app_registry.password", "app_registry.repository_prefix", "app_registry.username", "blobstore.secret_access_key", "capi.cc_username_lookup_client_secret", "capi.cf_api_controllers_client_secret", "capi.cf_api_backup_metadata_generator_client_secret", "capi.database.encryption_key", "capi.database.password", "cf_admin_password", "instance_index_env_injector_certificate.ca", "instance_index_env_injector_certificate.crt", "instance_index_env_injector_certificate.key", "system_certificate.crt", "system_certificate.key", "system_domain", "uaa.admin_client_secret", "uaa.database.password", "uaa.encryption_key.passphrase", "uaa.jwt_policy.signing_key", "uaa.login.service_provider.certificate", "uaa.login.service_provider.key", "uaa.login_secret", "workloads_certificate.crt", "workloads_certificate.key"\]`))
 			})
 		})
 
@@ -56,7 +56,7 @@ var _ = Describe("Missing Attributes", func() {
 			})
 
 			It("should list all the required attributes", func() {
-				Expect(ctx).To(ThrowError(`The following required data.values parameters are missing: \["app_domains", "app_registry.hostname", "app_registry.password", "app_registry.repository_prefix", "app_registry.username", "blobstore.secret_access_key", "capi.database.password", "system_certificate.crt", "system_certificate.key", "system_domain", "uaa.database.password", "uaa.encryption_key.passphrase", "uaa.jwt_policy.signing_key", "uaa.login.service_provider.certificate", "uaa.login.service_provider.key", "uaa.login_secret", "workloads_certificate.crt", "workloads_certificate.key"\]`))
+				Expect(ctx).To(ThrowError(`The following required data.values parameters are missing: \["app_domains", "app_registry.hostname", "app_registry.password", "app_registry.repository_prefix", "app_registry.username", "blobstore.secret_access_key", "capi.database.password", "instance_index_env_injector_certificate.ca", "instance_index_env_injector_certificate.crt", "instance_index_env_injector_certificate.key", "system_certificate.crt", "system_certificate.key", "system_domain", "uaa.database.password", "uaa.encryption_key.passphrase", "uaa.jwt_policy.signing_key", "uaa.login.service_provider.certificate", "uaa.login.service_provider.key", "uaa.login_secret", "workloads_certificate.crt", "workloads_certificate.key"\]`))
 			})
 		})
 	})
@@ -75,7 +75,7 @@ var _ = Describe("Missing Attributes", func() {
 		})
 
 		It("should complain about missing attributes", func() {
-			Expect(ctx).To(ThrowError(`The following required data.values parameters are missing: \["app_registry.username", "capi.cc_username_lookup_client_secret", "capi.cf_api_controllers_client_secret", "capi.cf_api_backup_metadata_generator_client_secret", "cf_admin_password", "system_certificate.key", "uaa.encryption_key.passphrase", "uaa.jwt_policy.signing_key", "uaa.login.service_provider.certificate", "uaa.login.service_provider.key", "uaa.login_secret", "workloads_certificate.crt"\]`))
+			Expect(ctx).To(ThrowError(`The following required data.values parameters are missing: \["app_registry.username", "capi.cc_username_lookup_client_secret", "capi.cf_api_controllers_client_secret", "capi.cf_api_backup_metadata_generator_client_secret", "cf_admin_password", "instance_index_env_injector_certificate.ca", "instance_index_env_injector_certificate.crt", "instance_index_env_injector_certificate.key", "system_certificate.key", "uaa.encryption_key.passphrase", "uaa.jwt_policy.signing_key", "uaa.login.service_provider.certificate", "uaa.login.service_provider.key", "uaa.login_secret", "workloads_certificate.crt"\]`))
 		})
 	})
 


### PR DESCRIPTION
## WHAT is this change about?
With the next Eirini release we are dropping EiriniX as a framework for our instance index environment variable injector (the one that injects CF_INSTANCE). Instead we are managing the webhook configuration statically via a [dedicated yaml](https://github.com/cloudfoundry-incubator/eirini-release/blob/b0dc988c4a4ff53b15dcbe040b7ada5be1f41756/helm/templates/core/instance-index-env-injector-webhook.yml) in the eirini deployment yamls.

In order to adopt this change in CF4K8S needs to 
* generate the webhook certificate bundle into a K8S secret which is mounted into the Eirini instance index env injector
* set the `caBundle` property to the base64 encoded webhook CA bundle into the `MutatingWebHookConfiguration`

This is what this PR does.

**Please note** that dropping EiriniX results into the webhook created by EiriniX (`eirini-x-mutating-hook`) to no longer work thus preventing statefulsets from creating pods (i.e. `cf push` would be broken). Therefore its `MutatingWebHookConfiguration` should be deleted as part of the cf-for-k8s upgrade process. Is there an automated step to achieve this?

## Does this PR introduce a change to `config/values.yml`?
Yes

## Acceptance Steps
1. Deploy CF4K8S
2. Push an application
3. ssh onto the application pod via `kubectl exec -n cf-workloads --container opi -it <application-pod-id> /bin/bash`
4. Once in the shell, verify that the `CF_INSTANCE_INDEX` env var is set via `echo $CF_INSTANCE_INDEX`

## Tag your pair, your PM, and/or team
@cloudfoundry/eirini 

## Things to remember
* Eirini story: https://www.pivotaltracker.com/story/show/176823153
