### PR TITLE
ENH: bump Istio from v1.7.3 to v1.8.0

### DIFF
--- a/build/istio/istioctl-values.yaml
+++ b/build/istio/istioctl-values.yaml
@@ -34,8 +34,6 @@ spec:
           minReplicas: 1
           maxReplicas: 1
   values:
-    prometheus:
-      enabled: false
     sidecarInjectorWebhook:
       rewriteAppHTTPProbe: true
     meshConfig:
@@ -79,7 +77,5 @@ spec:
           "x_forwarded_proto": "%REQ(X-FORWARDED-PROTO)%"
         }
     global:
-      controlPlaneSecurityEnabled: true
       proxy:
         holdApplicationUntilProxyStarts: true
-

--- a/build/istio/values.yaml
+++ b/build/istio/values.yaml
@@ -5,7 +5,7 @@
 #! These values cannot be changed later when rendering cf-for-k8s templates.
 #! Values related to CF should NOT be in this file.
 
-istio_version: 1.7.3
+istio_version: 1.8.4
 
 fluentbit:
   image: cloudfoundry/cf-k8s-networking-fluentbit@sha256:2b8563a032c007bdb5f8a1cdbd093edd8505fadd21a3443a2b891e87caee7504

--- a/ci/pipelines/cf-k8s-networking-istio-upgrade.yml
+++ b/ci/pipelines/cf-k8s-networking-istio-upgrade.yml
@@ -6,7 +6,7 @@ resources:
   source:
     owner: istio
     repository: istio
-    tag_filter: '1\.7\..*'
+    tag_filter: '1\.8\..*'
     access_token: ((cf_for_k8s_release_bot_access_token))
 
 - name: cf-for-k8s-istio-bump-branch

--- a/config/istio/istio-generated/xxx-generated-istio.yaml
+++ b/config/istio/istio-generated/xxx-generated-istio.yaml
@@ -1,123 +1,5 @@
 ---
-apiVersion: apiextensions.k8s.io/v1
-kind: CustomResourceDefinition
-metadata:
-  annotations:
-    helm.sh/resource-policy: keep
-  labels:
-    app: mixer
-    chart: istio
-    cloudfoundry.org/istio_version: 1.7.3
-    heritage: Tiller
-    istio: mixer-adapter
-    package: adapter
-    release: istio
-  name: adapters.config.istio.io
-spec:
-  group: config.istio.io
-  names:
-    categories:
-    - istio-io
-    - policy-istio-io
-    kind: adapter
-    plural: adapters
-    singular: adapter
-  scope: Namespaced
-  versions:
-  - name: v1alpha2
-    schema:
-      openAPIV3Schema:
-        properties:
-          spec:
-            type: object
-            x-kubernetes-preserve-unknown-fields: true
-          status:
-            type: object
-            x-kubernetes-preserve-unknown-fields: true
-        type: object
-    served: true
-    storage: true
-    subresources:
-      status: {}
----
-apiVersion: apiextensions.k8s.io/v1
-kind: CustomResourceDefinition
-metadata:
-  annotations:
-    helm.sh/resource-policy: keep
-  labels:
-    app: mixer
-    chart: istio
-    cloudfoundry.org/istio_version: 1.7.3
-    heritage: Tiller
-    istio: core
-    package: istio.io.mixer
-    release: istio
-  name: attributemanifests.config.istio.io
-spec:
-  group: config.istio.io
-  names:
-    categories:
-    - istio-io
-    - policy-istio-io
-    kind: attributemanifest
-    listKind: attributemanifestList
-    plural: attributemanifests
-    singular: attributemanifest
-  scope: Namespaced
-  versions:
-  - name: v1alpha2
-    schema:
-      openAPIV3Schema:
-        properties:
-          spec:
-            description: 'Describes the rules used to configure Mixer''s policy and telemetry features. See more details at: https://istio.io/docs/reference/config/policy-and-telemetry/istio.policy.v1beta1.html'
-            properties:
-              attributes:
-                additionalProperties:
-                  properties:
-                    description:
-                      description: A human-readable description of the attribute's purpose.
-                      format: string
-                      type: string
-                    valueType:
-                      description: The type of data carried by this attribute.
-                      enum:
-                      - VALUE_TYPE_UNSPECIFIED
-                      - STRING
-                      - INT64
-                      - DOUBLE
-                      - BOOL
-                      - TIMESTAMP
-                      - IP_ADDRESS
-                      - EMAIL_ADDRESS
-                      - URI
-                      - DNS_NAME
-                      - DURATION
-                      - STRING_MAP
-                      type: string
-                  type: object
-                description: The set of attributes this Istio component will be responsible for producing at runtime.
-                type: object
-              name:
-                description: Name of the component producing these attributes.
-                format: string
-                type: string
-              revision:
-                description: The revision of this document.
-                format: string
-                type: string
-            type: object
-          status:
-            type: object
-            x-kubernetes-preserve-unknown-fields: true
-        type: object
-    served: true
-    storage: true
-    subresources:
-      status: {}
----
-apiVersion: apiextensions.k8s.io/v1
+apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   annotations:
@@ -125,7 +7,7 @@ metadata:
   labels:
     app: istio-pilot
     chart: istio
-    cloudfoundry.org/istio_version: 1.7.3
+    cloudfoundry.org/istio_version: 1.8.4
     heritage: Tiller
     istio: security
     release: istio
@@ -140,186 +22,215 @@ spec:
     listKind: AuthorizationPolicyList
     plural: authorizationpolicies
     singular: authorizationpolicy
+  preserveUnknownFields: false
   scope: Namespaced
-  versions:
-  - name: v1beta1
-    schema:
-      openAPIV3Schema:
-        properties:
-          spec:
-            description: 'Configuration for access control on workloads. See more details at: https://istio.io/docs/reference/config/security/authorization-policy.html'
-            properties:
-              action:
-                description: Optional.
-                enum:
-                - ALLOW
-                - DENY
-                - AUDIT
-                type: string
-              rules:
-                description: Optional.
-                items:
-                  properties:
-                    from:
-                      description: Optional.
-                      items:
-                        properties:
-                          source:
-                            description: Source specifies the source of a request.
-                            properties:
-                              ipBlocks:
-                                description: Optional.
-                                items:
-                                  format: string
-                                  type: string
-                                type: array
-                              namespaces:
-                                description: Optional.
-                                items:
-                                  format: string
-                                  type: string
-                                type: array
-                              notIpBlocks:
-                                description: Optional.
-                                items:
-                                  format: string
-                                  type: string
-                                type: array
-                              notNamespaces:
-                                description: Optional.
-                                items:
-                                  format: string
-                                  type: string
-                                type: array
-                              notPrincipals:
-                                description: Optional.
-                                items:
-                                  format: string
-                                  type: string
-                                type: array
-                              notRequestPrincipals:
-                                description: Optional.
-                                items:
-                                  format: string
-                                  type: string
-                                type: array
-                              principals:
-                                description: Optional.
-                                items:
-                                  format: string
-                                  type: string
-                                type: array
-                              requestPrincipals:
-                                description: Optional.
-                                items:
-                                  format: string
-                                  type: string
-                                type: array
-                            type: object
-                        type: object
-                      type: array
-                    to:
-                      description: Optional.
-                      items:
-                        properties:
-                          operation:
-                            description: Operation specifies the operation of a request.
-                            properties:
-                              hosts:
-                                description: Optional.
-                                items:
-                                  format: string
-                                  type: string
-                                type: array
-                              methods:
-                                description: Optional.
-                                items:
-                                  format: string
-                                  type: string
-                                type: array
-                              notHosts:
-                                description: Optional.
-                                items:
-                                  format: string
-                                  type: string
-                                type: array
-                              notMethods:
-                                description: Optional.
-                                items:
-                                  format: string
-                                  type: string
-                                type: array
-                              notPaths:
-                                description: Optional.
-                                items:
-                                  format: string
-                                  type: string
-                                type: array
-                              notPorts:
-                                description: Optional.
-                                items:
-                                  format: string
-                                  type: string
-                                type: array
-                              paths:
-                                description: Optional.
-                                items:
-                                  format: string
-                                  type: string
-                                type: array
-                              ports:
-                                description: Optional.
-                                items:
-                                  format: string
-                                  type: string
-                                type: array
-                            type: object
-                        type: object
-                      type: array
-                    when:
-                      description: Optional.
-                      items:
-                        properties:
-                          key:
-                            description: The name of an Istio attribute.
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      properties:
+        spec:
+          description: 'Configuration for access control on workloads. See more details
+            at: https://istio.io/docs/reference/config/security/authorization-policy.html'
+          oneOf:
+          - not:
+              anyOf:
+              - required:
+                - provider
+          - required:
+            - provider
+          properties:
+            action:
+              description: Optional.
+              enum:
+              - ALLOW
+              - DENY
+              - AUDIT
+              - CUSTOM
+              type: string
+            provider:
+              properties:
+                name:
+                  description: Specifies the name of the extension provider.
+                  format: string
+                  type: string
+              type: object
+            rules:
+              description: Optional.
+              items:
+                properties:
+                  from:
+                    description: Optional.
+                    items:
+                      properties:
+                        source:
+                          description: Source specifies the source of a request.
+                          properties:
+                            ipBlocks:
+                              description: Optional.
+                              items:
+                                format: string
+                                type: string
+                              type: array
+                            namespaces:
+                              description: Optional.
+                              items:
+                                format: string
+                                type: string
+                              type: array
+                            notIpBlocks:
+                              description: Optional.
+                              items:
+                                format: string
+                                type: string
+                              type: array
+                            notNamespaces:
+                              description: Optional.
+                              items:
+                                format: string
+                                type: string
+                              type: array
+                            notPrincipals:
+                              description: Optional.
+                              items:
+                                format: string
+                                type: string
+                              type: array
+                            notRemoteIpBlocks:
+                              description: Optional.
+                              items:
+                                format: string
+                                type: string
+                              type: array
+                            notRequestPrincipals:
+                              description: Optional.
+                              items:
+                                format: string
+                                type: string
+                              type: array
+                            principals:
+                              description: Optional.
+                              items:
+                                format: string
+                                type: string
+                              type: array
+                            remoteIpBlocks:
+                              description: Optional.
+                              items:
+                                format: string
+                                type: string
+                              type: array
+                            requestPrincipals:
+                              description: Optional.
+                              items:
+                                format: string
+                                type: string
+                              type: array
+                          type: object
+                      type: object
+                    type: array
+                  to:
+                    description: Optional.
+                    items:
+                      properties:
+                        operation:
+                          description: Operation specifies the operation of a request.
+                          properties:
+                            hosts:
+                              description: Optional.
+                              items:
+                                format: string
+                                type: string
+                              type: array
+                            methods:
+                              description: Optional.
+                              items:
+                                format: string
+                                type: string
+                              type: array
+                            notHosts:
+                              description: Optional.
+                              items:
+                                format: string
+                                type: string
+                              type: array
+                            notMethods:
+                              description: Optional.
+                              items:
+                                format: string
+                                type: string
+                              type: array
+                            notPaths:
+                              description: Optional.
+                              items:
+                                format: string
+                                type: string
+                              type: array
+                            notPorts:
+                              description: Optional.
+                              items:
+                                format: string
+                                type: string
+                              type: array
+                            paths:
+                              description: Optional.
+                              items:
+                                format: string
+                                type: string
+                              type: array
+                            ports:
+                              description: Optional.
+                              items:
+                                format: string
+                                type: string
+                              type: array
+                          type: object
+                      type: object
+                    type: array
+                  when:
+                    description: Optional.
+                    items:
+                      properties:
+                        key:
+                          description: The name of an Istio attribute.
+                          format: string
+                          type: string
+                        notValues:
+                          description: Optional.
+                          items:
                             format: string
                             type: string
-                          notValues:
-                            description: Optional.
-                            items:
-                              format: string
-                              type: string
-                            type: array
-                          values:
-                            description: Optional.
-                            items:
-                              format: string
-                              type: string
-                            type: array
-                        type: object
-                      type: array
-                  type: object
-                type: array
-              selector:
-                description: Optional.
-                properties:
-                  matchLabels:
-                    additionalProperties:
-                      format: string
-                      type: string
-                    type: object
+                          type: array
+                        values:
+                          description: Optional.
+                          items:
+                            format: string
+                            type: string
+                          type: array
+                      type: object
+                    type: array
                 type: object
-            type: object
-          status:
-            type: object
-            x-kubernetes-preserve-unknown-fields: true
-        type: object
+              type: array
+            selector:
+              description: Optional.
+              properties:
+                matchLabels:
+                  additionalProperties:
+                    format: string
+                    type: string
+                  type: object
+              type: object
+          type: object
+        status:
+          type: object
+          x-kubernetes-preserve-unknown-fields: true
+      type: object
+  versions:
+  - name: v1beta1
     served: true
     storage: true
-    subresources:
-      status: {}
 ---
-apiVersion: apiextensions.k8s.io/v1
+apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   annotations:
@@ -327,11 +238,24 @@ metadata:
   labels:
     app: istio-pilot
     chart: istio
-    cloudfoundry.org/istio_version: 1.7.3
+    cloudfoundry.org/istio_version: 1.8.4
     heritage: Tiller
     release: istio
   name: destinationrules.networking.istio.io
 spec:
+  additionalPrinterColumns:
+  - JSONPath: .spec.host
+    description: The name of a service from the service registry
+    name: Host
+    type: string
+  - JSONPath: .metadata.creationTimestamp
+    description: 'CreationTimestamp is a timestamp representing the server time when
+      this object was created. It is not guaranteed to be set in happens-before order
+      across separate operations. Clients may not set this value. It is represented
+      in RFC3339 form and is in UTC. Populated by the system. Read-only. Null for
+      lists. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata'
+    name: Age
+    type: date
   group: networking.istio.io
   names:
     categories:
@@ -343,362 +267,121 @@ spec:
     shortNames:
     - dr
     singular: destinationrule
+  preserveUnknownFields: false
   scope: Namespaced
-  versions:
-  - additionalPrinterColumns:
-    - description: The name of a service from the service registry
-      jsonPath: .spec.host
-      name: Host
-      type: string
-    - description: 'CreationTimestamp is a timestamp representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations. Clients may not set this value. It is represented in RFC3339 form and is in UTC. Populated by the system. Read-only. Null for lists. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata'
-      jsonPath: .metadata.creationTimestamp
-      name: Age
-      type: date
-    name: v1alpha3
-    schema:
-      openAPIV3Schema:
-        properties:
-          spec:
-            description: 'Configuration affecting load balancing, outlier detection, etc. See more details at: https://istio.io/docs/reference/config/networking/destination-rule.html'
-            properties:
-              exportTo:
-                description: A list of namespaces to which this destination rule is exported.
-                items:
-                  format: string
-                  type: string
-                type: array
-              host:
-                description: The name of a service from the service registry.
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      properties:
+        spec:
+          description: 'Configuration affecting load balancing, outlier detection,
+            etc. See more details at: https://istio.io/docs/reference/config/networking/destination-rule.html'
+          properties:
+            exportTo:
+              description: A list of namespaces to which this destination rule is
+                exported.
+              items:
                 format: string
                 type: string
-              subsets:
-                items:
-                  properties:
-                    labels:
-                      additionalProperties:
-                        format: string
-                        type: string
-                      type: object
-                    name:
-                      description: Name of the subset.
+              type: array
+            host:
+              description: The name of a service from the service registry.
+              format: string
+              type: string
+            subsets:
+              items:
+                properties:
+                  labels:
+                    additionalProperties:
                       format: string
                       type: string
-                    trafficPolicy:
-                      description: Traffic policies that apply to this subset.
-                      properties:
-                        connectionPool:
-                          properties:
-                            http:
-                              description: HTTP connection pool settings.
-                              properties:
-                                h2UpgradePolicy:
-                                  description: Specify if http1.1 connection should be upgraded to http2 for the associated destination.
-                                  enum:
-                                  - DEFAULT
-                                  - DO_NOT_UPGRADE
-                                  - UPGRADE
-                                  type: string
-                                http1MaxPendingRequests:
-                                  description: Maximum number of pending HTTP requests to a destination.
-                                  format: int32
-                                  type: integer
-                                http2MaxRequests:
-                                  description: Maximum number of requests to a backend.
-                                  format: int32
-                                  type: integer
-                                idleTimeout:
-                                  description: The idle timeout for upstream connection pool connections.
-                                  type: string
-                                maxRequestsPerConnection:
-                                  description: Maximum number of requests per connection to a backend.
-                                  format: int32
-                                  type: integer
-                                maxRetries:
-                                  format: int32
-                                  type: integer
-                              type: object
-                            tcp:
-                              description: Settings common to both HTTP and TCP upstream connections.
-                              properties:
-                                connectTimeout:
-                                  description: TCP connection timeout.
-                                  type: string
-                                maxConnections:
-                                  description: Maximum number of HTTP1 /TCP connections to a destination host.
-                                  format: int32
-                                  type: integer
-                                tcpKeepalive:
-                                  description: If set then set SO_KEEPALIVE on the socket to enable TCP Keepalives.
-                                  properties:
-                                    interval:
-                                      description: The time duration between keep-alive probes.
-                                      type: string
-                                    probes:
-                                      type: integer
-                                    time:
-                                      type: string
-                                  type: object
-                              type: object
-                          type: object
-                        loadBalancer:
-                          description: Settings controlling the load balancer algorithms.
-                          oneOf:
-                          - not:
-                              anyOf:
-                              - required:
-                                - simple
-                              - properties:
-                                  consistentHash:
-                                    oneOf:
-                                    - not:
-                                        anyOf:
-                                        - required:
-                                          - httpHeaderName
-                                        - required:
-                                          - httpCookie
-                                        - required:
-                                          - useSourceIp
-                                        - required:
-                                          - httpQueryParameterName
-                                    - required:
-                                      - httpHeaderName
-                                    - required:
-                                      - httpCookie
-                                    - required:
-                                      - useSourceIp
-                                    - required:
-                                      - httpQueryParameterName
-                                required:
-                                - consistentHash
-                          - required:
-                            - simple
-                          - properties:
-                              consistentHash:
-                                oneOf:
-                                - not:
-                                    anyOf:
-                                    - required:
-                                      - httpHeaderName
-                                    - required:
-                                      - httpCookie
-                                    - required:
-                                      - useSourceIp
-                                    - required:
-                                      - httpQueryParameterName
-                                - required:
-                                  - httpHeaderName
-                                - required:
-                                  - httpCookie
-                                - required:
-                                  - useSourceIp
-                                - required:
-                                  - httpQueryParameterName
-                            required:
-                            - consistentHash
-                          properties:
-                            consistentHash:
-                              properties:
-                                httpCookie:
-                                  description: Hash based on HTTP cookie.
-                                  properties:
-                                    name:
-                                      description: Name of the cookie.
-                                      format: string
-                                      type: string
-                                    path:
-                                      description: Path to set for the cookie.
-                                      format: string
-                                      type: string
-                                    ttl:
-                                      description: Lifetime of the cookie.
-                                      type: string
-                                  type: object
-                                httpHeaderName:
-                                  description: Hash based on a specific HTTP header.
-                                  format: string
-                                  type: string
-                                httpQueryParameterName:
-                                  description: Hash based on a specific HTTP query parameter.
-                                  format: string
-                                  type: string
-                                minimumRingSize:
-                                  type: integer
-                                useSourceIp:
-                                  description: Hash based on the source IP address.
-                                  type: boolean
-                              type: object
-                            localityLbSetting:
-                              properties:
-                                distribute:
-                                  description: 'Optional: only one of distribute or failover can be set.'
-                                  items:
-                                    properties:
-                                      from:
-                                        description: Originating locality, '/' separated, e.g.
-                                        format: string
-                                        type: string
-                                      to:
-                                        additionalProperties:
-                                          type: integer
-                                        description: Map of upstream localities to traffic distribution weights.
-                                        type: object
-                                    type: object
-                                  type: array
-                                enabled:
-                                  description: enable locality load balancing, this is DestinationRule-level and will override mesh wide settings in entirety.
-                                  nullable: true
-                                  type: boolean
-                                failover:
-                                  description: 'Optional: only failover or distribute can be set.'
-                                  items:
-                                    properties:
-                                      from:
-                                        description: Originating region.
-                                        format: string
-                                        type: string
-                                      to:
-                                        format: string
-                                        type: string
-                                    type: object
-                                  type: array
-                              type: object
-                            simple:
-                              enum:
-                              - ROUND_ROBIN
-                              - LEAST_CONN
-                              - RANDOM
-                              - PASSTHROUGH
-                              type: string
-                          type: object
-                        outlierDetection:
-                          properties:
-                            baseEjectionTime:
-                              description: Minimum ejection duration.
-                              type: string
-                            consecutive5xxErrors:
-                              description: Number of 5xx errors before a host is ejected from the connection pool.
-                              nullable: true
-                              type: integer
-                            consecutiveErrors:
-                              format: int32
-                              type: integer
-                            consecutiveGatewayErrors:
-                              description: Number of gateway errors before a host is ejected from the connection pool.
-                              nullable: true
-                              type: integer
-                            interval:
-                              description: Time interval between ejection sweep analysis.
-                              type: string
-                            maxEjectionPercent:
-                              format: int32
-                              type: integer
-                            minHealthPercent:
-                              format: int32
-                              type: integer
-                          type: object
-                        portLevelSettings:
-                          description: Traffic policies specific to individual ports.
-                          items:
+                    type: object
+                  name:
+                    description: Name of the subset.
+                    format: string
+                    type: string
+                  trafficPolicy:
+                    description: Traffic policies that apply to this subset.
+                    properties:
+                      connectionPool:
+                        properties:
+                          http:
+                            description: HTTP connection pool settings.
                             properties:
-                              connectionPool:
+                              h2UpgradePolicy:
+                                description: Specify if http1.1 connection should
+                                  be upgraded to http2 for the associated destination.
+                                enum:
+                                - DEFAULT
+                                - DO_NOT_UPGRADE
+                                - UPGRADE
+                                type: string
+                              http1MaxPendingRequests:
+                                description: Maximum number of pending HTTP requests
+                                  to a destination.
+                                format: int32
+                                type: integer
+                              http2MaxRequests:
+                                description: Maximum number of requests to a backend.
+                                format: int32
+                                type: integer
+                              idleTimeout:
+                                description: The idle timeout for upstream connection
+                                  pool connections.
+                                type: string
+                              maxRequestsPerConnection:
+                                description: Maximum number of requests per connection
+                                  to a backend.
+                                format: int32
+                                type: integer
+                              maxRetries:
+                                format: int32
+                                type: integer
+                              useClientProtocol:
+                                description: If set to true, client protocol will
+                                  be preserved while initiating connection to backend.
+                                type: boolean
+                            type: object
+                          tcp:
+                            description: Settings common to both HTTP and TCP upstream
+                              connections.
+                            properties:
+                              connectTimeout:
+                                description: TCP connection timeout.
+                                type: string
+                              maxConnections:
+                                description: Maximum number of HTTP1 /TCP connections
+                                  to a destination host.
+                                format: int32
+                                type: integer
+                              tcpKeepalive:
+                                description: If set then set SO_KEEPALIVE on the socket
+                                  to enable TCP Keepalives.
                                 properties:
-                                  http:
-                                    description: HTTP connection pool settings.
-                                    properties:
-                                      h2UpgradePolicy:
-                                        description: Specify if http1.1 connection should be upgraded to http2 for the associated destination.
-                                        enum:
-                                        - DEFAULT
-                                        - DO_NOT_UPGRADE
-                                        - UPGRADE
-                                        type: string
-                                      http1MaxPendingRequests:
-                                        description: Maximum number of pending HTTP requests to a destination.
-                                        format: int32
-                                        type: integer
-                                      http2MaxRequests:
-                                        description: Maximum number of requests to a backend.
-                                        format: int32
-                                        type: integer
-                                      idleTimeout:
-                                        description: The idle timeout for upstream connection pool connections.
-                                        type: string
-                                      maxRequestsPerConnection:
-                                        description: Maximum number of requests per connection to a backend.
-                                        format: int32
-                                        type: integer
-                                      maxRetries:
-                                        format: int32
-                                        type: integer
-                                    type: object
-                                  tcp:
-                                    description: Settings common to both HTTP and TCP upstream connections.
-                                    properties:
-                                      connectTimeout:
-                                        description: TCP connection timeout.
-                                        type: string
-                                      maxConnections:
-                                        description: Maximum number of HTTP1 /TCP connections to a destination host.
-                                        format: int32
-                                        type: integer
-                                      tcpKeepalive:
-                                        description: If set then set SO_KEEPALIVE on the socket to enable TCP Keepalives.
-                                        properties:
-                                          interval:
-                                            description: The time duration between keep-alive probes.
-                                            type: string
-                                          probes:
-                                            type: integer
-                                          time:
-                                            type: string
-                                        type: object
-                                    type: object
+                                  interval:
+                                    description: The time duration between keep-alive
+                                      probes.
+                                    type: string
+                                  probes:
+                                    type: integer
+                                  time:
+                                    type: string
                                 type: object
-                              loadBalancer:
-                                description: Settings controlling the load balancer algorithms.
-                                oneOf:
-                                - not:
-                                    anyOf:
-                                    - required:
-                                      - simple
-                                    - properties:
-                                        consistentHash:
-                                          oneOf:
-                                          - not:
-                                              anyOf:
-                                              - required:
-                                                - httpHeaderName
-                                              - required:
-                                                - httpCookie
-                                              - required:
-                                                - useSourceIp
-                                              - required:
-                                                - httpQueryParameterName
-                                          - required:
-                                            - httpHeaderName
-                                          - required:
-                                            - httpCookie
-                                          - required:
-                                            - useSourceIp
-                                          - required:
-                                            - httpQueryParameterName
-                                      required:
-                                      - consistentHash
-                                - required:
-                                  - simple
-                                - properties:
-                                    consistentHash:
-                                      oneOf:
-                                      - not:
-                                          anyOf:
-                                          - required:
-                                            - httpHeaderName
-                                          - required:
-                                            - httpCookie
-                                          - required:
-                                            - useSourceIp
-                                          - required:
-                                            - httpQueryParameterName
+                            type: object
+                        type: object
+                      loadBalancer:
+                        description: Settings controlling the load balancer algorithms.
+                        oneOf:
+                        - not:
+                            anyOf:
+                            - required:
+                              - simple
+                            - properties:
+                                consistentHash:
+                                  oneOf:
+                                  - not:
+                                      anyOf:
                                       - required:
                                         - httpHeaderName
                                       - required:
@@ -707,248 +390,16 @@ spec:
                                         - useSourceIp
                                       - required:
                                         - httpQueryParameterName
-                                  required:
-                                  - consistentHash
-                                properties:
-                                  consistentHash:
-                                    properties:
-                                      httpCookie:
-                                        description: Hash based on HTTP cookie.
-                                        properties:
-                                          name:
-                                            description: Name of the cookie.
-                                            format: string
-                                            type: string
-                                          path:
-                                            description: Path to set for the cookie.
-                                            format: string
-                                            type: string
-                                          ttl:
-                                            description: Lifetime of the cookie.
-                                            type: string
-                                        type: object
-                                      httpHeaderName:
-                                        description: Hash based on a specific HTTP header.
-                                        format: string
-                                        type: string
-                                      httpQueryParameterName:
-                                        description: Hash based on a specific HTTP query parameter.
-                                        format: string
-                                        type: string
-                                      minimumRingSize:
-                                        type: integer
-                                      useSourceIp:
-                                        description: Hash based on the source IP address.
-                                        type: boolean
-                                    type: object
-                                  localityLbSetting:
-                                    properties:
-                                      distribute:
-                                        description: 'Optional: only one of distribute or failover can be set.'
-                                        items:
-                                          properties:
-                                            from:
-                                              description: Originating locality, '/' separated, e.g.
-                                              format: string
-                                              type: string
-                                            to:
-                                              additionalProperties:
-                                                type: integer
-                                              description: Map of upstream localities to traffic distribution weights.
-                                              type: object
-                                          type: object
-                                        type: array
-                                      enabled:
-                                        description: enable locality load balancing, this is DestinationRule-level and will override mesh wide settings in entirety.
-                                        nullable: true
-                                        type: boolean
-                                      failover:
-                                        description: 'Optional: only failover or distribute can be set.'
-                                        items:
-                                          properties:
-                                            from:
-                                              description: Originating region.
-                                              format: string
-                                              type: string
-                                            to:
-                                              format: string
-                                              type: string
-                                          type: object
-                                        type: array
-                                    type: object
-                                  simple:
-                                    enum:
-                                    - ROUND_ROBIN
-                                    - LEAST_CONN
-                                    - RANDOM
-                                    - PASSTHROUGH
-                                    type: string
-                                type: object
-                              outlierDetection:
-                                properties:
-                                  baseEjectionTime:
-                                    description: Minimum ejection duration.
-                                    type: string
-                                  consecutive5xxErrors:
-                                    description: Number of 5xx errors before a host is ejected from the connection pool.
-                                    nullable: true
-                                    type: integer
-                                  consecutiveErrors:
-                                    format: int32
-                                    type: integer
-                                  consecutiveGatewayErrors:
-                                    description: Number of gateway errors before a host is ejected from the connection pool.
-                                    nullable: true
-                                    type: integer
-                                  interval:
-                                    description: Time interval between ejection sweep analysis.
-                                    type: string
-                                  maxEjectionPercent:
-                                    format: int32
-                                    type: integer
-                                  minHealthPercent:
-                                    format: int32
-                                    type: integer
-                                type: object
-                              port:
-                                properties:
-                                  number:
-                                    type: integer
-                                type: object
-                              tls:
-                                description: TLS related settings for connections to the upstream service.
-                                properties:
-                                  caCertificates:
-                                    format: string
-                                    type: string
-                                  clientCertificate:
-                                    description: REQUIRED if mode is `MUTUAL`.
-                                    format: string
-                                    type: string
-                                  credentialName:
-                                    format: string
-                                    type: string
-                                  mode:
-                                    enum:
-                                    - DISABLE
-                                    - SIMPLE
-                                    - MUTUAL
-                                    - ISTIO_MUTUAL
-                                    type: string
-                                  privateKey:
-                                    description: REQUIRED if mode is `MUTUAL`.
-                                    format: string
-                                    type: string
-                                  sni:
-                                    description: SNI string to present to the server during TLS handshake.
-                                    format: string
-                                    type: string
-                                  subjectAltNames:
-                                    items:
-                                      format: string
-                                      type: string
-                                    type: array
-                                type: object
-                            type: object
-                          type: array
-                        tls:
-                          description: TLS related settings for connections to the upstream service.
-                          properties:
-                            caCertificates:
-                              format: string
-                              type: string
-                            clientCertificate:
-                              description: REQUIRED if mode is `MUTUAL`.
-                              format: string
-                              type: string
-                            credentialName:
-                              format: string
-                              type: string
-                            mode:
-                              enum:
-                              - DISABLE
-                              - SIMPLE
-                              - MUTUAL
-                              - ISTIO_MUTUAL
-                              type: string
-                            privateKey:
-                              description: REQUIRED if mode is `MUTUAL`.
-                              format: string
-                              type: string
-                            sni:
-                              description: SNI string to present to the server during TLS handshake.
-                              format: string
-                              type: string
-                            subjectAltNames:
-                              items:
-                                format: string
-                                type: string
-                              type: array
-                          type: object
-                      type: object
-                  type: object
-                type: array
-              trafficPolicy:
-                properties:
-                  connectionPool:
-                    properties:
-                      http:
-                        description: HTTP connection pool settings.
-                        properties:
-                          h2UpgradePolicy:
-                            description: Specify if http1.1 connection should be upgraded to http2 for the associated destination.
-                            enum:
-                            - DEFAULT
-                            - DO_NOT_UPGRADE
-                            - UPGRADE
-                            type: string
-                          http1MaxPendingRequests:
-                            description: Maximum number of pending HTTP requests to a destination.
-                            format: int32
-                            type: integer
-                          http2MaxRequests:
-                            description: Maximum number of requests to a backend.
-                            format: int32
-                            type: integer
-                          idleTimeout:
-                            description: The idle timeout for upstream connection pool connections.
-                            type: string
-                          maxRequestsPerConnection:
-                            description: Maximum number of requests per connection to a backend.
-                            format: int32
-                            type: integer
-                          maxRetries:
-                            format: int32
-                            type: integer
-                        type: object
-                      tcp:
-                        description: Settings common to both HTTP and TCP upstream connections.
-                        properties:
-                          connectTimeout:
-                            description: TCP connection timeout.
-                            type: string
-                          maxConnections:
-                            description: Maximum number of HTTP1 /TCP connections to a destination host.
-                            format: int32
-                            type: integer
-                          tcpKeepalive:
-                            description: If set then set SO_KEEPALIVE on the socket to enable TCP Keepalives.
-                            properties:
-                              interval:
-                                description: The time duration between keep-alive probes.
-                                type: string
-                              probes:
-                                type: integer
-                              time:
-                                type: string
-                            type: object
-                        type: object
-                    type: object
-                  loadBalancer:
-                    description: Settings controlling the load balancer algorithms.
-                    oneOf:
-                    - not:
-                        anyOf:
+                                  - required:
+                                    - httpHeaderName
+                                  - required:
+                                    - httpCookie
+                                  - required:
+                                    - useSourceIp
+                                  - required:
+                                    - httpQueryParameterName
+                              required:
+                              - consistentHash
                         - required:
                           - simple
                         - properties:
@@ -974,195 +425,218 @@ spec:
                                 - httpQueryParameterName
                           required:
                           - consistentHash
-                    - required:
-                      - simple
-                    - properties:
-                        consistentHash:
-                          oneOf:
-                          - not:
-                              anyOf:
-                              - required:
-                                - httpHeaderName
-                              - required:
-                                - httpCookie
-                              - required:
-                                - useSourceIp
-                              - required:
-                                - httpQueryParameterName
-                          - required:
-                            - httpHeaderName
-                          - required:
-                            - httpCookie
-                          - required:
-                            - useSourceIp
-                          - required:
-                            - httpQueryParameterName
-                      required:
-                      - consistentHash
-                    properties:
-                      consistentHash:
                         properties:
-                          httpCookie:
-                            description: Hash based on HTTP cookie.
+                          consistentHash:
                             properties:
-                              name:
-                                description: Name of the cookie.
+                              httpCookie:
+                                description: Hash based on HTTP cookie.
+                                properties:
+                                  name:
+                                    description: Name of the cookie.
+                                    format: string
+                                    type: string
+                                  path:
+                                    description: Path to set for the cookie.
+                                    format: string
+                                    type: string
+                                  ttl:
+                                    description: Lifetime of the cookie.
+                                    type: string
+                                type: object
+                              httpHeaderName:
+                                description: Hash based on a specific HTTP header.
                                 format: string
                                 type: string
-                              path:
-                                description: Path to set for the cookie.
+                              httpQueryParameterName:
+                                description: Hash based on a specific HTTP query parameter.
                                 format: string
                                 type: string
-                              ttl:
-                                description: Lifetime of the cookie.
-                                type: string
+                              minimumRingSize:
+                                type: integer
+                              useSourceIp:
+                                description: Hash based on the source IP address.
+                                type: boolean
                             type: object
-                          httpHeaderName:
-                            description: Hash based on a specific HTTP header.
-                            format: string
-                            type: string
-                          httpQueryParameterName:
-                            description: Hash based on a specific HTTP query parameter.
-                            format: string
-                            type: string
-                          minimumRingSize:
-                            type: integer
-                          useSourceIp:
-                            description: Hash based on the source IP address.
-                            type: boolean
-                        type: object
-                      localityLbSetting:
-                        properties:
-                          distribute:
-                            description: 'Optional: only one of distribute or failover can be set.'
-                            items:
-                              properties:
-                                from:
-                                  description: Originating locality, '/' separated, e.g.
-                                  format: string
-                                  type: string
-                                to:
-                                  additionalProperties:
-                                    type: integer
-                                  description: Map of upstream localities to traffic distribution weights.
-                                  type: object
-                              type: object
-                            type: array
-                          enabled:
-                            description: enable locality load balancing, this is DestinationRule-level and will override mesh wide settings in entirety.
-                            nullable: true
-                            type: boolean
-                          failover:
-                            description: 'Optional: only failover or distribute can be set.'
-                            items:
-                              properties:
-                                from:
-                                  description: Originating region.
-                                  format: string
-                                  type: string
-                                to:
-                                  format: string
-                                  type: string
-                              type: object
-                            type: array
-                        type: object
-                      simple:
-                        enum:
-                        - ROUND_ROBIN
-                        - LEAST_CONN
-                        - RANDOM
-                        - PASSTHROUGH
-                        type: string
-                    type: object
-                  outlierDetection:
-                    properties:
-                      baseEjectionTime:
-                        description: Minimum ejection duration.
-                        type: string
-                      consecutive5xxErrors:
-                        description: Number of 5xx errors before a host is ejected from the connection pool.
-                        nullable: true
-                        type: integer
-                      consecutiveErrors:
-                        format: int32
-                        type: integer
-                      consecutiveGatewayErrors:
-                        description: Number of gateway errors before a host is ejected from the connection pool.
-                        nullable: true
-                        type: integer
-                      interval:
-                        description: Time interval between ejection sweep analysis.
-                        type: string
-                      maxEjectionPercent:
-                        format: int32
-                        type: integer
-                      minHealthPercent:
-                        format: int32
-                        type: integer
-                    type: object
-                  portLevelSettings:
-                    description: Traffic policies specific to individual ports.
-                    items:
-                      properties:
-                        connectionPool:
-                          properties:
-                            http:
-                              description: HTTP connection pool settings.
-                              properties:
-                                h2UpgradePolicy:
-                                  description: Specify if http1.1 connection should be upgraded to http2 for the associated destination.
-                                  enum:
-                                  - DEFAULT
-                                  - DO_NOT_UPGRADE
-                                  - UPGRADE
-                                  type: string
-                                http1MaxPendingRequests:
-                                  description: Maximum number of pending HTTP requests to a destination.
-                                  format: int32
-                                  type: integer
-                                http2MaxRequests:
-                                  description: Maximum number of requests to a backend.
-                                  format: int32
-                                  type: integer
-                                idleTimeout:
-                                  description: The idle timeout for upstream connection pool connections.
-                                  type: string
-                                maxRequestsPerConnection:
-                                  description: Maximum number of requests per connection to a backend.
-                                  format: int32
-                                  type: integer
-                                maxRetries:
-                                  format: int32
-                                  type: integer
-                              type: object
-                            tcp:
-                              description: Settings common to both HTTP and TCP upstream connections.
-                              properties:
-                                connectTimeout:
-                                  description: TCP connection timeout.
-                                  type: string
-                                maxConnections:
-                                  description: Maximum number of HTTP1 /TCP connections to a destination host.
-                                  format: int32
-                                  type: integer
-                                tcpKeepalive:
-                                  description: If set then set SO_KEEPALIVE on the socket to enable TCP Keepalives.
+                          localityLbSetting:
+                            properties:
+                              distribute:
+                                description: 'Optional: only one of distribute or
+                                  failover can be set.'
+                                items:
                                   properties:
-                                    interval:
-                                      description: The time duration between keep-alive probes.
+                                    from:
+                                      description: Originating locality, '/' separated,
+                                        e.g.
+                                      format: string
                                       type: string
-                                    probes:
-                                      type: integer
-                                    time:
+                                    to:
+                                      additionalProperties:
+                                        type: integer
+                                      description: Map of upstream localities to traffic
+                                        distribution weights.
+                                      type: object
+                                  type: object
+                                type: array
+                              enabled:
+                                description: enable locality load balancing, this
+                                  is DestinationRule-level and will override mesh
+                                  wide settings in entirety.
+                                nullable: true
+                                type: boolean
+                              failover:
+                                description: 'Optional: only failover or distribute
+                                  can be set.'
+                                items:
+                                  properties:
+                                    from:
+                                      description: Originating region.
+                                      format: string
+                                      type: string
+                                    to:
+                                      format: string
                                       type: string
                                   type: object
+                                type: array
+                            type: object
+                          simple:
+                            enum:
+                            - ROUND_ROBIN
+                            - LEAST_CONN
+                            - RANDOM
+                            - PASSTHROUGH
+                            type: string
+                        type: object
+                      outlierDetection:
+                        properties:
+                          baseEjectionTime:
+                            description: Minimum ejection duration.
+                            type: string
+                          consecutive5xxErrors:
+                            description: Number of 5xx errors before a host is ejected
+                              from the connection pool.
+                            nullable: true
+                            type: integer
+                          consecutiveErrors:
+                            format: int32
+                            type: integer
+                          consecutiveGatewayErrors:
+                            description: Number of gateway errors before a host is
+                              ejected from the connection pool.
+                            nullable: true
+                            type: integer
+                          interval:
+                            description: Time interval between ejection sweep analysis.
+                            type: string
+                          maxEjectionPercent:
+                            format: int32
+                            type: integer
+                          minHealthPercent:
+                            format: int32
+                            type: integer
+                        type: object
+                      portLevelSettings:
+                        description: Traffic policies specific to individual ports.
+                        items:
+                          properties:
+                            connectionPool:
+                              properties:
+                                http:
+                                  description: HTTP connection pool settings.
+                                  properties:
+                                    h2UpgradePolicy:
+                                      description: Specify if http1.1 connection should
+                                        be upgraded to http2 for the associated destination.
+                                      enum:
+                                      - DEFAULT
+                                      - DO_NOT_UPGRADE
+                                      - UPGRADE
+                                      type: string
+                                    http1MaxPendingRequests:
+                                      description: Maximum number of pending HTTP
+                                        requests to a destination.
+                                      format: int32
+                                      type: integer
+                                    http2MaxRequests:
+                                      description: Maximum number of requests to a
+                                        backend.
+                                      format: int32
+                                      type: integer
+                                    idleTimeout:
+                                      description: The idle timeout for upstream connection
+                                        pool connections.
+                                      type: string
+                                    maxRequestsPerConnection:
+                                      description: Maximum number of requests per
+                                        connection to a backend.
+                                      format: int32
+                                      type: integer
+                                    maxRetries:
+                                      format: int32
+                                      type: integer
+                                    useClientProtocol:
+                                      description: If set to true, client protocol
+                                        will be preserved while initiating connection
+                                        to backend.
+                                      type: boolean
+                                  type: object
+                                tcp:
+                                  description: Settings common to both HTTP and TCP
+                                    upstream connections.
+                                  properties:
+                                    connectTimeout:
+                                      description: TCP connection timeout.
+                                      type: string
+                                    maxConnections:
+                                      description: Maximum number of HTTP1 /TCP connections
+                                        to a destination host.
+                                      format: int32
+                                      type: integer
+                                    tcpKeepalive:
+                                      description: If set then set SO_KEEPALIVE on
+                                        the socket to enable TCP Keepalives.
+                                      properties:
+                                        interval:
+                                          description: The time duration between keep-alive
+                                            probes.
+                                          type: string
+                                        probes:
+                                          type: integer
+                                        time:
+                                          type: string
+                                      type: object
+                                  type: object
                               type: object
-                          type: object
-                        loadBalancer:
-                          description: Settings controlling the load balancer algorithms.
-                          oneOf:
-                          - not:
-                              anyOf:
+                            loadBalancer:
+                              description: Settings controlling the load balancer
+                                algorithms.
+                              oneOf:
+                              - not:
+                                  anyOf:
+                                  - required:
+                                    - simple
+                                  - properties:
+                                      consistentHash:
+                                        oneOf:
+                                        - not:
+                                            anyOf:
+                                            - required:
+                                              - httpHeaderName
+                                            - required:
+                                              - httpCookie
+                                            - required:
+                                              - useSourceIp
+                                            - required:
+                                              - httpQueryParameterName
+                                        - required:
+                                          - httpHeaderName
+                                        - required:
+                                          - httpCookie
+                                        - required:
+                                          - useSourceIp
+                                        - required:
+                                          - httpQueryParameterName
+                                    required:
+                                    - consistentHash
                               - required:
                                 - simple
                               - properties:
@@ -1188,21 +662,277 @@ spec:
                                       - httpQueryParameterName
                                 required:
                                 - consistentHash
-                          - required:
-                            - simple
-                          - properties:
-                              consistentHash:
-                                oneOf:
-                                - not:
-                                    anyOf:
-                                    - required:
-                                      - httpHeaderName
-                                    - required:
-                                      - httpCookie
-                                    - required:
-                                      - useSourceIp
-                                    - required:
-                                      - httpQueryParameterName
+                              properties:
+                                consistentHash:
+                                  properties:
+                                    httpCookie:
+                                      description: Hash based on HTTP cookie.
+                                      properties:
+                                        name:
+                                          description: Name of the cookie.
+                                          format: string
+                                          type: string
+                                        path:
+                                          description: Path to set for the cookie.
+                                          format: string
+                                          type: string
+                                        ttl:
+                                          description: Lifetime of the cookie.
+                                          type: string
+                                      type: object
+                                    httpHeaderName:
+                                      description: Hash based on a specific HTTP header.
+                                      format: string
+                                      type: string
+                                    httpQueryParameterName:
+                                      description: Hash based on a specific HTTP query
+                                        parameter.
+                                      format: string
+                                      type: string
+                                    minimumRingSize:
+                                      type: integer
+                                    useSourceIp:
+                                      description: Hash based on the source IP address.
+                                      type: boolean
+                                  type: object
+                                localityLbSetting:
+                                  properties:
+                                    distribute:
+                                      description: 'Optional: only one of distribute
+                                        or failover can be set.'
+                                      items:
+                                        properties:
+                                          from:
+                                            description: Originating locality, '/'
+                                              separated, e.g.
+                                            format: string
+                                            type: string
+                                          to:
+                                            additionalProperties:
+                                              type: integer
+                                            description: Map of upstream localities
+                                              to traffic distribution weights.
+                                            type: object
+                                        type: object
+                                      type: array
+                                    enabled:
+                                      description: enable locality load balancing,
+                                        this is DestinationRule-level and will override
+                                        mesh wide settings in entirety.
+                                      nullable: true
+                                      type: boolean
+                                    failover:
+                                      description: 'Optional: only failover or distribute
+                                        can be set.'
+                                      items:
+                                        properties:
+                                          from:
+                                            description: Originating region.
+                                            format: string
+                                            type: string
+                                          to:
+                                            format: string
+                                            type: string
+                                        type: object
+                                      type: array
+                                  type: object
+                                simple:
+                                  enum:
+                                  - ROUND_ROBIN
+                                  - LEAST_CONN
+                                  - RANDOM
+                                  - PASSTHROUGH
+                                  type: string
+                              type: object
+                            outlierDetection:
+                              properties:
+                                baseEjectionTime:
+                                  description: Minimum ejection duration.
+                                  type: string
+                                consecutive5xxErrors:
+                                  description: Number of 5xx errors before a host
+                                    is ejected from the connection pool.
+                                  nullable: true
+                                  type: integer
+                                consecutiveErrors:
+                                  format: int32
+                                  type: integer
+                                consecutiveGatewayErrors:
+                                  description: Number of gateway errors before a host
+                                    is ejected from the connection pool.
+                                  nullable: true
+                                  type: integer
+                                interval:
+                                  description: Time interval between ejection sweep
+                                    analysis.
+                                  type: string
+                                maxEjectionPercent:
+                                  format: int32
+                                  type: integer
+                                minHealthPercent:
+                                  format: int32
+                                  type: integer
+                              type: object
+                            port:
+                              properties:
+                                number:
+                                  type: integer
+                              type: object
+                            tls:
+                              description: TLS related settings for connections to
+                                the upstream service.
+                              properties:
+                                caCertificates:
+                                  format: string
+                                  type: string
+                                clientCertificate:
+                                  description: REQUIRED if mode is `MUTUAL`.
+                                  format: string
+                                  type: string
+                                credentialName:
+                                  format: string
+                                  type: string
+                                mode:
+                                  enum:
+                                  - DISABLE
+                                  - SIMPLE
+                                  - MUTUAL
+                                  - ISTIO_MUTUAL
+                                  type: string
+                                privateKey:
+                                  description: REQUIRED if mode is `MUTUAL`.
+                                  format: string
+                                  type: string
+                                sni:
+                                  description: SNI string to present to the server
+                                    during TLS handshake.
+                                  format: string
+                                  type: string
+                                subjectAltNames:
+                                  items:
+                                    format: string
+                                    type: string
+                                  type: array
+                              type: object
+                          type: object
+                        type: array
+                      tls:
+                        description: TLS related settings for connections to the upstream
+                          service.
+                        properties:
+                          caCertificates:
+                            format: string
+                            type: string
+                          clientCertificate:
+                            description: REQUIRED if mode is `MUTUAL`.
+                            format: string
+                            type: string
+                          credentialName:
+                            format: string
+                            type: string
+                          mode:
+                            enum:
+                            - DISABLE
+                            - SIMPLE
+                            - MUTUAL
+                            - ISTIO_MUTUAL
+                            type: string
+                          privateKey:
+                            description: REQUIRED if mode is `MUTUAL`.
+                            format: string
+                            type: string
+                          sni:
+                            description: SNI string to present to the server during
+                              TLS handshake.
+                            format: string
+                            type: string
+                          subjectAltNames:
+                            items:
+                              format: string
+                              type: string
+                            type: array
+                        type: object
+                    type: object
+                type: object
+              type: array
+            trafficPolicy:
+              properties:
+                connectionPool:
+                  properties:
+                    http:
+                      description: HTTP connection pool settings.
+                      properties:
+                        h2UpgradePolicy:
+                          description: Specify if http1.1 connection should be upgraded
+                            to http2 for the associated destination.
+                          enum:
+                          - DEFAULT
+                          - DO_NOT_UPGRADE
+                          - UPGRADE
+                          type: string
+                        http1MaxPendingRequests:
+                          description: Maximum number of pending HTTP requests to
+                            a destination.
+                          format: int32
+                          type: integer
+                        http2MaxRequests:
+                          description: Maximum number of requests to a backend.
+                          format: int32
+                          type: integer
+                        idleTimeout:
+                          description: The idle timeout for upstream connection pool
+                            connections.
+                          type: string
+                        maxRequestsPerConnection:
+                          description: Maximum number of requests per connection to
+                            a backend.
+                          format: int32
+                          type: integer
+                        maxRetries:
+                          format: int32
+                          type: integer
+                        useClientProtocol:
+                          description: If set to true, client protocol will be preserved
+                            while initiating connection to backend.
+                          type: boolean
+                      type: object
+                    tcp:
+                      description: Settings common to both HTTP and TCP upstream connections.
+                      properties:
+                        connectTimeout:
+                          description: TCP connection timeout.
+                          type: string
+                        maxConnections:
+                          description: Maximum number of HTTP1 /TCP connections to
+                            a destination host.
+                          format: int32
+                          type: integer
+                        tcpKeepalive:
+                          description: If set then set SO_KEEPALIVE on the socket
+                            to enable TCP Keepalives.
+                          properties:
+                            interval:
+                              description: The time duration between keep-alive probes.
+                              type: string
+                            probes:
+                              type: integer
+                            time:
+                              type: string
+                          type: object
+                      type: object
+                  type: object
+                loadBalancer:
+                  description: Settings controlling the load balancer algorithms.
+                  oneOf:
+                  - not:
+                      anyOf:
+                      - required:
+                        - simple
+                      - properties:
+                          consistentHash:
+                            oneOf:
+                            - not:
+                                anyOf:
                                 - required:
                                   - httpHeaderName
                                 - required:
@@ -1211,1250 +941,477 @@ spec:
                                   - useSourceIp
                                 - required:
                                   - httpQueryParameterName
-                            required:
-                            - consistentHash
+                            - required:
+                              - httpHeaderName
+                            - required:
+                              - httpCookie
+                            - required:
+                              - useSourceIp
+                            - required:
+                              - httpQueryParameterName
+                        required:
+                        - consistentHash
+                  - required:
+                    - simple
+                  - properties:
+                      consistentHash:
+                        oneOf:
+                        - not:
+                            anyOf:
+                            - required:
+                              - httpHeaderName
+                            - required:
+                              - httpCookie
+                            - required:
+                              - useSourceIp
+                            - required:
+                              - httpQueryParameterName
+                        - required:
+                          - httpHeaderName
+                        - required:
+                          - httpCookie
+                        - required:
+                          - useSourceIp
+                        - required:
+                          - httpQueryParameterName
+                    required:
+                    - consistentHash
+                  properties:
+                    consistentHash:
+                      properties:
+                        httpCookie:
+                          description: Hash based on HTTP cookie.
                           properties:
-                            consistentHash:
-                              properties:
-                                httpCookie:
-                                  description: Hash based on HTTP cookie.
-                                  properties:
-                                    name:
-                                      description: Name of the cookie.
-                                      format: string
-                                      type: string
-                                    path:
-                                      description: Path to set for the cookie.
-                                      format: string
-                                      type: string
-                                    ttl:
-                                      description: Lifetime of the cookie.
-                                      type: string
-                                  type: object
-                                httpHeaderName:
-                                  description: Hash based on a specific HTTP header.
-                                  format: string
-                                  type: string
-                                httpQueryParameterName:
-                                  description: Hash based on a specific HTTP query parameter.
-                                  format: string
-                                  type: string
-                                minimumRingSize:
-                                  type: integer
-                                useSourceIp:
-                                  description: Hash based on the source IP address.
-                                  type: boolean
-                              type: object
-                            localityLbSetting:
-                              properties:
-                                distribute:
-                                  description: 'Optional: only one of distribute or failover can be set.'
-                                  items:
-                                    properties:
-                                      from:
-                                        description: Originating locality, '/' separated, e.g.
-                                        format: string
-                                        type: string
-                                      to:
-                                        additionalProperties:
-                                          type: integer
-                                        description: Map of upstream localities to traffic distribution weights.
-                                        type: object
-                                    type: object
-                                  type: array
-                                enabled:
-                                  description: enable locality load balancing, this is DestinationRule-level and will override mesh wide settings in entirety.
-                                  nullable: true
-                                  type: boolean
-                                failover:
-                                  description: 'Optional: only failover or distribute can be set.'
-                                  items:
-                                    properties:
-                                      from:
-                                        description: Originating region.
-                                        format: string
-                                        type: string
-                                      to:
-                                        format: string
-                                        type: string
-                                    type: object
-                                  type: array
-                              type: object
-                            simple:
-                              enum:
-                              - ROUND_ROBIN
-                              - LEAST_CONN
-                              - RANDOM
-                              - PASSTHROUGH
+                            name:
+                              description: Name of the cookie.
+                              format: string
+                              type: string
+                            path:
+                              description: Path to set for the cookie.
+                              format: string
+                              type: string
+                            ttl:
+                              description: Lifetime of the cookie.
                               type: string
                           type: object
-                        outlierDetection:
-                          properties:
-                            baseEjectionTime:
-                              description: Minimum ejection duration.
-                              type: string
-                            consecutive5xxErrors:
-                              description: Number of 5xx errors before a host is ejected from the connection pool.
-                              nullable: true
-                              type: integer
-                            consecutiveErrors:
-                              format: int32
-                              type: integer
-                            consecutiveGatewayErrors:
-                              description: Number of gateway errors before a host is ejected from the connection pool.
-                              nullable: true
-                              type: integer
-                            interval:
-                              description: Time interval between ejection sweep analysis.
-                              type: string
-                            maxEjectionPercent:
-                              format: int32
-                              type: integer
-                            minHealthPercent:
-                              format: int32
-                              type: integer
-                          type: object
-                        port:
-                          properties:
-                            number:
-                              type: integer
-                          type: object
-                        tls:
-                          description: TLS related settings for connections to the upstream service.
-                          properties:
-                            caCertificates:
-                              format: string
-                              type: string
-                            clientCertificate:
-                              description: REQUIRED if mode is `MUTUAL`.
-                              format: string
-                              type: string
-                            credentialName:
-                              format: string
-                              type: string
-                            mode:
-                              enum:
-                              - DISABLE
-                              - SIMPLE
-                              - MUTUAL
-                              - ISTIO_MUTUAL
-                              type: string
-                            privateKey:
-                              description: REQUIRED if mode is `MUTUAL`.
-                              format: string
-                              type: string
-                            sni:
-                              description: SNI string to present to the server during TLS handshake.
-                              format: string
-                              type: string
-                            subjectAltNames:
-                              items:
-                                format: string
-                                type: string
-                              type: array
-                          type: object
-                      type: object
-                    type: array
-                  tls:
-                    description: TLS related settings for connections to the upstream service.
-                    properties:
-                      caCertificates:
-                        format: string
-                        type: string
-                      clientCertificate:
-                        description: REQUIRED if mode is `MUTUAL`.
-                        format: string
-                        type: string
-                      credentialName:
-                        format: string
-                        type: string
-                      mode:
-                        enum:
-                        - DISABLE
-                        - SIMPLE
-                        - MUTUAL
-                        - ISTIO_MUTUAL
-                        type: string
-                      privateKey:
-                        description: REQUIRED if mode is `MUTUAL`.
-                        format: string
-                        type: string
-                      sni:
-                        description: SNI string to present to the server during TLS handshake.
-                        format: string
-                        type: string
-                      subjectAltNames:
-                        items:
+                        httpHeaderName:
+                          description: Hash based on a specific HTTP header.
                           format: string
                           type: string
-                        type: array
+                        httpQueryParameterName:
+                          description: Hash based on a specific HTTP query parameter.
+                          format: string
+                          type: string
+                        minimumRingSize:
+                          type: integer
+                        useSourceIp:
+                          description: Hash based on the source IP address.
+                          type: boolean
+                      type: object
+                    localityLbSetting:
+                      properties:
+                        distribute:
+                          description: 'Optional: only one of distribute or failover
+                            can be set.'
+                          items:
+                            properties:
+                              from:
+                                description: Originating locality, '/' separated,
+                                  e.g.
+                                format: string
+                                type: string
+                              to:
+                                additionalProperties:
+                                  type: integer
+                                description: Map of upstream localities to traffic
+                                  distribution weights.
+                                type: object
+                            type: object
+                          type: array
+                        enabled:
+                          description: enable locality load balancing, this is DestinationRule-level
+                            and will override mesh wide settings in entirety.
+                          nullable: true
+                          type: boolean
+                        failover:
+                          description: 'Optional: only failover or distribute can
+                            be set.'
+                          items:
+                            properties:
+                              from:
+                                description: Originating region.
+                                format: string
+                                type: string
+                              to:
+                                format: string
+                                type: string
+                            type: object
+                          type: array
+                      type: object
+                    simple:
+                      enum:
+                      - ROUND_ROBIN
+                      - LEAST_CONN
+                      - RANDOM
+                      - PASSTHROUGH
+                      type: string
+                  type: object
+                outlierDetection:
+                  properties:
+                    baseEjectionTime:
+                      description: Minimum ejection duration.
+                      type: string
+                    consecutive5xxErrors:
+                      description: Number of 5xx errors before a host is ejected from
+                        the connection pool.
+                      nullable: true
+                      type: integer
+                    consecutiveErrors:
+                      format: int32
+                      type: integer
+                    consecutiveGatewayErrors:
+                      description: Number of gateway errors before a host is ejected
+                        from the connection pool.
+                      nullable: true
+                      type: integer
+                    interval:
+                      description: Time interval between ejection sweep analysis.
+                      type: string
+                    maxEjectionPercent:
+                      format: int32
+                      type: integer
+                    minHealthPercent:
+                      format: int32
+                      type: integer
+                  type: object
+                portLevelSettings:
+                  description: Traffic policies specific to individual ports.
+                  items:
+                    properties:
+                      connectionPool:
+                        properties:
+                          http:
+                            description: HTTP connection pool settings.
+                            properties:
+                              h2UpgradePolicy:
+                                description: Specify if http1.1 connection should
+                                  be upgraded to http2 for the associated destination.
+                                enum:
+                                - DEFAULT
+                                - DO_NOT_UPGRADE
+                                - UPGRADE
+                                type: string
+                              http1MaxPendingRequests:
+                                description: Maximum number of pending HTTP requests
+                                  to a destination.
+                                format: int32
+                                type: integer
+                              http2MaxRequests:
+                                description: Maximum number of requests to a backend.
+                                format: int32
+                                type: integer
+                              idleTimeout:
+                                description: The idle timeout for upstream connection
+                                  pool connections.
+                                type: string
+                              maxRequestsPerConnection:
+                                description: Maximum number of requests per connection
+                                  to a backend.
+                                format: int32
+                                type: integer
+                              maxRetries:
+                                format: int32
+                                type: integer
+                              useClientProtocol:
+                                description: If set to true, client protocol will
+                                  be preserved while initiating connection to backend.
+                                type: boolean
+                            type: object
+                          tcp:
+                            description: Settings common to both HTTP and TCP upstream
+                              connections.
+                            properties:
+                              connectTimeout:
+                                description: TCP connection timeout.
+                                type: string
+                              maxConnections:
+                                description: Maximum number of HTTP1 /TCP connections
+                                  to a destination host.
+                                format: int32
+                                type: integer
+                              tcpKeepalive:
+                                description: If set then set SO_KEEPALIVE on the socket
+                                  to enable TCP Keepalives.
+                                properties:
+                                  interval:
+                                    description: The time duration between keep-alive
+                                      probes.
+                                    type: string
+                                  probes:
+                                    type: integer
+                                  time:
+                                    type: string
+                                type: object
+                            type: object
+                        type: object
+                      loadBalancer:
+                        description: Settings controlling the load balancer algorithms.
+                        oneOf:
+                        - not:
+                            anyOf:
+                            - required:
+                              - simple
+                            - properties:
+                                consistentHash:
+                                  oneOf:
+                                  - not:
+                                      anyOf:
+                                      - required:
+                                        - httpHeaderName
+                                      - required:
+                                        - httpCookie
+                                      - required:
+                                        - useSourceIp
+                                      - required:
+                                        - httpQueryParameterName
+                                  - required:
+                                    - httpHeaderName
+                                  - required:
+                                    - httpCookie
+                                  - required:
+                                    - useSourceIp
+                                  - required:
+                                    - httpQueryParameterName
+                              required:
+                              - consistentHash
+                        - required:
+                          - simple
+                        - properties:
+                            consistentHash:
+                              oneOf:
+                              - not:
+                                  anyOf:
+                                  - required:
+                                    - httpHeaderName
+                                  - required:
+                                    - httpCookie
+                                  - required:
+                                    - useSourceIp
+                                  - required:
+                                    - httpQueryParameterName
+                              - required:
+                                - httpHeaderName
+                              - required:
+                                - httpCookie
+                              - required:
+                                - useSourceIp
+                              - required:
+                                - httpQueryParameterName
+                          required:
+                          - consistentHash
+                        properties:
+                          consistentHash:
+                            properties:
+                              httpCookie:
+                                description: Hash based on HTTP cookie.
+                                properties:
+                                  name:
+                                    description: Name of the cookie.
+                                    format: string
+                                    type: string
+                                  path:
+                                    description: Path to set for the cookie.
+                                    format: string
+                                    type: string
+                                  ttl:
+                                    description: Lifetime of the cookie.
+                                    type: string
+                                type: object
+                              httpHeaderName:
+                                description: Hash based on a specific HTTP header.
+                                format: string
+                                type: string
+                              httpQueryParameterName:
+                                description: Hash based on a specific HTTP query parameter.
+                                format: string
+                                type: string
+                              minimumRingSize:
+                                type: integer
+                              useSourceIp:
+                                description: Hash based on the source IP address.
+                                type: boolean
+                            type: object
+                          localityLbSetting:
+                            properties:
+                              distribute:
+                                description: 'Optional: only one of distribute or
+                                  failover can be set.'
+                                items:
+                                  properties:
+                                    from:
+                                      description: Originating locality, '/' separated,
+                                        e.g.
+                                      format: string
+                                      type: string
+                                    to:
+                                      additionalProperties:
+                                        type: integer
+                                      description: Map of upstream localities to traffic
+                                        distribution weights.
+                                      type: object
+                                  type: object
+                                type: array
+                              enabled:
+                                description: enable locality load balancing, this
+                                  is DestinationRule-level and will override mesh
+                                  wide settings in entirety.
+                                nullable: true
+                                type: boolean
+                              failover:
+                                description: 'Optional: only failover or distribute
+                                  can be set.'
+                                items:
+                                  properties:
+                                    from:
+                                      description: Originating region.
+                                      format: string
+                                      type: string
+                                    to:
+                                      format: string
+                                      type: string
+                                  type: object
+                                type: array
+                            type: object
+                          simple:
+                            enum:
+                            - ROUND_ROBIN
+                            - LEAST_CONN
+                            - RANDOM
+                            - PASSTHROUGH
+                            type: string
+                        type: object
+                      outlierDetection:
+                        properties:
+                          baseEjectionTime:
+                            description: Minimum ejection duration.
+                            type: string
+                          consecutive5xxErrors:
+                            description: Number of 5xx errors before a host is ejected
+                              from the connection pool.
+                            nullable: true
+                            type: integer
+                          consecutiveErrors:
+                            format: int32
+                            type: integer
+                          consecutiveGatewayErrors:
+                            description: Number of gateway errors before a host is
+                              ejected from the connection pool.
+                            nullable: true
+                            type: integer
+                          interval:
+                            description: Time interval between ejection sweep analysis.
+                            type: string
+                          maxEjectionPercent:
+                            format: int32
+                            type: integer
+                          minHealthPercent:
+                            format: int32
+                            type: integer
+                        type: object
+                      port:
+                        properties:
+                          number:
+                            type: integer
+                        type: object
+                      tls:
+                        description: TLS related settings for connections to the upstream
+                          service.
+                        properties:
+                          caCertificates:
+                            format: string
+                            type: string
+                          clientCertificate:
+                            description: REQUIRED if mode is `MUTUAL`.
+                            format: string
+                            type: string
+                          credentialName:
+                            format: string
+                            type: string
+                          mode:
+                            enum:
+                            - DISABLE
+                            - SIMPLE
+                            - MUTUAL
+                            - ISTIO_MUTUAL
+                            type: string
+                          privateKey:
+                            description: REQUIRED if mode is `MUTUAL`.
+                            format: string
+                            type: string
+                          sni:
+                            description: SNI string to present to the server during
+                              TLS handshake.
+                            format: string
+                            type: string
+                          subjectAltNames:
+                            items:
+                              format: string
+                              type: string
+                            type: array
+                        type: object
                     type: object
-                type: object
-            type: object
-          status:
-            type: object
-            x-kubernetes-preserve-unknown-fields: true
-        type: object
+                  type: array
+                tls:
+                  description: TLS related settings for connections to the upstream
+                    service.
+                  properties:
+                    caCertificates:
+                      format: string
+                      type: string
+                    clientCertificate:
+                      description: REQUIRED if mode is `MUTUAL`.
+                      format: string
+                      type: string
+                    credentialName:
+                      format: string
+                      type: string
+                    mode:
+                      enum:
+                      - DISABLE
+                      - SIMPLE
+                      - MUTUAL
+                      - ISTIO_MUTUAL
+                      type: string
+                    privateKey:
+                      description: REQUIRED if mode is `MUTUAL`.
+                      format: string
+                      type: string
+                    sni:
+                      description: SNI string to present to the server during TLS
+                        handshake.
+                      format: string
+                      type: string
+                    subjectAltNames:
+                      items:
+                        format: string
+                        type: string
+                      type: array
+                  type: object
+              type: object
+          type: object
+        status:
+          type: object
+          x-kubernetes-preserve-unknown-fields: true
+      type: object
+  versions:
+  - name: v1alpha3
     served: true
     storage: true
-    subresources:
-      status: {}
-  - additionalPrinterColumns:
-    - description: The name of a service from the service registry
-      jsonPath: .spec.host
-      name: Host
-      type: string
-    - description: 'CreationTimestamp is a timestamp representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations. Clients may not set this value. It is represented in RFC3339 form and is in UTC. Populated by the system. Read-only. Null for lists. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata'
-      jsonPath: .metadata.creationTimestamp
-      name: Age
-      type: date
-    name: v1beta1
-    schema:
-      openAPIV3Schema:
-        properties:
-          spec:
-            description: 'Configuration affecting load balancing, outlier detection, etc. See more details at: https://istio.io/docs/reference/config/networking/destination-rule.html'
-            properties:
-              exportTo:
-                description: A list of namespaces to which this destination rule is exported.
-                items:
-                  format: string
-                  type: string
-                type: array
-              host:
-                description: The name of a service from the service registry.
-                format: string
-                type: string
-              subsets:
-                items:
-                  properties:
-                    labels:
-                      additionalProperties:
-                        format: string
-                        type: string
-                      type: object
-                    name:
-                      description: Name of the subset.
-                      format: string
-                      type: string
-                    trafficPolicy:
-                      description: Traffic policies that apply to this subset.
-                      properties:
-                        connectionPool:
-                          properties:
-                            http:
-                              description: HTTP connection pool settings.
-                              properties:
-                                h2UpgradePolicy:
-                                  description: Specify if http1.1 connection should be upgraded to http2 for the associated destination.
-                                  enum:
-                                  - DEFAULT
-                                  - DO_NOT_UPGRADE
-                                  - UPGRADE
-                                  type: string
-                                http1MaxPendingRequests:
-                                  description: Maximum number of pending HTTP requests to a destination.
-                                  format: int32
-                                  type: integer
-                                http2MaxRequests:
-                                  description: Maximum number of requests to a backend.
-                                  format: int32
-                                  type: integer
-                                idleTimeout:
-                                  description: The idle timeout for upstream connection pool connections.
-                                  type: string
-                                maxRequestsPerConnection:
-                                  description: Maximum number of requests per connection to a backend.
-                                  format: int32
-                                  type: integer
-                                maxRetries:
-                                  format: int32
-                                  type: integer
-                              type: object
-                            tcp:
-                              description: Settings common to both HTTP and TCP upstream connections.
-                              properties:
-                                connectTimeout:
-                                  description: TCP connection timeout.
-                                  type: string
-                                maxConnections:
-                                  description: Maximum number of HTTP1 /TCP connections to a destination host.
-                                  format: int32
-                                  type: integer
-                                tcpKeepalive:
-                                  description: If set then set SO_KEEPALIVE on the socket to enable TCP Keepalives.
-                                  properties:
-                                    interval:
-                                      description: The time duration between keep-alive probes.
-                                      type: string
-                                    probes:
-                                      type: integer
-                                    time:
-                                      type: string
-                                  type: object
-                              type: object
-                          type: object
-                        loadBalancer:
-                          description: Settings controlling the load balancer algorithms.
-                          oneOf:
-                          - not:
-                              anyOf:
-                              - required:
-                                - simple
-                              - properties:
-                                  consistentHash:
-                                    oneOf:
-                                    - not:
-                                        anyOf:
-                                        - required:
-                                          - httpHeaderName
-                                        - required:
-                                          - httpCookie
-                                        - required:
-                                          - useSourceIp
-                                        - required:
-                                          - httpQueryParameterName
-                                    - required:
-                                      - httpHeaderName
-                                    - required:
-                                      - httpCookie
-                                    - required:
-                                      - useSourceIp
-                                    - required:
-                                      - httpQueryParameterName
-                                required:
-                                - consistentHash
-                          - required:
-                            - simple
-                          - properties:
-                              consistentHash:
-                                oneOf:
-                                - not:
-                                    anyOf:
-                                    - required:
-                                      - httpHeaderName
-                                    - required:
-                                      - httpCookie
-                                    - required:
-                                      - useSourceIp
-                                    - required:
-                                      - httpQueryParameterName
-                                - required:
-                                  - httpHeaderName
-                                - required:
-                                  - httpCookie
-                                - required:
-                                  - useSourceIp
-                                - required:
-                                  - httpQueryParameterName
-                            required:
-                            - consistentHash
-                          properties:
-                            consistentHash:
-                              properties:
-                                httpCookie:
-                                  description: Hash based on HTTP cookie.
-                                  properties:
-                                    name:
-                                      description: Name of the cookie.
-                                      format: string
-                                      type: string
-                                    path:
-                                      description: Path to set for the cookie.
-                                      format: string
-                                      type: string
-                                    ttl:
-                                      description: Lifetime of the cookie.
-                                      type: string
-                                  type: object
-                                httpHeaderName:
-                                  description: Hash based on a specific HTTP header.
-                                  format: string
-                                  type: string
-                                httpQueryParameterName:
-                                  description: Hash based on a specific HTTP query parameter.
-                                  format: string
-                                  type: string
-                                minimumRingSize:
-                                  type: integer
-                                useSourceIp:
-                                  description: Hash based on the source IP address.
-                                  type: boolean
-                              type: object
-                            localityLbSetting:
-                              properties:
-                                distribute:
-                                  description: 'Optional: only one of distribute or failover can be set.'
-                                  items:
-                                    properties:
-                                      from:
-                                        description: Originating locality, '/' separated, e.g.
-                                        format: string
-                                        type: string
-                                      to:
-                                        additionalProperties:
-                                          type: integer
-                                        description: Map of upstream localities to traffic distribution weights.
-                                        type: object
-                                    type: object
-                                  type: array
-                                enabled:
-                                  description: enable locality load balancing, this is DestinationRule-level and will override mesh wide settings in entirety.
-                                  nullable: true
-                                  type: boolean
-                                failover:
-                                  description: 'Optional: only failover or distribute can be set.'
-                                  items:
-                                    properties:
-                                      from:
-                                        description: Originating region.
-                                        format: string
-                                        type: string
-                                      to:
-                                        format: string
-                                        type: string
-                                    type: object
-                                  type: array
-                              type: object
-                            simple:
-                              enum:
-                              - ROUND_ROBIN
-                              - LEAST_CONN
-                              - RANDOM
-                              - PASSTHROUGH
-                              type: string
-                          type: object
-                        outlierDetection:
-                          properties:
-                            baseEjectionTime:
-                              description: Minimum ejection duration.
-                              type: string
-                            consecutive5xxErrors:
-                              description: Number of 5xx errors before a host is ejected from the connection pool.
-                              nullable: true
-                              type: integer
-                            consecutiveErrors:
-                              format: int32
-                              type: integer
-                            consecutiveGatewayErrors:
-                              description: Number of gateway errors before a host is ejected from the connection pool.
-                              nullable: true
-                              type: integer
-                            interval:
-                              description: Time interval between ejection sweep analysis.
-                              type: string
-                            maxEjectionPercent:
-                              format: int32
-                              type: integer
-                            minHealthPercent:
-                              format: int32
-                              type: integer
-                          type: object
-                        portLevelSettings:
-                          description: Traffic policies specific to individual ports.
-                          items:
-                            properties:
-                              connectionPool:
-                                properties:
-                                  http:
-                                    description: HTTP connection pool settings.
-                                    properties:
-                                      h2UpgradePolicy:
-                                        description: Specify if http1.1 connection should be upgraded to http2 for the associated destination.
-                                        enum:
-                                        - DEFAULT
-                                        - DO_NOT_UPGRADE
-                                        - UPGRADE
-                                        type: string
-                                      http1MaxPendingRequests:
-                                        description: Maximum number of pending HTTP requests to a destination.
-                                        format: int32
-                                        type: integer
-                                      http2MaxRequests:
-                                        description: Maximum number of requests to a backend.
-                                        format: int32
-                                        type: integer
-                                      idleTimeout:
-                                        description: The idle timeout for upstream connection pool connections.
-                                        type: string
-                                      maxRequestsPerConnection:
-                                        description: Maximum number of requests per connection to a backend.
-                                        format: int32
-                                        type: integer
-                                      maxRetries:
-                                        format: int32
-                                        type: integer
-                                    type: object
-                                  tcp:
-                                    description: Settings common to both HTTP and TCP upstream connections.
-                                    properties:
-                                      connectTimeout:
-                                        description: TCP connection timeout.
-                                        type: string
-                                      maxConnections:
-                                        description: Maximum number of HTTP1 /TCP connections to a destination host.
-                                        format: int32
-                                        type: integer
-                                      tcpKeepalive:
-                                        description: If set then set SO_KEEPALIVE on the socket to enable TCP Keepalives.
-                                        properties:
-                                          interval:
-                                            description: The time duration between keep-alive probes.
-                                            type: string
-                                          probes:
-                                            type: integer
-                                          time:
-                                            type: string
-                                        type: object
-                                    type: object
-                                type: object
-                              loadBalancer:
-                                description: Settings controlling the load balancer algorithms.
-                                oneOf:
-                                - not:
-                                    anyOf:
-                                    - required:
-                                      - simple
-                                    - properties:
-                                        consistentHash:
-                                          oneOf:
-                                          - not:
-                                              anyOf:
-                                              - required:
-                                                - httpHeaderName
-                                              - required:
-                                                - httpCookie
-                                              - required:
-                                                - useSourceIp
-                                              - required:
-                                                - httpQueryParameterName
-                                          - required:
-                                            - httpHeaderName
-                                          - required:
-                                            - httpCookie
-                                          - required:
-                                            - useSourceIp
-                                          - required:
-                                            - httpQueryParameterName
-                                      required:
-                                      - consistentHash
-                                - required:
-                                  - simple
-                                - properties:
-                                    consistentHash:
-                                      oneOf:
-                                      - not:
-                                          anyOf:
-                                          - required:
-                                            - httpHeaderName
-                                          - required:
-                                            - httpCookie
-                                          - required:
-                                            - useSourceIp
-                                          - required:
-                                            - httpQueryParameterName
-                                      - required:
-                                        - httpHeaderName
-                                      - required:
-                                        - httpCookie
-                                      - required:
-                                        - useSourceIp
-                                      - required:
-                                        - httpQueryParameterName
-                                  required:
-                                  - consistentHash
-                                properties:
-                                  consistentHash:
-                                    properties:
-                                      httpCookie:
-                                        description: Hash based on HTTP cookie.
-                                        properties:
-                                          name:
-                                            description: Name of the cookie.
-                                            format: string
-                                            type: string
-                                          path:
-                                            description: Path to set for the cookie.
-                                            format: string
-                                            type: string
-                                          ttl:
-                                            description: Lifetime of the cookie.
-                                            type: string
-                                        type: object
-                                      httpHeaderName:
-                                        description: Hash based on a specific HTTP header.
-                                        format: string
-                                        type: string
-                                      httpQueryParameterName:
-                                        description: Hash based on a specific HTTP query parameter.
-                                        format: string
-                                        type: string
-                                      minimumRingSize:
-                                        type: integer
-                                      useSourceIp:
-                                        description: Hash based on the source IP address.
-                                        type: boolean
-                                    type: object
-                                  localityLbSetting:
-                                    properties:
-                                      distribute:
-                                        description: 'Optional: only one of distribute or failover can be set.'
-                                        items:
-                                          properties:
-                                            from:
-                                              description: Originating locality, '/' separated, e.g.
-                                              format: string
-                                              type: string
-                                            to:
-                                              additionalProperties:
-                                                type: integer
-                                              description: Map of upstream localities to traffic distribution weights.
-                                              type: object
-                                          type: object
-                                        type: array
-                                      enabled:
-                                        description: enable locality load balancing, this is DestinationRule-level and will override mesh wide settings in entirety.
-                                        nullable: true
-                                        type: boolean
-                                      failover:
-                                        description: 'Optional: only failover or distribute can be set.'
-                                        items:
-                                          properties:
-                                            from:
-                                              description: Originating region.
-                                              format: string
-                                              type: string
-                                            to:
-                                              format: string
-                                              type: string
-                                          type: object
-                                        type: array
-                                    type: object
-                                  simple:
-                                    enum:
-                                    - ROUND_ROBIN
-                                    - LEAST_CONN
-                                    - RANDOM
-                                    - PASSTHROUGH
-                                    type: string
-                                type: object
-                              outlierDetection:
-                                properties:
-                                  baseEjectionTime:
-                                    description: Minimum ejection duration.
-                                    type: string
-                                  consecutive5xxErrors:
-                                    description: Number of 5xx errors before a host is ejected from the connection pool.
-                                    nullable: true
-                                    type: integer
-                                  consecutiveErrors:
-                                    format: int32
-                                    type: integer
-                                  consecutiveGatewayErrors:
-                                    description: Number of gateway errors before a host is ejected from the connection pool.
-                                    nullable: true
-                                    type: integer
-                                  interval:
-                                    description: Time interval between ejection sweep analysis.
-                                    type: string
-                                  maxEjectionPercent:
-                                    format: int32
-                                    type: integer
-                                  minHealthPercent:
-                                    format: int32
-                                    type: integer
-                                type: object
-                              port:
-                                properties:
-                                  number:
-                                    type: integer
-                                type: object
-                              tls:
-                                description: TLS related settings for connections to the upstream service.
-                                properties:
-                                  caCertificates:
-                                    format: string
-                                    type: string
-                                  clientCertificate:
-                                    description: REQUIRED if mode is `MUTUAL`.
-                                    format: string
-                                    type: string
-                                  credentialName:
-                                    format: string
-                                    type: string
-                                  mode:
-                                    enum:
-                                    - DISABLE
-                                    - SIMPLE
-                                    - MUTUAL
-                                    - ISTIO_MUTUAL
-                                    type: string
-                                  privateKey:
-                                    description: REQUIRED if mode is `MUTUAL`.
-                                    format: string
-                                    type: string
-                                  sni:
-                                    description: SNI string to present to the server during TLS handshake.
-                                    format: string
-                                    type: string
-                                  subjectAltNames:
-                                    items:
-                                      format: string
-                                      type: string
-                                    type: array
-                                type: object
-                            type: object
-                          type: array
-                        tls:
-                          description: TLS related settings for connections to the upstream service.
-                          properties:
-                            caCertificates:
-                              format: string
-                              type: string
-                            clientCertificate:
-                              description: REQUIRED if mode is `MUTUAL`.
-                              format: string
-                              type: string
-                            credentialName:
-                              format: string
-                              type: string
-                            mode:
-                              enum:
-                              - DISABLE
-                              - SIMPLE
-                              - MUTUAL
-                              - ISTIO_MUTUAL
-                              type: string
-                            privateKey:
-                              description: REQUIRED if mode is `MUTUAL`.
-                              format: string
-                              type: string
-                            sni:
-                              description: SNI string to present to the server during TLS handshake.
-                              format: string
-                              type: string
-                            subjectAltNames:
-                              items:
-                                format: string
-                                type: string
-                              type: array
-                          type: object
-                      type: object
-                  type: object
-                type: array
-              trafficPolicy:
-                properties:
-                  connectionPool:
-                    properties:
-                      http:
-                        description: HTTP connection pool settings.
-                        properties:
-                          h2UpgradePolicy:
-                            description: Specify if http1.1 connection should be upgraded to http2 for the associated destination.
-                            enum:
-                            - DEFAULT
-                            - DO_NOT_UPGRADE
-                            - UPGRADE
-                            type: string
-                          http1MaxPendingRequests:
-                            description: Maximum number of pending HTTP requests to a destination.
-                            format: int32
-                            type: integer
-                          http2MaxRequests:
-                            description: Maximum number of requests to a backend.
-                            format: int32
-                            type: integer
-                          idleTimeout:
-                            description: The idle timeout for upstream connection pool connections.
-                            type: string
-                          maxRequestsPerConnection:
-                            description: Maximum number of requests per connection to a backend.
-                            format: int32
-                            type: integer
-                          maxRetries:
-                            format: int32
-                            type: integer
-                        type: object
-                      tcp:
-                        description: Settings common to both HTTP and TCP upstream connections.
-                        properties:
-                          connectTimeout:
-                            description: TCP connection timeout.
-                            type: string
-                          maxConnections:
-                            description: Maximum number of HTTP1 /TCP connections to a destination host.
-                            format: int32
-                            type: integer
-                          tcpKeepalive:
-                            description: If set then set SO_KEEPALIVE on the socket to enable TCP Keepalives.
-                            properties:
-                              interval:
-                                description: The time duration between keep-alive probes.
-                                type: string
-                              probes:
-                                type: integer
-                              time:
-                                type: string
-                            type: object
-                        type: object
-                    type: object
-                  loadBalancer:
-                    description: Settings controlling the load balancer algorithms.
-                    oneOf:
-                    - not:
-                        anyOf:
-                        - required:
-                          - simple
-                        - properties:
-                            consistentHash:
-                              oneOf:
-                              - not:
-                                  anyOf:
-                                  - required:
-                                    - httpHeaderName
-                                  - required:
-                                    - httpCookie
-                                  - required:
-                                    - useSourceIp
-                                  - required:
-                                    - httpQueryParameterName
-                              - required:
-                                - httpHeaderName
-                              - required:
-                                - httpCookie
-                              - required:
-                                - useSourceIp
-                              - required:
-                                - httpQueryParameterName
-                          required:
-                          - consistentHash
-                    - required:
-                      - simple
-                    - properties:
-                        consistentHash:
-                          oneOf:
-                          - not:
-                              anyOf:
-                              - required:
-                                - httpHeaderName
-                              - required:
-                                - httpCookie
-                              - required:
-                                - useSourceIp
-                              - required:
-                                - httpQueryParameterName
-                          - required:
-                            - httpHeaderName
-                          - required:
-                            - httpCookie
-                          - required:
-                            - useSourceIp
-                          - required:
-                            - httpQueryParameterName
-                      required:
-                      - consistentHash
-                    properties:
-                      consistentHash:
-                        properties:
-                          httpCookie:
-                            description: Hash based on HTTP cookie.
-                            properties:
-                              name:
-                                description: Name of the cookie.
-                                format: string
-                                type: string
-                              path:
-                                description: Path to set for the cookie.
-                                format: string
-                                type: string
-                              ttl:
-                                description: Lifetime of the cookie.
-                                type: string
-                            type: object
-                          httpHeaderName:
-                            description: Hash based on a specific HTTP header.
-                            format: string
-                            type: string
-                          httpQueryParameterName:
-                            description: Hash based on a specific HTTP query parameter.
-                            format: string
-                            type: string
-                          minimumRingSize:
-                            type: integer
-                          useSourceIp:
-                            description: Hash based on the source IP address.
-                            type: boolean
-                        type: object
-                      localityLbSetting:
-                        properties:
-                          distribute:
-                            description: 'Optional: only one of distribute or failover can be set.'
-                            items:
-                              properties:
-                                from:
-                                  description: Originating locality, '/' separated, e.g.
-                                  format: string
-                                  type: string
-                                to:
-                                  additionalProperties:
-                                    type: integer
-                                  description: Map of upstream localities to traffic distribution weights.
-                                  type: object
-                              type: object
-                            type: array
-                          enabled:
-                            description: enable locality load balancing, this is DestinationRule-level and will override mesh wide settings in entirety.
-                            nullable: true
-                            type: boolean
-                          failover:
-                            description: 'Optional: only failover or distribute can be set.'
-                            items:
-                              properties:
-                                from:
-                                  description: Originating region.
-                                  format: string
-                                  type: string
-                                to:
-                                  format: string
-                                  type: string
-                              type: object
-                            type: array
-                        type: object
-                      simple:
-                        enum:
-                        - ROUND_ROBIN
-                        - LEAST_CONN
-                        - RANDOM
-                        - PASSTHROUGH
-                        type: string
-                    type: object
-                  outlierDetection:
-                    properties:
-                      baseEjectionTime:
-                        description: Minimum ejection duration.
-                        type: string
-                      consecutive5xxErrors:
-                        description: Number of 5xx errors before a host is ejected from the connection pool.
-                        nullable: true
-                        type: integer
-                      consecutiveErrors:
-                        format: int32
-                        type: integer
-                      consecutiveGatewayErrors:
-                        description: Number of gateway errors before a host is ejected from the connection pool.
-                        nullable: true
-                        type: integer
-                      interval:
-                        description: Time interval between ejection sweep analysis.
-                        type: string
-                      maxEjectionPercent:
-                        format: int32
-                        type: integer
-                      minHealthPercent:
-                        format: int32
-                        type: integer
-                    type: object
-                  portLevelSettings:
-                    description: Traffic policies specific to individual ports.
-                    items:
-                      properties:
-                        connectionPool:
-                          properties:
-                            http:
-                              description: HTTP connection pool settings.
-                              properties:
-                                h2UpgradePolicy:
-                                  description: Specify if http1.1 connection should be upgraded to http2 for the associated destination.
-                                  enum:
-                                  - DEFAULT
-                                  - DO_NOT_UPGRADE
-                                  - UPGRADE
-                                  type: string
-                                http1MaxPendingRequests:
-                                  description: Maximum number of pending HTTP requests to a destination.
-                                  format: int32
-                                  type: integer
-                                http2MaxRequests:
-                                  description: Maximum number of requests to a backend.
-                                  format: int32
-                                  type: integer
-                                idleTimeout:
-                                  description: The idle timeout for upstream connection pool connections.
-                                  type: string
-                                maxRequestsPerConnection:
-                                  description: Maximum number of requests per connection to a backend.
-                                  format: int32
-                                  type: integer
-                                maxRetries:
-                                  format: int32
-                                  type: integer
-                              type: object
-                            tcp:
-                              description: Settings common to both HTTP and TCP upstream connections.
-                              properties:
-                                connectTimeout:
-                                  description: TCP connection timeout.
-                                  type: string
-                                maxConnections:
-                                  description: Maximum number of HTTP1 /TCP connections to a destination host.
-                                  format: int32
-                                  type: integer
-                                tcpKeepalive:
-                                  description: If set then set SO_KEEPALIVE on the socket to enable TCP Keepalives.
-                                  properties:
-                                    interval:
-                                      description: The time duration between keep-alive probes.
-                                      type: string
-                                    probes:
-                                      type: integer
-                                    time:
-                                      type: string
-                                  type: object
-                              type: object
-                          type: object
-                        loadBalancer:
-                          description: Settings controlling the load balancer algorithms.
-                          oneOf:
-                          - not:
-                              anyOf:
-                              - required:
-                                - simple
-                              - properties:
-                                  consistentHash:
-                                    oneOf:
-                                    - not:
-                                        anyOf:
-                                        - required:
-                                          - httpHeaderName
-                                        - required:
-                                          - httpCookie
-                                        - required:
-                                          - useSourceIp
-                                        - required:
-                                          - httpQueryParameterName
-                                    - required:
-                                      - httpHeaderName
-                                    - required:
-                                      - httpCookie
-                                    - required:
-                                      - useSourceIp
-                                    - required:
-                                      - httpQueryParameterName
-                                required:
-                                - consistentHash
-                          - required:
-                            - simple
-                          - properties:
-                              consistentHash:
-                                oneOf:
-                                - not:
-                                    anyOf:
-                                    - required:
-                                      - httpHeaderName
-                                    - required:
-                                      - httpCookie
-                                    - required:
-                                      - useSourceIp
-                                    - required:
-                                      - httpQueryParameterName
-                                - required:
-                                  - httpHeaderName
-                                - required:
-                                  - httpCookie
-                                - required:
-                                  - useSourceIp
-                                - required:
-                                  - httpQueryParameterName
-                            required:
-                            - consistentHash
-                          properties:
-                            consistentHash:
-                              properties:
-                                httpCookie:
-                                  description: Hash based on HTTP cookie.
-                                  properties:
-                                    name:
-                                      description: Name of the cookie.
-                                      format: string
-                                      type: string
-                                    path:
-                                      description: Path to set for the cookie.
-                                      format: string
-                                      type: string
-                                    ttl:
-                                      description: Lifetime of the cookie.
-                                      type: string
-                                  type: object
-                                httpHeaderName:
-                                  description: Hash based on a specific HTTP header.
-                                  format: string
-                                  type: string
-                                httpQueryParameterName:
-                                  description: Hash based on a specific HTTP query parameter.
-                                  format: string
-                                  type: string
-                                minimumRingSize:
-                                  type: integer
-                                useSourceIp:
-                                  description: Hash based on the source IP address.
-                                  type: boolean
-                              type: object
-                            localityLbSetting:
-                              properties:
-                                distribute:
-                                  description: 'Optional: only one of distribute or failover can be set.'
-                                  items:
-                                    properties:
-                                      from:
-                                        description: Originating locality, '/' separated, e.g.
-                                        format: string
-                                        type: string
-                                      to:
-                                        additionalProperties:
-                                          type: integer
-                                        description: Map of upstream localities to traffic distribution weights.
-                                        type: object
-                                    type: object
-                                  type: array
-                                enabled:
-                                  description: enable locality load balancing, this is DestinationRule-level and will override mesh wide settings in entirety.
-                                  nullable: true
-                                  type: boolean
-                                failover:
-                                  description: 'Optional: only failover or distribute can be set.'
-                                  items:
-                                    properties:
-                                      from:
-                                        description: Originating region.
-                                        format: string
-                                        type: string
-                                      to:
-                                        format: string
-                                        type: string
-                                    type: object
-                                  type: array
-                              type: object
-                            simple:
-                              enum:
-                              - ROUND_ROBIN
-                              - LEAST_CONN
-                              - RANDOM
-                              - PASSTHROUGH
-                              type: string
-                          type: object
-                        outlierDetection:
-                          properties:
-                            baseEjectionTime:
-                              description: Minimum ejection duration.
-                              type: string
-                            consecutive5xxErrors:
-                              description: Number of 5xx errors before a host is ejected from the connection pool.
-                              nullable: true
-                              type: integer
-                            consecutiveErrors:
-                              format: int32
-                              type: integer
-                            consecutiveGatewayErrors:
-                              description: Number of gateway errors before a host is ejected from the connection pool.
-                              nullable: true
-                              type: integer
-                            interval:
-                              description: Time interval between ejection sweep analysis.
-                              type: string
-                            maxEjectionPercent:
-                              format: int32
-                              type: integer
-                            minHealthPercent:
-                              format: int32
-                              type: integer
-                          type: object
-                        port:
-                          properties:
-                            number:
-                              type: integer
-                          type: object
-                        tls:
-                          description: TLS related settings for connections to the upstream service.
-                          properties:
-                            caCertificates:
-                              format: string
-                              type: string
-                            clientCertificate:
-                              description: REQUIRED if mode is `MUTUAL`.
-                              format: string
-                              type: string
-                            credentialName:
-                              format: string
-                              type: string
-                            mode:
-                              enum:
-                              - DISABLE
-                              - SIMPLE
-                              - MUTUAL
-                              - ISTIO_MUTUAL
-                              type: string
-                            privateKey:
-                              description: REQUIRED if mode is `MUTUAL`.
-                              format: string
-                              type: string
-                            sni:
-                              description: SNI string to present to the server during TLS handshake.
-                              format: string
-                              type: string
-                            subjectAltNames:
-                              items:
-                                format: string
-                                type: string
-                              type: array
-                          type: object
-                      type: object
-                    type: array
-                  tls:
-                    description: TLS related settings for connections to the upstream service.
-                    properties:
-                      caCertificates:
-                        format: string
-                        type: string
-                      clientCertificate:
-                        description: REQUIRED if mode is `MUTUAL`.
-                        format: string
-                        type: string
-                      credentialName:
-                        format: string
-                        type: string
-                      mode:
-                        enum:
-                        - DISABLE
-                        - SIMPLE
-                        - MUTUAL
-                        - ISTIO_MUTUAL
-                        type: string
-                      privateKey:
-                        description: REQUIRED if mode is `MUTUAL`.
-                        format: string
-                        type: string
-                      sni:
-                        description: SNI string to present to the server during TLS handshake.
-                        format: string
-                        type: string
-                      subjectAltNames:
-                        items:
-                          format: string
-                          type: string
-                        type: array
-                    type: object
-                type: object
-            type: object
-          status:
-            type: object
-            x-kubernetes-preserve-unknown-fields: true
-        type: object
+  - name: v1beta1
     served: true
     storage: false
-    subresources:
-      status: {}
 ---
-apiVersion: apiextensions.k8s.io/v1
+apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   annotations:
@@ -2462,7 +1419,7 @@ metadata:
   labels:
     app: istio-pilot
     chart: istio
-    cloudfoundry.org/istio_version: 1.7.3
+    cloudfoundry.org/istio_version: 1.8.4
     heritage: Tiller
     release: istio
   name: envoyfilters.networking.istio.io
@@ -2476,215 +1433,233 @@ spec:
     listKind: EnvoyFilterList
     plural: envoyfilters
     singular: envoyfilter
+  preserveUnknownFields: true
   scope: Namespaced
-  versions:
-  - name: v1alpha3
-    schema:
-      openAPIV3Schema:
-        properties:
-          spec:
-            description: 'Customizing Envoy configuration generated by Istio. See more details at: https://istio.io/docs/reference/config/networking/envoy-filter.html'
-            properties:
-              configPatches:
-                description: One or more patches with match conditions.
-                items:
-                  properties:
-                    applyTo:
-                      enum:
-                      - INVALID
-                      - LISTENER
-                      - FILTER_CHAIN
-                      - NETWORK_FILTER
-                      - HTTP_FILTER
-                      - ROUTE_CONFIGURATION
-                      - VIRTUAL_HOST
-                      - HTTP_ROUTE
-                      - CLUSTER
-                      type: string
-                    match:
-                      description: Match on listener/route configuration/cluster.
-                      oneOf:
-                      - not:
-                          anyOf:
-                          - required:
-                            - listener
-                          - required:
-                            - routeConfiguration
-                          - required:
-                            - cluster
-                      - required:
-                        - listener
-                      - required:
-                        - routeConfiguration
-                      - required:
-                        - cluster
-                      properties:
-                        cluster:
-                          description: Match on envoy cluster attributes.
-                          properties:
-                            name:
-                              description: The exact name of the cluster to match.
-                              format: string
-                              type: string
-                            portNumber:
-                              description: The service port for which this cluster was generated.
-                              type: integer
-                            service:
-                              description: The fully qualified service name for this cluster.
-                              format: string
-                              type: string
-                            subset:
-                              description: The subset associated with the service.
-                              format: string
-                              type: string
-                          type: object
-                        context:
-                          description: The specific config generation context to match on.
-                          enum:
-                          - ANY
-                          - SIDECAR_INBOUND
-                          - SIDECAR_OUTBOUND
-                          - GATEWAY
-                          type: string
-                        listener:
-                          description: Match on envoy listener attributes.
-                          properties:
-                            filterChain:
-                              description: Match a specific filter chain in a listener.
-                              properties:
-                                applicationProtocols:
-                                  description: Applies only to sidecars.
-                                  format: string
-                                  type: string
-                                filter:
-                                  description: The name of a specific filter to apply the patch to.
-                                  properties:
-                                    name:
-                                      description: The filter name to match on.
-                                      format: string
-                                      type: string
-                                    subFilter:
-                                      properties:
-                                        name:
-                                          description: The filter name to match on.
-                                          format: string
-                                          type: string
-                                      type: object
-                                  type: object
-                                name:
-                                  description: The name assigned to the filter chain.
-                                  format: string
-                                  type: string
-                                sni:
-                                  description: The SNI value used by a filter chain's match condition.
-                                  format: string
-                                  type: string
-                                transportProtocol:
-                                  description: Applies only to SIDECAR_INBOUND context.
-                                  format: string
-                                  type: string
-                              type: object
-                            name:
-                              description: Match a specific listener by its name.
-                              format: string
-                              type: string
-                            portName:
-                              format: string
-                              type: string
-                            portNumber:
-                              type: integer
-                          type: object
-                        proxy:
-                          description: Match on properties associated with a proxy.
-                          properties:
-                            metadata:
-                              additionalProperties:
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      properties:
+        spec:
+          description: 'Customizing Envoy configuration generated by Istio. See more
+            details at: https://istio.io/docs/reference/config/networking/envoy-filter.html'
+          properties:
+            configPatches:
+              description: One or more patches with match conditions.
+              items:
+                properties:
+                  applyTo:
+                    enum:
+                    - INVALID
+                    - LISTENER
+                    - FILTER_CHAIN
+                    - NETWORK_FILTER
+                    - HTTP_FILTER
+                    - ROUTE_CONFIGURATION
+                    - VIRTUAL_HOST
+                    - HTTP_ROUTE
+                    - CLUSTER
+                    - EXTENSION_CONFIG
+                    type: string
+                  match:
+                    description: Match on listener/route configuration/cluster.
+                    oneOf:
+                    - not:
+                        anyOf:
+                        - required:
+                          - listener
+                        - required:
+                          - routeConfiguration
+                        - required:
+                          - cluster
+                    - required:
+                      - listener
+                    - required:
+                      - routeConfiguration
+                    - required:
+                      - cluster
+                    properties:
+                      cluster:
+                        description: Match on envoy cluster attributes.
+                        properties:
+                          name:
+                            description: The exact name of the cluster to match.
+                            format: string
+                            type: string
+                          portNumber:
+                            description: The service port for which this cluster was
+                              generated.
+                            type: integer
+                          service:
+                            description: The fully qualified service name for this
+                              cluster.
+                            format: string
+                            type: string
+                          subset:
+                            description: The subset associated with the service.
+                            format: string
+                            type: string
+                        type: object
+                      context:
+                        description: The specific config generation context to match
+                          on.
+                        enum:
+                        - ANY
+                        - SIDECAR_INBOUND
+                        - SIDECAR_OUTBOUND
+                        - GATEWAY
+                        type: string
+                      listener:
+                        description: Match on envoy listener attributes.
+                        properties:
+                          filterChain:
+                            description: Match a specific filter chain in a listener.
+                            properties:
+                              applicationProtocols:
+                                description: Applies only to sidecars.
                                 format: string
                                 type: string
-                              type: object
-                            proxyVersion:
+                              filter:
+                                description: The name of a specific filter to apply
+                                  the patch to.
+                                properties:
+                                  name:
+                                    description: The filter name to match on.
+                                    format: string
+                                    type: string
+                                  subFilter:
+                                    properties:
+                                      name:
+                                        description: The filter name to match on.
+                                        format: string
+                                        type: string
+                                    type: object
+                                type: object
+                              name:
+                                description: The name assigned to the filter chain.
+                                format: string
+                                type: string
+                              sni:
+                                description: The SNI value used by a filter chain's
+                                  match condition.
+                                format: string
+                                type: string
+                              transportProtocol:
+                                description: Applies only to `SIDECAR_INBOUND` context.
+                                format: string
+                                type: string
+                            type: object
+                          name:
+                            description: Match a specific listener by its name.
+                            format: string
+                            type: string
+                          portName:
+                            format: string
+                            type: string
+                          portNumber:
+                            type: integer
+                        type: object
+                      proxy:
+                        description: Match on properties associated with a proxy.
+                        properties:
+                          metadata:
+                            additionalProperties:
                               format: string
                               type: string
-                          type: object
-                        routeConfiguration:
-                          description: Match on envoy HTTP route configuration attributes.
-                          properties:
-                            gateway:
-                              format: string
-                              type: string
-                            name:
-                              description: Route configuration name to match on.
-                              format: string
-                              type: string
-                            portName:
-                              description: Applicable only for GATEWAY context.
-                              format: string
-                              type: string
-                            portNumber:
-                              type: integer
-                            vhost:
-                              properties:
-                                name:
-                                  format: string
-                                  type: string
-                                route:
-                                  description: Match a specific route within the virtual host.
-                                  properties:
-                                    action:
-                                      description: Match a route with specific action type.
-                                      enum:
-                                      - ANY
-                                      - ROUTE
-                                      - REDIRECT
-                                      - DIRECT_RESPONSE
-                                      type: string
-                                    name:
-                                      format: string
-                                      type: string
-                                  type: object
-                              type: object
-                          type: object
-                      type: object
-                    patch:
-                      description: The patch to apply along with the operation.
-                      properties:
-                        operation:
-                          description: Determines how the patch should be applied.
-                          enum:
-                          - INVALID
-                          - MERGE
-                          - ADD
-                          - REMOVE
-                          - INSERT_BEFORE
-                          - INSERT_AFTER
-                          - INSERT_FIRST
-                          type: string
-                        value:
-                          description: The JSON config of the object being patched.
-                          type: object
-                          x-kubernetes-preserve-unknown-fields: true
-                      type: object
-                  type: object
-                type: array
-              workloadSelector:
-                properties:
-                  labels:
-                    additionalProperties:
-                      format: string
-                      type: string
+                            type: object
+                          proxyVersion:
+                            format: string
+                            type: string
+                        type: object
+                      routeConfiguration:
+                        description: Match on envoy HTTP route configuration attributes.
+                        properties:
+                          gateway:
+                            format: string
+                            type: string
+                          name:
+                            description: Route configuration name to match on.
+                            format: string
+                            type: string
+                          portName:
+                            description: Applicable only for GATEWAY context.
+                            format: string
+                            type: string
+                          portNumber:
+                            type: integer
+                          vhost:
+                            properties:
+                              name:
+                                format: string
+                                type: string
+                              route:
+                                description: Match a specific route within the virtual
+                                  host.
+                                properties:
+                                  action:
+                                    description: Match a route with specific action
+                                      type.
+                                    enum:
+                                    - ANY
+                                    - ROUTE
+                                    - REDIRECT
+                                    - DIRECT_RESPONSE
+                                    type: string
+                                  name:
+                                    format: string
+                                    type: string
+                                type: object
+                            type: object
+                        type: object
+                    type: object
+                  patch:
+                    description: The patch to apply along with the operation.
+                    properties:
+                      filterClass:
+                        description: Determines the filter insertion order.
+                        enum:
+                        - UNSPECIFIED
+                        - AUTHN
+                        - AUTHZ
+                        - STATS
+                        type: string
+                      operation:
+                        description: Determines how the patch should be applied.
+                        enum:
+                        - INVALID
+                        - MERGE
+                        - ADD
+                        - REMOVE
+                        - INSERT_BEFORE
+                        - INSERT_AFTER
+                        - INSERT_FIRST
+                        - REPLACE
+                        type: string
+                      value:
+                        description: The JSON config of the object being patched.
+                        type: object
                     type: object
                 type: object
-            type: object
-          status:
-            type: object
-            x-kubernetes-preserve-unknown-fields: true
-        type: object
+              type: array
+            workloadSelector:
+              properties:
+                labels:
+                  additionalProperties:
+                    format: string
+                    type: string
+                  type: object
+              type: object
+          type: object
+        status:
+          type: object
+          x-kubernetes-preserve-unknown-fields: true
+      type: object
+  versions:
+  - name: v1alpha3
     served: true
     storage: true
-    subresources:
-      status: {}
 ---
-apiVersion: apiextensions.k8s.io/v1
+apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   annotations:
@@ -2692,7 +1667,7 @@ metadata:
   labels:
     app: istio-pilot
     chart: istio
-    cloudfoundry.org/istio_version: 1.7.3
+    cloudfoundry.org/istio_version: 1.8.4
     heritage: Tiller
     release: istio
   name: gateways.networking.istio.io
@@ -2708,950 +1683,209 @@ spec:
     shortNames:
     - gw
     singular: gateway
+  preserveUnknownFields: false
   scope: Namespaced
-  versions:
-  - name: v1alpha3
-    schema:
-      openAPIV3Schema:
-        properties:
-          spec:
-            description: 'Configuration affecting edge load balancer. See more details at: https://istio.io/docs/reference/config/networking/gateway.html'
-            properties:
-              selector:
-                additionalProperties:
-                  format: string
-                  type: string
-                type: object
-              servers:
-                description: A list of server specifications.
-                items:
-                  properties:
-                    bind:
-                      format: string
-                      type: string
-                    defaultEndpoint:
-                      format: string
-                      type: string
-                    hosts:
-                      description: One or more hosts exposed by this gateway.
-                      items:
-                        format: string
-                        type: string
-                      type: array
-                    name:
-                      description: An optional name of the server, when set must be unique across all servers.
-                      format: string
-                      type: string
-                    port:
-                      properties:
-                        name:
-                          description: Label assigned to the port.
-                          format: string
-                          type: string
-                        number:
-                          description: A valid non-negative integer port number.
-                          type: integer
-                        protocol:
-                          description: The protocol exposed on the port.
-                          format: string
-                          type: string
-                        targetPort:
-                          type: integer
-                      type: object
-                    tls:
-                      description: Set of TLS related options that govern the server's behavior.
-                      properties:
-                        caCertificates:
-                          description: REQUIRED if mode is `MUTUAL`.
-                          format: string
-                          type: string
-                        cipherSuites:
-                          description: 'Optional: If specified, only support the specified cipher list.'
-                          items:
-                            format: string
-                            type: string
-                          type: array
-                        credentialName:
-                          format: string
-                          type: string
-                        httpsRedirect:
-                          type: boolean
-                        maxProtocolVersion:
-                          description: 'Optional: Maximum TLS protocol version.'
-                          enum:
-                          - TLS_AUTO
-                          - TLSV1_0
-                          - TLSV1_1
-                          - TLSV1_2
-                          - TLSV1_3
-                          type: string
-                        minProtocolVersion:
-                          description: 'Optional: Minimum TLS protocol version.'
-                          enum:
-                          - TLS_AUTO
-                          - TLSV1_0
-                          - TLSV1_1
-                          - TLSV1_2
-                          - TLSV1_3
-                          type: string
-                        mode:
-                          enum:
-                          - PASSTHROUGH
-                          - SIMPLE
-                          - MUTUAL
-                          - AUTO_PASSTHROUGH
-                          - ISTIO_MUTUAL
-                          type: string
-                        privateKey:
-                          description: REQUIRED if mode is `SIMPLE` or `MUTUAL`.
-                          format: string
-                          type: string
-                        serverCertificate:
-                          description: REQUIRED if mode is `SIMPLE` or `MUTUAL`.
-                          format: string
-                          type: string
-                        subjectAltNames:
-                          items:
-                            format: string
-                            type: string
-                          type: array
-                        verifyCertificateHash:
-                          items:
-                            format: string
-                            type: string
-                          type: array
-                        verifyCertificateSpki:
-                          items:
-                            format: string
-                            type: string
-                          type: array
-                      type: object
-                  type: object
-                type: array
-            type: object
-          status:
-            type: object
-            x-kubernetes-preserve-unknown-fields: true
-        type: object
-    served: true
-    storage: true
-    subresources:
-      status: {}
-  - name: v1beta1
-    schema:
-      openAPIV3Schema:
-        properties:
-          spec:
-            description: 'Configuration affecting edge load balancer. See more details at: https://istio.io/docs/reference/config/networking/gateway.html'
-            properties:
-              selector:
-                additionalProperties:
-                  format: string
-                  type: string
-                type: object
-              servers:
-                description: A list of server specifications.
-                items:
-                  properties:
-                    bind:
-                      format: string
-                      type: string
-                    defaultEndpoint:
-                      format: string
-                      type: string
-                    hosts:
-                      description: One or more hosts exposed by this gateway.
-                      items:
-                        format: string
-                        type: string
-                      type: array
-                    name:
-                      description: An optional name of the server, when set must be unique across all servers.
-                      format: string
-                      type: string
-                    port:
-                      properties:
-                        name:
-                          description: Label assigned to the port.
-                          format: string
-                          type: string
-                        number:
-                          description: A valid non-negative integer port number.
-                          type: integer
-                        protocol:
-                          description: The protocol exposed on the port.
-                          format: string
-                          type: string
-                        targetPort:
-                          type: integer
-                      type: object
-                    tls:
-                      description: Set of TLS related options that govern the server's behavior.
-                      properties:
-                        caCertificates:
-                          description: REQUIRED if mode is `MUTUAL`.
-                          format: string
-                          type: string
-                        cipherSuites:
-                          description: 'Optional: If specified, only support the specified cipher list.'
-                          items:
-                            format: string
-                            type: string
-                          type: array
-                        credentialName:
-                          format: string
-                          type: string
-                        httpsRedirect:
-                          type: boolean
-                        maxProtocolVersion:
-                          description: 'Optional: Maximum TLS protocol version.'
-                          enum:
-                          - TLS_AUTO
-                          - TLSV1_0
-                          - TLSV1_1
-                          - TLSV1_2
-                          - TLSV1_3
-                          type: string
-                        minProtocolVersion:
-                          description: 'Optional: Minimum TLS protocol version.'
-                          enum:
-                          - TLS_AUTO
-                          - TLSV1_0
-                          - TLSV1_1
-                          - TLSV1_2
-                          - TLSV1_3
-                          type: string
-                        mode:
-                          enum:
-                          - PASSTHROUGH
-                          - SIMPLE
-                          - MUTUAL
-                          - AUTO_PASSTHROUGH
-                          - ISTIO_MUTUAL
-                          type: string
-                        privateKey:
-                          description: REQUIRED if mode is `SIMPLE` or `MUTUAL`.
-                          format: string
-                          type: string
-                        serverCertificate:
-                          description: REQUIRED if mode is `SIMPLE` or `MUTUAL`.
-                          format: string
-                          type: string
-                        subjectAltNames:
-                          items:
-                            format: string
-                            type: string
-                          type: array
-                        verifyCertificateHash:
-                          items:
-                            format: string
-                            type: string
-                          type: array
-                        verifyCertificateSpki:
-                          items:
-                            format: string
-                            type: string
-                          type: array
-                      type: object
-                  type: object
-                type: array
-            type: object
-          status:
-            type: object
-            x-kubernetes-preserve-unknown-fields: true
-        type: object
-    served: true
-    storage: false
-    subresources:
-      status: {}
----
-apiVersion: apiextensions.k8s.io/v1
-kind: CustomResourceDefinition
-metadata:
-  annotations:
-    helm.sh/resource-policy: keep
-  labels:
-    app: mixer
-    chart: istio
-    cloudfoundry.org/istio_version: 1.7.3
-    heritage: Tiller
-    istio: mixer-handler
-    package: handler
-    release: istio
-  name: handlers.config.istio.io
-spec:
-  group: config.istio.io
-  names:
-    categories:
-    - istio-io
-    - policy-istio-io
-    kind: handler
-    listKind: handlerList
-    plural: handlers
-    singular: handler
-  scope: Namespaced
-  versions:
-  - name: v1alpha2
-    schema:
-      openAPIV3Schema:
-        properties:
-          spec:
-            description: Handler allows the operator to configure a specific adapter implementation.
-            properties:
-              adapter:
-                description: The name of a specific adapter implementation.
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      properties:
+        spec:
+          description: 'Configuration affecting edge load balancer. See more details
+            at: https://istio.io/docs/reference/config/networking/gateway.html'
+          properties:
+            selector:
+              additionalProperties:
                 format: string
                 type: string
-              compiledAdapter:
-                description: The name of the compiled in adapter this handler instantiates.
-                format: string
-                type: string
-              connection:
-                description: Information on how to connect to the out-of-process adapter.
+              type: object
+            servers:
+              description: A list of server specifications.
+              items:
                 properties:
-                  address:
-                    description: The address of the backend.
+                  bind:
                     format: string
                     type: string
-                  authentication:
-                    description: Auth config for the connection to the backend.
-                    oneOf:
-                    - not:
-                        anyOf:
-                        - properties:
-                            tls:
-                              allOf:
-                              - oneOf:
-                                - not:
-                                    anyOf:
-                                    - required:
-                                      - tokenPath
-                                    - required:
-                                      - oauth
-                                - required:
-                                  - tokenPath
-                                - required:
-                                  - oauth
-                              - oneOf:
-                                - not:
-                                    anyOf:
-                                    - required:
-                                      - authHeader
-                                    - required:
-                                      - customHeader
-                                - required:
-                                  - authHeader
-                                - required:
-                                  - customHeader
-                          required:
-                          - tls
-                        - required:
-                          - mutual
-                    - properties:
-                        tls:
-                          allOf:
-                          - oneOf:
-                            - not:
-                                anyOf:
-                                - required:
-                                  - tokenPath
-                                - required:
-                                  - oauth
-                            - required:
-                              - tokenPath
-                            - required:
-                              - oauth
-                          - oneOf:
-                            - not:
-                                anyOf:
-                                - required:
-                                  - authHeader
-                                - required:
-                                  - customHeader
-                            - required:
-                              - authHeader
-                            - required:
-                              - customHeader
-                      required:
-                      - tls
-                    - required:
-                      - mutual
-                    properties:
-                      mutual:
-                        properties:
-                          caCertificates:
-                            format: string
-                            type: string
-                          clientCertificate:
-                            description: The path to the file holding client certificate for mutual TLS.
-                            format: string
-                            type: string
-                          privateKey:
-                            description: The path to the file holding the private key for mutual TLS.
-                            format: string
-                            type: string
-                          serverName:
-                            description: Used to configure mixer mutual TLS client to supply server name for SNI.
-                            format: string
-                            type: string
-                        type: object
-                      tls:
-                        properties:
-                          authHeader:
-                            description: Access token is passed as authorization header.
-                            enum:
-                            - PLAIN
-                            - BEARER
-                            type: string
-                          caCertificates:
-                            format: string
-                            type: string
-                          customHeader:
-                            description: Customized header key to hold access token, e.g.
-                            format: string
-                            type: string
-                          oauth:
-                            description: Oauth config to fetch access token from auth provider.
-                            properties:
-                              clientId:
-                                description: OAuth client id for mixer.
-                                format: string
-                                type: string
-                              clientSecret:
-                                description: The path to the file holding the client secret for oauth.
-                                format: string
-                                type: string
-                              endpointParams:
-                                additionalProperties:
-                                  format: string
-                                  type: string
-                                description: Additional parameters for requests to the token endpoint.
-                                type: object
-                              scopes:
-                                description: List of requested permissions.
-                                items:
-                                  format: string
-                                  type: string
-                                type: array
-                              tokenUrl:
-                                description: The Resource server's token endpoint URL.
-                                format: string
-                                type: string
-                            type: object
-                          serverName:
-                            format: string
-                            type: string
-                          tokenPath:
-                            format: string
-                            type: string
-                        type: object
-                    type: object
-                  timeout:
-                    description: Timeout for remote calls to the backend.
+                  defaultEndpoint:
+                    format: string
                     type: string
-                type: object
-              name:
-                description: Must be unique in the entire Mixer configuration.
-                format: string
-                type: string
-              params:
-                description: Depends on adapter implementation.
-                type: object
-                x-kubernetes-preserve-unknown-fields: true
-            type: object
-          status:
-            type: object
-            x-kubernetes-preserve-unknown-fields: true
-        type: object
-    served: true
-    storage: true
-    subresources:
-      status: {}
----
-apiVersion: apiextensions.k8s.io/v1
-kind: CustomResourceDefinition
-metadata:
-  annotations:
-    helm.sh/resource-policy: keep
-  labels:
-    app: istio-mixer
-    chart: istio
-    cloudfoundry.org/istio_version: 1.7.3
-    heritage: Tiller
-    release: istio
-  name: httpapispecbindings.config.istio.io
-spec:
-  group: config.istio.io
-  names:
-    categories:
-    - istio-io
-    - apim-istio-io
-    kind: HTTPAPISpecBinding
-    listKind: HTTPAPISpecBindingList
-    plural: httpapispecbindings
-    singular: httpapispecbinding
-  scope: Namespaced
-  versions:
-  - name: v1alpha2
-    schema:
-      openAPIV3Schema:
-        properties:
-          spec:
-            properties:
-              api_specs:
-                items:
-                  properties:
-                    name:
-                      description: The short name of the HTTPAPISpec.
+                  hosts:
+                    description: One or more hosts exposed by this gateway.
+                    items:
                       format: string
                       type: string
-                    namespace:
-                      description: Optional namespace of the HTTPAPISpec.
-                      format: string
-                      type: string
-                  type: object
-                type: array
-              apiSpecs:
-                items:
-                  properties:
-                    name:
-                      description: The short name of the HTTPAPISpec.
-                      format: string
-                      type: string
-                    namespace:
-                      description: Optional namespace of the HTTPAPISpec.
-                      format: string
-                      type: string
-                  type: object
-                type: array
-              services:
-                description: One or more services to map the listed HTTPAPISpec onto.
-                items:
-                  properties:
-                    domain:
-                      description: Domain suffix used to construct the service FQDN in implementations that support such specification.
-                      format: string
-                      type: string
-                    labels:
-                      additionalProperties:
+                    type: array
+                  name:
+                    description: An optional name of the server, when set must be
+                      unique across all servers.
+                    format: string
+                    type: string
+                  port:
+                    properties:
+                      name:
+                        description: Label assigned to the port.
                         format: string
                         type: string
-                      description: Optional one or more labels that uniquely identify the service version.
-                      type: object
-                    name:
-                      description: The short name of the service such as "foo".
-                      format: string
-                      type: string
-                    namespace:
-                      description: Optional namespace of the service.
-                      format: string
-                      type: string
-                    service:
-                      description: The service FQDN.
-                      format: string
-                      type: string
-                  type: object
-                type: array
-            type: object
-          status:
-            type: object
-            x-kubernetes-preserve-unknown-fields: true
-        type: object
-    served: true
-    storage: true
-    subresources:
-      status: {}
----
-apiVersion: apiextensions.k8s.io/v1
-kind: CustomResourceDefinition
-metadata:
-  annotations:
-    helm.sh/resource-policy: keep
-  labels:
-    app: istio-mixer
-    chart: istio
-    cloudfoundry.org/istio_version: 1.7.3
-    heritage: Tiller
-    release: istio
-  name: httpapispecs.config.istio.io
-spec:
-  group: config.istio.io
-  names:
-    categories:
-    - istio-io
-    - apim-istio-io
-    kind: HTTPAPISpec
-    listKind: HTTPAPISpecList
-    plural: httpapispecs
-    singular: httpapispec
-  scope: Namespaced
-  versions:
-  - name: v1alpha2
-    schema:
-      openAPIV3Schema:
-        properties:
-          spec:
-            properties:
-              api_keys:
-                items:
-                  oneOf:
-                  - not:
-                      anyOf:
-                      - required:
-                        - query
-                      - required:
-                        - header
-                      - required:
-                        - cookie
-                  - required:
-                    - query
-                  - required:
-                    - header
-                  - required:
-                    - cookie
-                  properties:
-                    cookie:
-                      format: string
-                      type: string
-                    header:
-                      description: API key is sent in a request header.
-                      format: string
-                      type: string
-                    query:
-                      description: API Key is sent as a query parameter.
-                      format: string
-                      type: string
-                  type: object
-                type: array
-              apiKeys:
-                items:
-                  oneOf:
-                  - not:
-                      anyOf:
-                      - required:
-                        - query
-                      - required:
-                        - header
-                      - required:
-                        - cookie
-                  - required:
-                    - query
-                  - required:
-                    - header
-                  - required:
-                    - cookie
-                  properties:
-                    cookie:
-                      format: string
-                      type: string
-                    header:
-                      description: API key is sent in a request header.
-                      format: string
-                      type: string
-                    query:
-                      description: API Key is sent as a query parameter.
-                      format: string
-                      type: string
-                  type: object
-                type: array
-              attributes:
-                properties:
-                  attributes:
-                    additionalProperties:
-                      oneOf:
-                      - not:
-                          anyOf:
-                          - required:
-                            - stringValue
-                          - required:
-                            - int64Value
-                          - required:
-                            - doubleValue
-                          - required:
-                            - boolValue
-                          - required:
-                            - bytesValue
-                          - required:
-                            - timestampValue
-                          - required:
-                            - durationValue
-                          - required:
-                            - stringMapValue
-                      - required:
-                        - stringValue
-                      - required:
-                        - int64Value
-                      - required:
-                        - doubleValue
-                      - required:
-                        - boolValue
-                      - required:
-                        - bytesValue
-                      - required:
-                        - timestampValue
-                      - required:
-                        - durationValue
-                      - required:
-                        - stringMapValue
-                      properties:
-                        boolValue:
-                          type: boolean
-                        bytesValue:
-                          format: binary
-                          type: string
-                        doubleValue:
-                          format: double
-                          type: number
-                        durationValue:
-                          type: string
-                        int64Value:
-                          format: int64
-                          type: integer
-                        stringMapValue:
-                          properties:
-                            entries:
-                              additionalProperties:
-                                format: string
-                                type: string
-                              description: Holds a set of name/value pairs.
-                              type: object
-                          type: object
-                        stringValue:
+                      number:
+                        description: A valid non-negative integer port number.
+                        type: integer
+                      protocol:
+                        description: The protocol exposed on the port.
+                        format: string
+                        type: string
+                      targetPort:
+                        type: integer
+                    type: object
+                  tls:
+                    description: Set of TLS related options that govern the server's
+                      behavior.
+                    properties:
+                      caCertificates:
+                        description: REQUIRED if mode is `MUTUAL`.
+                        format: string
+                        type: string
+                      cipherSuites:
+                        description: 'Optional: If specified, only support the specified
+                          cipher list.'
+                        items:
                           format: string
                           type: string
-                        timestampValue:
-                          format: dateTime
+                        type: array
+                      credentialName:
+                        format: string
+                        type: string
+                      httpsRedirect:
+                        type: boolean
+                      maxProtocolVersion:
+                        description: 'Optional: Maximum TLS protocol version.'
+                        enum:
+                        - TLS_AUTO
+                        - TLSV1_0
+                        - TLSV1_1
+                        - TLSV1_2
+                        - TLSV1_3
+                        type: string
+                      minProtocolVersion:
+                        description: 'Optional: Minimum TLS protocol version.'
+                        enum:
+                        - TLS_AUTO
+                        - TLSV1_0
+                        - TLSV1_1
+                        - TLSV1_2
+                        - TLSV1_3
+                        type: string
+                      mode:
+                        enum:
+                        - PASSTHROUGH
+                        - SIMPLE
+                        - MUTUAL
+                        - AUTO_PASSTHROUGH
+                        - ISTIO_MUTUAL
+                        type: string
+                      privateKey:
+                        description: REQUIRED if mode is `SIMPLE` or `MUTUAL`.
+                        format: string
+                        type: string
+                      serverCertificate:
+                        description: REQUIRED if mode is `SIMPLE` or `MUTUAL`.
+                        format: string
+                        type: string
+                      subjectAltNames:
+                        items:
+                          format: string
                           type: string
-                      type: object
-                    description: A map of attribute name to its value.
+                        type: array
+                      verifyCertificateHash:
+                        items:
+                          format: string
+                          type: string
+                        type: array
+                      verifyCertificateSpki:
+                        items:
+                          format: string
+                          type: string
+                        type: array
                     type: object
                 type: object
-              patterns:
-                description: List of HTTP patterns to match.
-                items:
-                  oneOf:
-                  - not:
-                      anyOf:
-                      - required:
-                        - uriTemplate
-                      - required:
-                        - regex
-                  - required:
-                    - uriTemplate
-                  - required:
-                    - regex
-                  properties:
-                    attributes:
-                      properties:
-                        attributes:
-                          additionalProperties:
-                            oneOf:
-                            - not:
-                                anyOf:
-                                - required:
-                                  - stringValue
-                                - required:
-                                  - int64Value
-                                - required:
-                                  - doubleValue
-                                - required:
-                                  - boolValue
-                                - required:
-                                  - bytesValue
-                                - required:
-                                  - timestampValue
-                                - required:
-                                  - durationValue
-                                - required:
-                                  - stringMapValue
-                            - required:
-                              - stringValue
-                            - required:
-                              - int64Value
-                            - required:
-                              - doubleValue
-                            - required:
-                              - boolValue
-                            - required:
-                              - bytesValue
-                            - required:
-                              - timestampValue
-                            - required:
-                              - durationValue
-                            - required:
-                              - stringMapValue
-                            properties:
-                              boolValue:
-                                type: boolean
-                              bytesValue:
-                                format: binary
-                                type: string
-                              doubleValue:
-                                format: double
-                                type: number
-                              durationValue:
-                                type: string
-                              int64Value:
-                                format: int64
-                                type: integer
-                              stringMapValue:
-                                properties:
-                                  entries:
-                                    additionalProperties:
-                                      format: string
-                                      type: string
-                                    description: Holds a set of name/value pairs.
-                                    type: object
-                                type: object
-                              stringValue:
-                                format: string
-                                type: string
-                              timestampValue:
-                                format: dateTime
-                                type: string
-                            type: object
-                          description: A map of attribute name to its value.
-                          type: object
-                      type: object
-                    httpMethod:
-                      format: string
-                      type: string
-                    regex:
-                      format: string
-                      type: string
-                    uriTemplate:
-                      format: string
-                      type: string
-                  type: object
-                type: array
-            type: object
-          status:
-            type: object
-            x-kubernetes-preserve-unknown-fields: true
-        type: object
-    served: true
-    storage: true
-    subresources:
-      status: {}
----
-apiVersion: apiextensions.k8s.io/v1
-kind: CustomResourceDefinition
-metadata:
-  annotations:
-    helm.sh/resource-policy: keep
-  labels:
-    app: mixer
-    chart: istio
-    cloudfoundry.org/istio_version: 1.7.3
-    heritage: Tiller
-    istio: mixer-instance
-    package: instance
-    release: istio
-  name: instances.config.istio.io
-spec:
-  group: config.istio.io
-  names:
-    categories:
-    - istio-io
-    - policy-istio-io
-    kind: instance
-    listKind: instanceList
-    plural: instances
-    singular: instance
-  scope: Namespaced
+              type: array
+          type: object
+        status:
+          type: object
+          x-kubernetes-preserve-unknown-fields: true
+      type: object
   versions:
-  - name: v1alpha2
-    schema:
-      openAPIV3Schema:
-        properties:
-          spec:
-            description: An Instance tells Mixer how to create instances for particular template.
-            properties:
-              attributeBindings:
-                additionalProperties:
-                  format: string
-                  type: string
-                type: object
-              compiledTemplate:
-                description: The name of the compiled in template this instance creates instances for.
-                format: string
-                type: string
-              name:
-                format: string
-                type: string
-              params:
-                description: Depends on referenced template.
-                type: object
-                x-kubernetes-preserve-unknown-fields: true
-              template:
-                description: The name of the template this instance creates instances for.
-                format: string
-                type: string
-            type: object
-          status:
-            type: object
-            x-kubernetes-preserve-unknown-fields: true
-        type: object
+  - name: v1alpha3
     served: true
     storage: true
-    subresources:
-      status: {}
+  - name: v1beta1
+    served: true
+    storage: false
 ---
-apiVersion: apiextensions.k8s.io/v1
+apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   labels:
-    cloudfoundry.org/istio_version: 1.7.3
+    cloudfoundry.org/istio_version: 1.8.4
     release: istio
   name: istiooperators.install.istio.io
 spec:
+  additionalPrinterColumns:
+  - JSONPath: .spec.revision
+    description: Istio control plane revision
+    name: Revision
+    type: string
+  - JSONPath: .status.status
+    description: IOP current state
+    name: Status
+    type: string
+  - JSONPath: .metadata.creationTimestamp
+    description: 'CreationTimestamp is a timestamp representing the server time when
+      this object was created. It is not guaranteed to be set in happens-before order
+      across separate operations. Clients may not set this value. It is represented
+      in RFC3339 form and is in UTC. Populated by the system. Read-only. Null for
+      lists. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata'
+    name: Age
+    type: date
   group: install.istio.io
   names:
     kind: IstioOperator
     plural: istiooperators
     shortNames:
     - iop
+    - io
     singular: istiooperator
   scope: Namespaced
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        spec:
+          description: 'Specification of the desired state of the istio control plane
+            resource. More info: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#spec-and-status'
+          type: object
+        status:
+          description: 'Status describes each of istio control plane component status
+            at the current time. 0 means NONE, 1 means UPDATING, 2 means HEALTHY,
+            3 means ERROR, 4 means RECONCILING. More info: https://github.com/istio/api/blob/master/operator/v1alpha1/istio.operator.v1alpha1.pb.html
+            & https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#spec-and-status'
+          type: object
   versions:
-  - additionalPrinterColumns:
-    - description: Istio control plane revision
-      jsonPath: .spec.revision
-      name: Revision
-      type: string
-    - description: IOP current state
-      jsonPath: .status.status
-      name: Status
-      type: string
-    - description: 'CreationTimestamp is a timestamp representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations. Clients may not set this value. It is represented in RFC3339 form and is in UTC. Populated by the system. Read-only. Null for lists. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata'
-      jsonPath: .metadata.creationTimestamp
-      name: Age
-      type: date
-    name: v1alpha1
-    schema:
-      openAPIV3Schema:
-        properties:
-          apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#resources'
-            type: string
-          kind:
-            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-            type: string
-          spec:
-            description: 'Specification of the desired state of the istio control plane resource. More info: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#spec-and-status'
-            type: object
-            x-kubernetes-preserve-unknown-fields: true
-          status:
-            description: 'Status describes each of istio control plane component status at the current time. 0 means NONE, 1 means UPDATING, 2 means HEALTHY, 3 means ERROR, 4 means RECONCILING. More info: https://github.com/istio/api/blob/master/operator/v1alpha1/istio.operator.v1alpha1.pb.html & https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#spec-and-status'
-            type: object
-            x-kubernetes-preserve-unknown-fields: true
-        type: object
+  - name: v1alpha1
     served: true
     storage: true
-    subresources:
-      status: {}
 ---
-apiVersion: apiextensions.k8s.io/v1
+apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   annotations:
@@ -3659,7 +1893,7 @@ metadata:
   labels:
     app: istio-pilot
     chart: istio
-    cloudfoundry.org/istio_version: 1.7.3
+    cloudfoundry.org/istio_version: 1.8.4
     heritage: Tiller
     istio: security
     release: istio
@@ -3676,17 +1910,31 @@ spec:
     shortNames:
     - pa
     singular: peerauthentication
+  preserveUnknownFields: false
   scope: Namespaced
-  versions:
-  - name: v1beta1
-    schema:
-      openAPIV3Schema:
-        properties:
-          spec:
-            description: PeerAuthentication defines how traffic will be tunneled (or not) to the sidecar.
-            properties:
-              mtls:
-                description: Mutual TLS settings for workload.
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      properties:
+        spec:
+          description: PeerAuthentication defines how traffic will be tunneled (or
+            not) to the sidecar.
+          properties:
+            mtls:
+              description: Mutual TLS settings for workload.
+              properties:
+                mode:
+                  description: Defines the mTLS mode used for peer authentication.
+                  enum:
+                  - UNSET
+                  - DISABLE
+                  - PERMISSIVE
+                  - STRICT
+                  type: string
+              type: object
+            portLevelMtls:
+              additionalProperties:
                 properties:
                   mode:
                     description: Defines the mTLS mode used for peer authentication.
@@ -3697,217 +1945,29 @@ spec:
                     - STRICT
                     type: string
                 type: object
-              portLevelMtls:
-                additionalProperties:
-                  properties:
-                    mode:
-                      description: Defines the mTLS mode used for peer authentication.
-                      enum:
-                      - UNSET
-                      - DISABLE
-                      - PERMISSIVE
-                      - STRICT
-                      type: string
+              description: Port specific mutual TLS settings.
+              type: object
+            selector:
+              description: The selector determines the workloads to apply the ChannelAuthentication
+                on.
+              properties:
+                matchLabels:
+                  additionalProperties:
+                    format: string
+                    type: string
                   type: object
-                description: Port specific mutual TLS settings.
-                type: object
-              selector:
-                description: The selector determines the workloads to apply the ChannelAuthentication on.
-                properties:
-                  matchLabels:
-                    additionalProperties:
-                      format: string
-                      type: string
-                    type: object
-                type: object
-            type: object
-          status:
-            type: object
-            x-kubernetes-preserve-unknown-fields: true
-        type: object
-    served: true
-    storage: true
-    subresources:
-      status: {}
----
-apiVersion: apiextensions.k8s.io/v1
-kind: CustomResourceDefinition
-metadata:
-  annotations:
-    helm.sh/resource-policy: keep
-  labels:
-    app: istio-mixer
-    chart: istio
-    cloudfoundry.org/istio_version: 1.7.3
-    heritage: Tiller
-    release: istio
-  name: quotaspecbindings.config.istio.io
-spec:
-  group: config.istio.io
-  names:
-    categories:
-    - istio-io
-    - apim-istio-io
-    kind: QuotaSpecBinding
-    listKind: QuotaSpecBindingList
-    plural: quotaspecbindings
-    singular: quotaspecbinding
-  scope: Namespaced
+              type: object
+          type: object
+        status:
+          type: object
+          x-kubernetes-preserve-unknown-fields: true
+      type: object
   versions:
-  - name: v1alpha2
-    schema:
-      openAPIV3Schema:
-        properties:
-          spec:
-            properties:
-              quotaSpecs:
-                items:
-                  properties:
-                    name:
-                      description: The short name of the QuotaSpec.
-                      format: string
-                      type: string
-                    namespace:
-                      description: Optional namespace of the QuotaSpec.
-                      format: string
-                      type: string
-                  type: object
-                type: array
-              services:
-                description: One or more services to map the listed QuotaSpec onto.
-                items:
-                  properties:
-                    domain:
-                      description: Domain suffix used to construct the service FQDN in implementations that support such specification.
-                      format: string
-                      type: string
-                    labels:
-                      additionalProperties:
-                        format: string
-                        type: string
-                      description: Optional one or more labels that uniquely identify the service version.
-                      type: object
-                    name:
-                      description: The short name of the service such as "foo".
-                      format: string
-                      type: string
-                    namespace:
-                      description: Optional namespace of the service.
-                      format: string
-                      type: string
-                    service:
-                      description: The service FQDN.
-                      format: string
-                      type: string
-                  type: object
-                type: array
-            type: object
-          status:
-            type: object
-            x-kubernetes-preserve-unknown-fields: true
-        type: object
+  - name: v1beta1
     served: true
     storage: true
-    subresources:
-      status: {}
 ---
-apiVersion: apiextensions.k8s.io/v1
-kind: CustomResourceDefinition
-metadata:
-  annotations:
-    helm.sh/resource-policy: keep
-  labels:
-    app: istio-mixer
-    chart: istio
-    cloudfoundry.org/istio_version: 1.7.3
-    heritage: Tiller
-    release: istio
-  name: quotaspecs.config.istio.io
-spec:
-  group: config.istio.io
-  names:
-    categories:
-    - istio-io
-    - apim-istio-io
-    kind: QuotaSpec
-    listKind: QuotaSpecList
-    plural: quotaspecs
-    singular: quotaspec
-  scope: Namespaced
-  versions:
-  - name: v1alpha2
-    schema:
-      openAPIV3Schema:
-        properties:
-          spec:
-            description: Determines the quotas used for individual requests.
-            properties:
-              rules:
-                description: A list of Quota rules.
-                items:
-                  properties:
-                    match:
-                      description: If empty, match all request.
-                      items:
-                        properties:
-                          clause:
-                            additionalProperties:
-                              oneOf:
-                              - not:
-                                  anyOf:
-                                  - required:
-                                    - exact
-                                  - required:
-                                    - prefix
-                                  - required:
-                                    - regex
-                              - required:
-                                - exact
-                              - required:
-                                - prefix
-                              - required:
-                                - regex
-                              properties:
-                                exact:
-                                  format: string
-                                  type: string
-                                prefix:
-                                  format: string
-                                  type: string
-                                regex:
-                                  description: RE2 style regex-based match (https://github.com/google/re2/wiki/Syntax).
-                                  format: string
-                                  type: string
-                              type: object
-                            description: Map of attribute names to StringMatch type.
-                            type: object
-                        type: object
-                      type: array
-                    quotas:
-                      description: The list of quotas to charge.
-                      items:
-                        properties:
-                          charge:
-                            format: int32
-                            type: integer
-                          quota:
-                            format: string
-                            type: string
-                        type: object
-                      type: array
-                  type: object
-                type: array
-            type: object
-          status:
-            type: object
-            x-kubernetes-preserve-unknown-fields: true
-        type: object
-    served: true
-    storage: true
-    subresources:
-      status: {}
----
-apiVersion: apiextensions.k8s.io/v1
+apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   annotations:
@@ -3915,7 +1975,7 @@ metadata:
   labels:
     app: istio-pilot
     chart: istio
-    cloudfoundry.org/istio_version: 1.7.3
+    cloudfoundry.org/istio_version: 1.8.4
     heritage: Tiller
     istio: security
     release: istio
@@ -3932,237 +1992,93 @@ spec:
     shortNames:
     - ra
     singular: requestauthentication
+  preserveUnknownFields: false
   scope: Namespaced
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      properties:
+        spec:
+          description: RequestAuthentication defines what request authentication methods
+            are supported by a workload.
+          properties:
+            jwtRules:
+              description: Define the list of JWTs that can be validated at the selected
+                workloads' proxy.
+              items:
+                properties:
+                  audiences:
+                    items:
+                      format: string
+                      type: string
+                    type: array
+                  forwardOriginalToken:
+                    description: If set to true, the orginal token will be kept for
+                      the ustream request.
+                    type: boolean
+                  fromHeaders:
+                    description: List of header locations from which JWT is expected.
+                    items:
+                      properties:
+                        name:
+                          description: The HTTP header name.
+                          format: string
+                          type: string
+                        prefix:
+                          description: The prefix that should be stripped before decoding
+                            the token.
+                          format: string
+                          type: string
+                      type: object
+                    type: array
+                  fromParams:
+                    description: List of query parameters from which JWT is expected.
+                    items:
+                      format: string
+                      type: string
+                    type: array
+                  issuer:
+                    description: Identifies the issuer that issued the JWT.
+                    format: string
+                    type: string
+                  jwks:
+                    description: JSON Web Key Set of public keys to validate signature
+                      of the JWT.
+                    format: string
+                    type: string
+                  jwks_uri:
+                    format: string
+                    type: string
+                  jwksUri:
+                    format: string
+                    type: string
+                  outputPayloadToHeader:
+                    format: string
+                    type: string
+                type: object
+              type: array
+            selector:
+              description: The selector determines the workloads to apply the RequestAuthentication
+                on.
+              properties:
+                matchLabels:
+                  additionalProperties:
+                    format: string
+                    type: string
+                  type: object
+              type: object
+          type: object
+        status:
+          type: object
+          x-kubernetes-preserve-unknown-fields: true
+      type: object
   versions:
   - name: v1beta1
-    schema:
-      openAPIV3Schema:
-        properties:
-          spec:
-            description: RequestAuthentication defines what request authentication methods are supported by a workload.
-            properties:
-              jwtRules:
-                description: Define the list of JWTs that can be validated at the selected workloads' proxy.
-                items:
-                  properties:
-                    audiences:
-                      items:
-                        format: string
-                        type: string
-                      type: array
-                    forwardOriginalToken:
-                      description: If set to true, the orginal token will be kept for the ustream request.
-                      type: boolean
-                    fromHeaders:
-                      description: List of header locations from which JWT is expected.
-                      items:
-                        properties:
-                          name:
-                            description: The HTTP header name.
-                            format: string
-                            type: string
-                          prefix:
-                            description: The prefix that should be stripped before decoding the token.
-                            format: string
-                            type: string
-                        type: object
-                      type: array
-                    fromParams:
-                      description: List of query parameters from which JWT is expected.
-                      items:
-                        format: string
-                        type: string
-                      type: array
-                    issuer:
-                      description: Identifies the issuer that issued the JWT.
-                      format: string
-                      type: string
-                    jwks:
-                      description: JSON Web Key Set of public keys to validate signature of the JWT.
-                      format: string
-                      type: string
-                    jwks_uri:
-                      format: string
-                      type: string
-                    jwksUri:
-                      format: string
-                      type: string
-                    outputPayloadToHeader:
-                      format: string
-                      type: string
-                  type: object
-                type: array
-              selector:
-                description: The selector determines the workloads to apply the RequestAuthentication on.
-                properties:
-                  matchLabels:
-                    additionalProperties:
-                      format: string
-                      type: string
-                    type: object
-                type: object
-            type: object
-          status:
-            type: object
-            x-kubernetes-preserve-unknown-fields: true
-        type: object
     served: true
     storage: true
-    subresources:
-      status: {}
 ---
-apiVersion: apiextensions.k8s.io/v1
-kind: CustomResourceDefinition
-metadata:
-  annotations:
-    helm.sh/resource-policy: keep
-  labels:
-    app: mixer
-    chart: istio
-    cloudfoundry.org/istio_version: 1.7.3
-    heritage: Tiller
-    istio: core
-    package: istio.io.mixer
-    release: istio
-  name: rules.config.istio.io
-spec:
-  group: config.istio.io
-  names:
-    categories:
-    - istio-io
-    - policy-istio-io
-    kind: rule
-    listKind: ruleList
-    plural: rules
-    singular: rule
-  scope: Namespaced
-  versions:
-  - name: v1alpha2
-    schema:
-      openAPIV3Schema:
-        properties:
-          spec:
-            description: 'Describes the rules used to configure Mixer''s policy and telemetry features. See more details at: https://istio.io/docs/reference/config/policy-and-telemetry/istio.policy.v1beta1.html'
-            properties:
-              actions:
-                description: The actions that will be executed when match evaluates to `true`.
-                items:
-                  properties:
-                    handler:
-                      description: Fully qualified name of the handler to invoke.
-                      format: string
-                      type: string
-                    instances:
-                      items:
-                        format: string
-                        type: string
-                      type: array
-                    name:
-                      description: A handle to refer to the results of the action.
-                      format: string
-                      type: string
-                  type: object
-                type: array
-              match:
-                description: Match is an attribute based predicate.
-                format: string
-                type: string
-              requestHeaderOperations:
-                items:
-                  properties:
-                    name:
-                      description: Header name literal value.
-                      format: string
-                      type: string
-                    operation:
-                      description: Header operation type.
-                      enum:
-                      - REPLACE
-                      - REMOVE
-                      - APPEND
-                      type: string
-                    values:
-                      description: Header value expressions.
-                      items:
-                        format: string
-                        type: string
-                      type: array
-                  type: object
-                type: array
-              responseHeaderOperations:
-                items:
-                  properties:
-                    name:
-                      description: Header name literal value.
-                      format: string
-                      type: string
-                    operation:
-                      description: Header operation type.
-                      enum:
-                      - REPLACE
-                      - REMOVE
-                      - APPEND
-                      type: string
-                    values:
-                      description: Header value expressions.
-                      items:
-                        format: string
-                        type: string
-                      type: array
-                  type: object
-                type: array
-              sampling:
-                properties:
-                  random:
-                    description: Provides filtering of actions based on random selection per request.
-                    properties:
-                      attributeExpression:
-                        description: Specifies an attribute expression to use to override the numerator in the `percent_sampled` field.
-                        format: string
-                        type: string
-                      percentSampled:
-                        description: The default sampling rate, expressed as a percentage.
-                        properties:
-                          denominator:
-                            description: Specifies the denominator.
-                            enum:
-                            - HUNDRED
-                            - TEN_THOUSAND
-                            type: string
-                          numerator:
-                            description: Specifies the numerator.
-                            type: integer
-                        type: object
-                      useIndependentRandomness:
-                        description: By default sampling will be based on the value of the request header `x-request-id`.
-                        type: boolean
-                    type: object
-                  rateLimit:
-                    properties:
-                      maxUnsampledEntries:
-                        description: Number of entries to allow during the `sampling_duration` before sampling is enforced.
-                        format: int64
-                        type: integer
-                      samplingDuration:
-                        description: Window in which to enforce the sampling rate.
-                        type: string
-                      samplingRate:
-                        description: The rate at which to sample entries once the unsampled limit has been reached.
-                        format: int64
-                        type: integer
-                    type: object
-                type: object
-            type: object
-          status:
-            type: object
-            x-kubernetes-preserve-unknown-fields: true
-        type: object
-    served: true
-    storage: true
-    subresources:
-      status: {}
----
-apiVersion: apiextensions.k8s.io/v1
+apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   annotations:
@@ -4170,11 +2086,33 @@ metadata:
   labels:
     app: istio-pilot
     chart: istio
-    cloudfoundry.org/istio_version: 1.7.3
+    cloudfoundry.org/istio_version: 1.8.4
     heritage: Tiller
     release: istio
   name: serviceentries.networking.istio.io
 spec:
+  additionalPrinterColumns:
+  - JSONPath: .spec.hosts
+    description: The hosts associated with the ServiceEntry
+    name: Hosts
+    type: string
+  - JSONPath: .spec.location
+    description: Whether the service is external to the mesh or part of the mesh (MESH_EXTERNAL
+      or MESH_INTERNAL)
+    name: Location
+    type: string
+  - JSONPath: .spec.resolution
+    description: Service discovery mode for the hosts (NONE, STATIC, or DNS)
+    name: Resolution
+    type: string
+  - JSONPath: .metadata.creationTimestamp
+    description: 'CreationTimestamp is a timestamp representing the server time when
+      this object was created. It is not guaranteed to be set in happens-before order
+      across separate operations. Clients may not set this value. It is represented
+      in RFC3339 form and is in UTC. Populated by the system. Read-only. Null for
+      lists. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata'
+    name: Age
+    type: date
   group: networking.istio.io
   names:
     categories:
@@ -4186,268 +2124,127 @@ spec:
     shortNames:
     - se
     singular: serviceentry
+  preserveUnknownFields: false
   scope: Namespaced
-  versions:
-  - additionalPrinterColumns:
-    - description: The hosts associated with the ServiceEntry
-      jsonPath: .spec.hosts
-      name: Hosts
-      type: string
-    - description: Whether the service is external to the mesh or part of the mesh (MESH_EXTERNAL or MESH_INTERNAL)
-      jsonPath: .spec.location
-      name: Location
-      type: string
-    - description: Service discovery mode for the hosts (NONE, STATIC, or DNS)
-      jsonPath: .spec.resolution
-      name: Resolution
-      type: string
-    - description: 'CreationTimestamp is a timestamp representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations. Clients may not set this value. It is represented in RFC3339 form and is in UTC. Populated by the system. Read-only. Null for lists. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata'
-      jsonPath: .metadata.creationTimestamp
-      name: Age
-      type: date
-    name: v1alpha3
-    schema:
-      openAPIV3Schema:
-        properties:
-          spec:
-            description: 'Configuration affecting service registry. See more details at: https://istio.io/docs/reference/config/networking/service-entry.html'
-            properties:
-              addresses:
-                description: The virtual IP addresses associated with the service.
-                items:
-                  format: string
-                  type: string
-                type: array
-              endpoints:
-                description: One or more endpoints associated with the service.
-                items:
-                  properties:
-                    address:
-                      format: string
-                      type: string
-                    labels:
-                      additionalProperties:
-                        format: string
-                        type: string
-                      description: One or more labels associated with the endpoint.
-                      type: object
-                    locality:
-                      description: The locality associated with the endpoint.
-                      format: string
-                      type: string
-                    network:
-                      format: string
-                      type: string
-                    ports:
-                      additionalProperties:
-                        type: integer
-                      description: Set of ports associated with the endpoint.
-                      type: object
-                    serviceAccount:
-                      format: string
-                      type: string
-                    weight:
-                      description: The load balancing weight associated with the endpoint.
-                      type: integer
-                  type: object
-                type: array
-              exportTo:
-                description: A list of namespaces to which this service is exported.
-                items:
-                  format: string
-                  type: string
-                type: array
-              hosts:
-                description: The hosts associated with the ServiceEntry.
-                items:
-                  format: string
-                  type: string
-                type: array
-              location:
-                enum:
-                - MESH_EXTERNAL
-                - MESH_INTERNAL
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      properties:
+        spec:
+          description: 'Configuration affecting service registry. See more details
+            at: https://istio.io/docs/reference/config/networking/service-entry.html'
+          properties:
+            addresses:
+              description: The virtual IP addresses associated with the service.
+              items:
+                format: string
                 type: string
-              ports:
-                description: The ports associated with the external service.
-                items:
-                  properties:
-                    name:
-                      description: Label assigned to the port.
-                      format: string
-                      type: string
-                    number:
-                      description: A valid non-negative integer port number.
-                      type: integer
-                    protocol:
-                      description: The protocol exposed on the port.
-                      format: string
-                      type: string
-                    targetPort:
-                      type: integer
-                  type: object
-                type: array
-              resolution:
-                description: Service discovery mode for the hosts.
-                enum:
-                - NONE
-                - STATIC
-                - DNS
-                type: string
-              subjectAltNames:
-                items:
-                  format: string
-                  type: string
-                type: array
-              workloadSelector:
-                description: Applicable only for MESH_INTERNAL services.
+              type: array
+            endpoints:
+              description: One or more endpoints associated with the service.
+              items:
                 properties:
+                  address:
+                    format: string
+                    type: string
                   labels:
                     additionalProperties:
                       format: string
                       type: string
+                    description: One or more labels associated with the endpoint.
                     type: object
+                  locality:
+                    description: The locality associated with the endpoint.
+                    format: string
+                    type: string
+                  network:
+                    format: string
+                    type: string
+                  ports:
+                    additionalProperties:
+                      type: integer
+                    description: Set of ports associated with the endpoint.
+                    type: object
+                  serviceAccount:
+                    format: string
+                    type: string
+                  weight:
+                    description: The load balancing weight associated with the endpoint.
+                    type: integer
                 type: object
-            type: object
-          status:
-            type: object
-            x-kubernetes-preserve-unknown-fields: true
-        type: object
+              type: array
+            exportTo:
+              description: A list of namespaces to which this service is exported.
+              items:
+                format: string
+                type: string
+              type: array
+            hosts:
+              description: The hosts associated with the ServiceEntry.
+              items:
+                format: string
+                type: string
+              type: array
+            location:
+              enum:
+              - MESH_EXTERNAL
+              - MESH_INTERNAL
+              type: string
+            ports:
+              description: The ports associated with the external service.
+              items:
+                properties:
+                  name:
+                    description: Label assigned to the port.
+                    format: string
+                    type: string
+                  number:
+                    description: A valid non-negative integer port number.
+                    type: integer
+                  protocol:
+                    description: The protocol exposed on the port.
+                    format: string
+                    type: string
+                  targetPort:
+                    type: integer
+                type: object
+              type: array
+            resolution:
+              description: Service discovery mode for the hosts.
+              enum:
+              - NONE
+              - STATIC
+              - DNS
+              type: string
+            subjectAltNames:
+              items:
+                format: string
+                type: string
+              type: array
+            workloadSelector:
+              description: Applicable only for MESH_INTERNAL services.
+              properties:
+                labels:
+                  additionalProperties:
+                    format: string
+                    type: string
+                  type: object
+              type: object
+          type: object
+        status:
+          type: object
+          x-kubernetes-preserve-unknown-fields: true
+      type: object
+  versions:
+  - name: v1alpha3
     served: true
     storage: true
-    subresources:
-      status: {}
-  - additionalPrinterColumns:
-    - description: The hosts associated with the ServiceEntry
-      jsonPath: .spec.hosts
-      name: Hosts
-      type: string
-    - description: Whether the service is external to the mesh or part of the mesh (MESH_EXTERNAL or MESH_INTERNAL)
-      jsonPath: .spec.location
-      name: Location
-      type: string
-    - description: Service discovery mode for the hosts (NONE, STATIC, or DNS)
-      jsonPath: .spec.resolution
-      name: Resolution
-      type: string
-    - description: 'CreationTimestamp is a timestamp representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations. Clients may not set this value. It is represented in RFC3339 form and is in UTC. Populated by the system. Read-only. Null for lists. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata'
-      jsonPath: .metadata.creationTimestamp
-      name: Age
-      type: date
-    name: v1beta1
-    schema:
-      openAPIV3Schema:
-        properties:
-          spec:
-            description: 'Configuration affecting service registry. See more details at: https://istio.io/docs/reference/config/networking/service-entry.html'
-            properties:
-              addresses:
-                description: The virtual IP addresses associated with the service.
-                items:
-                  format: string
-                  type: string
-                type: array
-              endpoints:
-                description: One or more endpoints associated with the service.
-                items:
-                  properties:
-                    address:
-                      format: string
-                      type: string
-                    labels:
-                      additionalProperties:
-                        format: string
-                        type: string
-                      description: One or more labels associated with the endpoint.
-                      type: object
-                    locality:
-                      description: The locality associated with the endpoint.
-                      format: string
-                      type: string
-                    network:
-                      format: string
-                      type: string
-                    ports:
-                      additionalProperties:
-                        type: integer
-                      description: Set of ports associated with the endpoint.
-                      type: object
-                    serviceAccount:
-                      format: string
-                      type: string
-                    weight:
-                      description: The load balancing weight associated with the endpoint.
-                      type: integer
-                  type: object
-                type: array
-              exportTo:
-                description: A list of namespaces to which this service is exported.
-                items:
-                  format: string
-                  type: string
-                type: array
-              hosts:
-                description: The hosts associated with the ServiceEntry.
-                items:
-                  format: string
-                  type: string
-                type: array
-              location:
-                enum:
-                - MESH_EXTERNAL
-                - MESH_INTERNAL
-                type: string
-              ports:
-                description: The ports associated with the external service.
-                items:
-                  properties:
-                    name:
-                      description: Label assigned to the port.
-                      format: string
-                      type: string
-                    number:
-                      description: A valid non-negative integer port number.
-                      type: integer
-                    protocol:
-                      description: The protocol exposed on the port.
-                      format: string
-                      type: string
-                    targetPort:
-                      type: integer
-                  type: object
-                type: array
-              resolution:
-                description: Service discovery mode for the hosts.
-                enum:
-                - NONE
-                - STATIC
-                - DNS
-                type: string
-              subjectAltNames:
-                items:
-                  format: string
-                  type: string
-                type: array
-              workloadSelector:
-                description: Applicable only for MESH_INTERNAL services.
-                properties:
-                  labels:
-                    additionalProperties:
-                      format: string
-                      type: string
-                    type: object
-                type: object
-            type: object
-          status:
-            type: object
-            x-kubernetes-preserve-unknown-fields: true
-        type: object
+  - name: v1beta1
     served: true
     storage: false
-    subresources:
-      status: {}
 ---
-apiVersion: apiextensions.k8s.io/v1
+apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   annotations:
@@ -4455,7 +2252,7 @@ metadata:
   labels:
     app: istio-pilot
     chart: istio
-    cloudfoundry.org/istio_version: 1.7.3
+    cloudfoundry.org/istio_version: 1.8.4
     heritage: Tiller
     release: istio
   name: sidecars.networking.istio.io
@@ -4469,293 +2266,136 @@ spec:
     listKind: SidecarList
     plural: sidecars
     singular: sidecar
+  preserveUnknownFields: false
   scope: Namespaced
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      properties:
+        spec:
+          description: 'Configuration affecting network reachability of a sidecar.
+            See more details at: https://istio.io/docs/reference/config/networking/sidecar.html'
+          properties:
+            egress:
+              items:
+                properties:
+                  bind:
+                    format: string
+                    type: string
+                  captureMode:
+                    enum:
+                    - DEFAULT
+                    - IPTABLES
+                    - NONE
+                    type: string
+                  hosts:
+                    items:
+                      format: string
+                      type: string
+                    type: array
+                  port:
+                    description: The port associated with the listener.
+                    properties:
+                      name:
+                        description: Label assigned to the port.
+                        format: string
+                        type: string
+                      number:
+                        description: A valid non-negative integer port number.
+                        type: integer
+                      protocol:
+                        description: The protocol exposed on the port.
+                        format: string
+                        type: string
+                      targetPort:
+                        type: integer
+                    type: object
+                type: object
+              type: array
+            ingress:
+              items:
+                properties:
+                  bind:
+                    description: The IP to which the listener should be bound.
+                    format: string
+                    type: string
+                  captureMode:
+                    enum:
+                    - DEFAULT
+                    - IPTABLES
+                    - NONE
+                    type: string
+                  defaultEndpoint:
+                    format: string
+                    type: string
+                  port:
+                    description: The port associated with the listener.
+                    properties:
+                      name:
+                        description: Label assigned to the port.
+                        format: string
+                        type: string
+                      number:
+                        description: A valid non-negative integer port number.
+                        type: integer
+                      protocol:
+                        description: The protocol exposed on the port.
+                        format: string
+                        type: string
+                      targetPort:
+                        type: integer
+                    type: object
+                type: object
+              type: array
+            outboundTrafficPolicy:
+              description: Configuration for the outbound traffic policy.
+              properties:
+                egressProxy:
+                  properties:
+                    host:
+                      description: The name of a service from the service registry.
+                      format: string
+                      type: string
+                    port:
+                      description: Specifies the port on the host that is being addressed.
+                      properties:
+                        number:
+                          type: integer
+                      type: object
+                    subset:
+                      description: The name of a subset within the service.
+                      format: string
+                      type: string
+                  type: object
+                mode:
+                  enum:
+                  - REGISTRY_ONLY
+                  - ALLOW_ANY
+                  type: string
+              type: object
+            workloadSelector:
+              properties:
+                labels:
+                  additionalProperties:
+                    format: string
+                    type: string
+                  type: object
+              type: object
+          type: object
+        status:
+          type: object
+          x-kubernetes-preserve-unknown-fields: true
+      type: object
   versions:
   - name: v1alpha3
-    schema:
-      openAPIV3Schema:
-        properties:
-          spec:
-            description: 'Configuration affecting network reachability of a sidecar. See more details at: https://istio.io/docs/reference/config/networking/sidecar.html'
-            properties:
-              egress:
-                items:
-                  properties:
-                    bind:
-                      format: string
-                      type: string
-                    captureMode:
-                      enum:
-                      - DEFAULT
-                      - IPTABLES
-                      - NONE
-                      type: string
-                    hosts:
-                      items:
-                        format: string
-                        type: string
-                      type: array
-                    port:
-                      description: The port associated with the listener.
-                      properties:
-                        name:
-                          description: Label assigned to the port.
-                          format: string
-                          type: string
-                        number:
-                          description: A valid non-negative integer port number.
-                          type: integer
-                        protocol:
-                          description: The protocol exposed on the port.
-                          format: string
-                          type: string
-                        targetPort:
-                          type: integer
-                      type: object
-                  type: object
-                type: array
-              ingress:
-                items:
-                  properties:
-                    bind:
-                      description: The IP to which the listener should be bound.
-                      format: string
-                      type: string
-                    captureMode:
-                      enum:
-                      - DEFAULT
-                      - IPTABLES
-                      - NONE
-                      type: string
-                    defaultEndpoint:
-                      format: string
-                      type: string
-                    port:
-                      description: The port associated with the listener.
-                      properties:
-                        name:
-                          description: Label assigned to the port.
-                          format: string
-                          type: string
-                        number:
-                          description: A valid non-negative integer port number.
-                          type: integer
-                        protocol:
-                          description: The protocol exposed on the port.
-                          format: string
-                          type: string
-                        targetPort:
-                          type: integer
-                      type: object
-                  type: object
-                type: array
-              outboundTrafficPolicy:
-                description: Configuration for the outbound traffic policy.
-                properties:
-                  egressProxy:
-                    properties:
-                      host:
-                        description: The name of a service from the service registry.
-                        format: string
-                        type: string
-                      port:
-                        description: Specifies the port on the host that is being addressed.
-                        properties:
-                          number:
-                            type: integer
-                        type: object
-                      subset:
-                        description: The name of a subset within the service.
-                        format: string
-                        type: string
-                    type: object
-                  mode:
-                    enum:
-                    - REGISTRY_ONLY
-                    - ALLOW_ANY
-                    type: string
-                type: object
-              workloadSelector:
-                properties:
-                  labels:
-                    additionalProperties:
-                      format: string
-                      type: string
-                    type: object
-                type: object
-            type: object
-          status:
-            type: object
-            x-kubernetes-preserve-unknown-fields: true
-        type: object
     served: true
     storage: true
-    subresources:
-      status: {}
   - name: v1beta1
-    schema:
-      openAPIV3Schema:
-        properties:
-          spec:
-            description: 'Configuration affecting network reachability of a sidecar. See more details at: https://istio.io/docs/reference/config/networking/sidecar.html'
-            properties:
-              egress:
-                items:
-                  properties:
-                    bind:
-                      format: string
-                      type: string
-                    captureMode:
-                      enum:
-                      - DEFAULT
-                      - IPTABLES
-                      - NONE
-                      type: string
-                    hosts:
-                      items:
-                        format: string
-                        type: string
-                      type: array
-                    port:
-                      description: The port associated with the listener.
-                      properties:
-                        name:
-                          description: Label assigned to the port.
-                          format: string
-                          type: string
-                        number:
-                          description: A valid non-negative integer port number.
-                          type: integer
-                        protocol:
-                          description: The protocol exposed on the port.
-                          format: string
-                          type: string
-                        targetPort:
-                          type: integer
-                      type: object
-                  type: object
-                type: array
-              ingress:
-                items:
-                  properties:
-                    bind:
-                      description: The IP to which the listener should be bound.
-                      format: string
-                      type: string
-                    captureMode:
-                      enum:
-                      - DEFAULT
-                      - IPTABLES
-                      - NONE
-                      type: string
-                    defaultEndpoint:
-                      format: string
-                      type: string
-                    port:
-                      description: The port associated with the listener.
-                      properties:
-                        name:
-                          description: Label assigned to the port.
-                          format: string
-                          type: string
-                        number:
-                          description: A valid non-negative integer port number.
-                          type: integer
-                        protocol:
-                          description: The protocol exposed on the port.
-                          format: string
-                          type: string
-                        targetPort:
-                          type: integer
-                      type: object
-                  type: object
-                type: array
-              outboundTrafficPolicy:
-                description: Configuration for the outbound traffic policy.
-                properties:
-                  egressProxy:
-                    properties:
-                      host:
-                        description: The name of a service from the service registry.
-                        format: string
-                        type: string
-                      port:
-                        description: Specifies the port on the host that is being addressed.
-                        properties:
-                          number:
-                            type: integer
-                        type: object
-                      subset:
-                        description: The name of a subset within the service.
-                        format: string
-                        type: string
-                    type: object
-                  mode:
-                    enum:
-                    - REGISTRY_ONLY
-                    - ALLOW_ANY
-                    type: string
-                type: object
-              workloadSelector:
-                properties:
-                  labels:
-                    additionalProperties:
-                      format: string
-                      type: string
-                    type: object
-                type: object
-            type: object
-          status:
-            type: object
-            x-kubernetes-preserve-unknown-fields: true
-        type: object
     served: true
     storage: false
-    subresources:
-      status: {}
 ---
-apiVersion: apiextensions.k8s.io/v1
-kind: CustomResourceDefinition
-metadata:
-  annotations:
-    helm.sh/resource-policy: keep
-  labels:
-    app: mixer
-    chart: istio
-    cloudfoundry.org/istio_version: 1.7.3
-    heritage: Tiller
-    istio: mixer-template
-    package: template
-    release: istio
-  name: templates.config.istio.io
-spec:
-  group: config.istio.io
-  names:
-    categories:
-    - istio-io
-    - policy-istio-io
-    kind: template
-    plural: templates
-    singular: template
-  scope: Namespaced
-  versions:
-  - name: v1alpha2
-    schema:
-      openAPIV3Schema:
-        properties:
-          spec:
-            type: object
-            x-kubernetes-preserve-unknown-fields: true
-          status:
-            type: object
-            x-kubernetes-preserve-unknown-fields: true
-        type: object
-    served: true
-    storage: true
-    subresources:
-      status: {}
----
-apiVersion: apiextensions.k8s.io/v1
+apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   annotations:
@@ -4763,11 +2403,28 @@ metadata:
   labels:
     app: istio-pilot
     chart: istio
-    cloudfoundry.org/istio_version: 1.7.3
+    cloudfoundry.org/istio_version: 1.8.4
     heritage: Tiller
     release: istio
   name: virtualservices.networking.istio.io
 spec:
+  additionalPrinterColumns:
+  - JSONPath: .spec.gateways
+    description: The names of gateways and sidecars that should apply these routes
+    name: Gateways
+    type: string
+  - JSONPath: .spec.hosts
+    description: The destination hosts to which traffic is being sent
+    name: Hosts
+    type: string
+  - JSONPath: .metadata.creationTimestamp
+    description: 'CreationTimestamp is a timestamp representing the server time when
+      this object was created. It is not guaranteed to be set in happens-before order
+      across separate operations. Clients may not set this value. It is represented
+      in RFC3339 form and is in UTC. Populated by the system. Read-only. Null for
+      lists. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata'
+    name: Age
+    type: date
   group: networking.istio.io
   names:
     categories:
@@ -4779,405 +2436,268 @@ spec:
     shortNames:
     - vs
     singular: virtualservice
+  preserveUnknownFields: false
   scope: Namespaced
-  versions:
-  - additionalPrinterColumns:
-    - description: The names of gateways and sidecars that should apply these routes
-      jsonPath: .spec.gateways
-      name: Gateways
-      type: string
-    - description: The destination hosts to which traffic is being sent
-      jsonPath: .spec.hosts
-      name: Hosts
-      type: string
-    - description: 'CreationTimestamp is a timestamp representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations. Clients may not set this value. It is represented in RFC3339 form and is in UTC. Populated by the system. Read-only. Null for lists. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata'
-      jsonPath: .metadata.creationTimestamp
-      name: Age
-      type: date
-    name: v1alpha3
-    schema:
-      openAPIV3Schema:
-        properties:
-          spec:
-            description: 'Configuration affecting label/content routing, sni routing, etc. See more details at: https://istio.io/docs/reference/config/networking/virtual-service.html'
-            properties:
-              exportTo:
-                description: A list of namespaces to which this virtual service is exported.
-                items:
-                  format: string
-                  type: string
-                type: array
-              gateways:
-                description: The names of gateways and sidecars that should apply these routes.
-                items:
-                  format: string
-                  type: string
-                type: array
-              hosts:
-                description: The destination hosts to which traffic is being sent.
-                items:
-                  format: string
-                  type: string
-                type: array
-              http:
-                description: An ordered list of route rules for HTTP traffic.
-                items:
-                  properties:
-                    corsPolicy:
-                      description: Cross-Origin Resource Sharing policy (CORS).
-                      properties:
-                        allowCredentials:
-                          nullable: true
-                          type: boolean
-                        allowHeaders:
-                          items:
-                            format: string
-                            type: string
-                          type: array
-                        allowMethods:
-                          description: List of HTTP methods allowed to access the resource.
-                          items:
-                            format: string
-                            type: string
-                          type: array
-                        allowOrigin:
-                          description: The list of origins that are allowed to perform CORS requests.
-                          items:
-                            format: string
-                            type: string
-                          type: array
-                        allowOrigins:
-                          description: String patterns that match allowed origins.
-                          items:
-                            oneOf:
-                            - not:
-                                anyOf:
-                                - required:
-                                  - exact
-                                - required:
-                                  - prefix
-                                - required:
-                                  - regex
-                            - required:
-                              - exact
-                            - required:
-                              - prefix
-                            - required:
-                              - regex
-                            properties:
-                              exact:
-                                format: string
-                                type: string
-                              prefix:
-                                format: string
-                                type: string
-                              regex:
-                                description: RE2 style regex-based match (https://github.com/google/re2/wiki/Syntax).
-                                format: string
-                                type: string
-                            type: object
-                          type: array
-                        exposeHeaders:
-                          items:
-                            format: string
-                            type: string
-                          type: array
-                        maxAge:
-                          type: string
-                      type: object
-                    delegate:
-                      properties:
-                        name:
-                          description: Name specifies the name of the delegate VirtualService.
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      properties:
+        spec:
+          description: 'Configuration affecting label/content routing, sni routing,
+            etc. See more details at: https://istio.io/docs/reference/config/networking/virtual-service.html'
+          properties:
+            exportTo:
+              description: A list of namespaces to which this virtual service is exported.
+              items:
+                format: string
+                type: string
+              type: array
+            gateways:
+              description: The names of gateways and sidecars that should apply these
+                routes.
+              items:
+                format: string
+                type: string
+              type: array
+            hosts:
+              description: The destination hosts to which traffic is being sent.
+              items:
+                format: string
+                type: string
+              type: array
+            http:
+              description: An ordered list of route rules for HTTP traffic.
+              items:
+                properties:
+                  corsPolicy:
+                    description: Cross-Origin Resource Sharing policy (CORS).
+                    properties:
+                      allowCredentials:
+                        nullable: true
+                        type: boolean
+                      allowHeaders:
+                        items:
                           format: string
                           type: string
-                        namespace:
-                          description: Namespace specifies the namespace where the delegate VirtualService resides.
+                        type: array
+                      allowMethods:
+                        description: List of HTTP methods allowed to access the resource.
+                        items:
                           format: string
                           type: string
-                      type: object
-                    fault:
-                      description: Fault injection policy to apply on HTTP traffic at the client side.
-                      properties:
-                        abort:
+                        type: array
+                      allowOrigin:
+                        description: The list of origins that are allowed to perform
+                          CORS requests.
+                        items:
+                          format: string
+                          type: string
+                        type: array
+                      allowOrigins:
+                        description: String patterns that match allowed origins.
+                        items:
                           oneOf:
                           - not:
                               anyOf:
                               - required:
-                                - httpStatus
+                                - exact
                               - required:
-                                - grpcStatus
+                                - prefix
                               - required:
-                                - http2Error
+                                - regex
                           - required:
-                            - httpStatus
+                            - exact
                           - required:
-                            - grpcStatus
+                            - prefix
                           - required:
-                            - http2Error
+                            - regex
                           properties:
-                            grpcStatus:
+                            exact:
                               format: string
                               type: string
-                            http2Error:
+                            prefix:
                               format: string
                               type: string
-                            httpStatus:
-                              description: HTTP status code to use to abort the Http request.
-                              format: int32
-                              type: integer
-                            percentage:
-                              description: Percentage of requests to be aborted with the error code provided.
-                              properties:
-                                value:
-                                  format: double
-                                  type: number
-                              type: object
-                          type: object
-                        delay:
-                          oneOf:
-                          - not:
-                              anyOf:
-                              - required:
-                                - fixedDelay
-                              - required:
-                                - exponentialDelay
-                          - required:
-                            - fixedDelay
-                          - required:
-                            - exponentialDelay
-                          properties:
-                            exponentialDelay:
+                            regex:
+                              description: RE2 style regex-based match (https://github.com/google/re2/wiki/Syntax).
+                              format: string
                               type: string
-                            fixedDelay:
-                              description: Add a fixed delay before forwarding the request.
-                              type: string
-                            percent:
-                              description: Percentage of requests on which the delay will be injected (0-100).
-                              format: int32
-                              type: integer
-                            percentage:
-                              description: Percentage of requests on which the delay will be injected.
-                              properties:
-                                value:
-                                  format: double
-                                  type: number
-                              type: object
                           type: object
-                      type: object
-                    headers:
-                      properties:
-                        request:
-                          properties:
-                            add:
-                              additionalProperties:
-                                format: string
-                                type: string
-                              type: object
-                            remove:
-                              items:
-                                format: string
-                                type: string
-                              type: array
-                            set:
-                              additionalProperties:
-                                format: string
-                                type: string
-                              type: object
-                          type: object
-                        response:
-                          properties:
-                            add:
-                              additionalProperties:
-                                format: string
-                                type: string
-                              type: object
-                            remove:
-                              items:
-                                format: string
-                                type: string
-                              type: array
-                            set:
-                              additionalProperties:
-                                format: string
-                                type: string
-                              type: object
-                          type: object
-                      type: object
-                    match:
-                      items:
+                        type: array
+                      exposeHeaders:
+                        items:
+                          format: string
+                          type: string
+                        type: array
+                      maxAge:
+                        type: string
+                    type: object
+                  delegate:
+                    properties:
+                      name:
+                        description: Name specifies the name of the delegate VirtualService.
+                        format: string
+                        type: string
+                      namespace:
+                        description: Namespace specifies the namespace where the delegate
+                          VirtualService resides.
+                        format: string
+                        type: string
+                    type: object
+                  fault:
+                    description: Fault injection policy to apply on HTTP traffic at
+                      the client side.
+                    properties:
+                      abort:
+                        oneOf:
+                        - not:
+                            anyOf:
+                            - required:
+                              - httpStatus
+                            - required:
+                              - grpcStatus
+                            - required:
+                              - http2Error
+                        - required:
+                          - httpStatus
+                        - required:
+                          - grpcStatus
+                        - required:
+                          - http2Error
                         properties:
-                          authority:
-                            oneOf:
-                            - not:
-                                anyOf:
-                                - required:
-                                  - exact
-                                - required:
-                                  - prefix
-                                - required:
-                                  - regex
-                            - required:
-                              - exact
-                            - required:
-                              - prefix
-                            - required:
-                              - regex
+                          grpcStatus:
+                            format: string
+                            type: string
+                          http2Error:
+                            format: string
+                            type: string
+                          httpStatus:
+                            description: HTTP status code to use to abort the Http
+                              request.
+                            format: int32
+                            type: integer
+                          percentage:
+                            description: Percentage of requests to be aborted with
+                              the error code provided.
                             properties:
-                              exact:
-                                format: string
-                                type: string
-                              prefix:
-                                format: string
-                                type: string
-                              regex:
-                                description: RE2 style regex-based match (https://github.com/google/re2/wiki/Syntax).
-                                format: string
-                                type: string
+                              value:
+                                format: double
+                                type: number
                             type: object
-                          gateways:
-                            description: Names of gateways where the rule should be applied.
+                        type: object
+                      delay:
+                        oneOf:
+                        - not:
+                            anyOf:
+                            - required:
+                              - fixedDelay
+                            - required:
+                              - exponentialDelay
+                        - required:
+                          - fixedDelay
+                        - required:
+                          - exponentialDelay
+                        properties:
+                          exponentialDelay:
+                            type: string
+                          fixedDelay:
+                            description: Add a fixed delay before forwarding the request.
+                            type: string
+                          percent:
+                            description: Percentage of requests on which the delay
+                              will be injected (0-100).
+                            format: int32
+                            type: integer
+                          percentage:
+                            description: Percentage of requests on which the delay
+                              will be injected.
+                            properties:
+                              value:
+                                format: double
+                                type: number
+                            type: object
+                        type: object
+                    type: object
+                  headers:
+                    properties:
+                      request:
+                        properties:
+                          add:
+                            additionalProperties:
+                              format: string
+                              type: string
+                            type: object
+                          remove:
                             items:
                               format: string
                               type: string
                             type: array
-                          headers:
-                            additionalProperties:
-                              oneOf:
-                              - not:
-                                  anyOf:
-                                  - required:
-                                    - exact
-                                  - required:
-                                    - prefix
-                                  - required:
-                                    - regex
-                              - required:
-                                - exact
-                              - required:
-                                - prefix
-                              - required:
-                                - regex
-                              properties:
-                                exact:
-                                  format: string
-                                  type: string
-                                prefix:
-                                  format: string
-                                  type: string
-                                regex:
-                                  description: RE2 style regex-based match (https://github.com/google/re2/wiki/Syntax).
-                                  format: string
-                                  type: string
-                              type: object
-                            type: object
-                          ignoreUriCase:
-                            description: Flag to specify whether the URI matching should be case-insensitive.
-                            type: boolean
-                          method:
-                            oneOf:
-                            - not:
-                                anyOf:
-                                - required:
-                                  - exact
-                                - required:
-                                  - prefix
-                                - required:
-                                  - regex
-                            - required:
-                              - exact
-                            - required:
-                              - prefix
-                            - required:
-                              - regex
-                            properties:
-                              exact:
-                                format: string
-                                type: string
-                              prefix:
-                                format: string
-                                type: string
-                              regex:
-                                description: RE2 style regex-based match (https://github.com/google/re2/wiki/Syntax).
-                                format: string
-                                type: string
-                            type: object
-                          name:
-                            description: The name assigned to a match.
-                            format: string
-                            type: string
-                          port:
-                            description: Specifies the ports on the host that is being addressed.
-                            type: integer
-                          queryParams:
-                            additionalProperties:
-                              oneOf:
-                              - not:
-                                  anyOf:
-                                  - required:
-                                    - exact
-                                  - required:
-                                    - prefix
-                                  - required:
-                                    - regex
-                              - required:
-                                - exact
-                              - required:
-                                - prefix
-                              - required:
-                                - regex
-                              properties:
-                                exact:
-                                  format: string
-                                  type: string
-                                prefix:
-                                  format: string
-                                  type: string
-                                regex:
-                                  description: RE2 style regex-based match (https://github.com/google/re2/wiki/Syntax).
-                                  format: string
-                                  type: string
-                              type: object
-                            description: Query parameters for matching.
-                            type: object
-                          scheme:
-                            oneOf:
-                            - not:
-                                anyOf:
-                                - required:
-                                  - exact
-                                - required:
-                                  - prefix
-                                - required:
-                                  - regex
-                            - required:
-                              - exact
-                            - required:
-                              - prefix
-                            - required:
-                              - regex
-                            properties:
-                              exact:
-                                format: string
-                                type: string
-                              prefix:
-                                format: string
-                                type: string
-                              regex:
-                                description: RE2 style regex-based match (https://github.com/google/re2/wiki/Syntax).
-                                format: string
-                                type: string
-                            type: object
-                          sourceLabels:
+                          set:
                             additionalProperties:
                               format: string
                               type: string
                             type: object
-                          sourceNamespace:
-                            description: Source namespace constraining the applicability of a rule to workloads in that namespace.
+                        type: object
+                      response:
+                        properties:
+                          add:
+                            additionalProperties:
+                              format: string
+                              type: string
+                            type: object
+                          remove:
+                            items:
+                              format: string
+                              type: string
+                            type: array
+                          set:
+                            additionalProperties:
+                              format: string
+                              type: string
+                            type: object
+                        type: object
+                    type: object
+                  match:
+                    items:
+                      properties:
+                        authority:
+                          oneOf:
+                          - not:
+                              anyOf:
+                              - required:
+                                - exact
+                              - required:
+                                - prefix
+                              - required:
+                                - regex
+                          - required:
+                            - exact
+                          - required:
+                            - prefix
+                          - required:
+                            - regex
+                          properties:
+                            exact:
+                              format: string
+                              type: string
+                            prefix:
+                              format: string
+                              type: string
+                            regex:
+                              description: RE2 style regex-based match (https://github.com/google/re2/wiki/Syntax).
+                              format: string
+                              type: string
+                          type: object
+                        gateways:
+                          description: Names of gateways where the rule should be
+                            applied.
+                          items:
                             format: string
                             type: string
-                          uri:
+                          type: array
+                        headers:
+                          additionalProperties:
                             oneOf:
                             - not:
                                 anyOf:
@@ -5205,1074 +2725,496 @@ spec:
                                 format: string
                                 type: string
                             type: object
-                          withoutHeaders:
-                            additionalProperties:
-                              oneOf:
-                              - not:
-                                  anyOf:
-                                  - required:
-                                    - exact
-                                  - required:
-                                    - prefix
-                                  - required:
-                                    - regex
+                          type: object
+                        ignoreUriCase:
+                          description: Flag to specify whether the URI matching should
+                            be case-insensitive.
+                          type: boolean
+                        method:
+                          oneOf:
+                          - not:
+                              anyOf:
                               - required:
                                 - exact
                               - required:
                                 - prefix
                               - required:
                                 - regex
-                              properties:
-                                exact:
-                                  format: string
-                                  type: string
-                                prefix:
-                                  format: string
-                                  type: string
-                                regex:
-                                  description: RE2 style regex-based match (https://github.com/google/re2/wiki/Syntax).
-                                  format: string
-                                  type: string
-                              type: object
-                            description: withoutHeader has the same syntax with the header, but has opposite meaning.
-                            type: object
-                        type: object
-                      type: array
-                    mirror:
-                      properties:
-                        host:
-                          description: The name of a service from the service registry.
+                          - required:
+                            - exact
+                          - required:
+                            - prefix
+                          - required:
+                            - regex
+                          properties:
+                            exact:
+                              format: string
+                              type: string
+                            prefix:
+                              format: string
+                              type: string
+                            regex:
+                              description: RE2 style regex-based match (https://github.com/google/re2/wiki/Syntax).
+                              format: string
+                              type: string
+                          type: object
+                        name:
+                          description: The name assigned to a match.
                           format: string
                           type: string
                         port:
-                          description: Specifies the port on the host that is being addressed.
-                          properties:
-                            number:
-                              type: integer
-                          type: object
-                        subset:
-                          description: The name of a subset within the service.
-                          format: string
-                          type: string
-                      type: object
-                    mirror_percent:
-                      description: Percentage of the traffic to be mirrored by the `mirror` field.
-                      nullable: true
-                      type: integer
-                    mirrorPercent:
-                      description: Percentage of the traffic to be mirrored by the `mirror` field.
-                      nullable: true
-                      type: integer
-                    mirrorPercentage:
-                      description: Percentage of the traffic to be mirrored by the `mirror` field.
-                      properties:
-                        value:
-                          format: double
-                          type: number
-                      type: object
-                    name:
-                      description: The name assigned to the route for debugging purposes.
-                      format: string
-                      type: string
-                    redirect:
-                      description: A HTTP rule can either redirect or forward (default) traffic.
-                      properties:
-                        authority:
-                          format: string
-                          type: string
-                        redirectCode:
+                          description: Specifies the ports on the host that is being
+                            addressed.
                           type: integer
-                        uri:
+                        queryParams:
+                          additionalProperties:
+                            oneOf:
+                            - not:
+                                anyOf:
+                                - required:
+                                  - exact
+                                - required:
+                                  - prefix
+                                - required:
+                                  - regex
+                            - required:
+                              - exact
+                            - required:
+                              - prefix
+                            - required:
+                              - regex
+                            properties:
+                              exact:
+                                format: string
+                                type: string
+                              prefix:
+                                format: string
+                                type: string
+                              regex:
+                                description: RE2 style regex-based match (https://github.com/google/re2/wiki/Syntax).
+                                format: string
+                                type: string
+                            type: object
+                          description: Query parameters for matching.
+                          type: object
+                        scheme:
+                          oneOf:
+                          - not:
+                              anyOf:
+                              - required:
+                                - exact
+                              - required:
+                                - prefix
+                              - required:
+                                - regex
+                          - required:
+                            - exact
+                          - required:
+                            - prefix
+                          - required:
+                            - regex
+                          properties:
+                            exact:
+                              format: string
+                              type: string
+                            prefix:
+                              format: string
+                              type: string
+                            regex:
+                              description: RE2 style regex-based match (https://github.com/google/re2/wiki/Syntax).
+                              format: string
+                              type: string
+                          type: object
+                        sourceLabels:
+                          additionalProperties:
+                            format: string
+                            type: string
+                          type: object
+                        sourceNamespace:
+                          description: Source namespace constraining the applicability
+                            of a rule to workloads in that namespace.
                           format: string
                           type: string
+                        uri:
+                          oneOf:
+                          - not:
+                              anyOf:
+                              - required:
+                                - exact
+                              - required:
+                                - prefix
+                              - required:
+                                - regex
+                          - required:
+                            - exact
+                          - required:
+                            - prefix
+                          - required:
+                            - regex
+                          properties:
+                            exact:
+                              format: string
+                              type: string
+                            prefix:
+                              format: string
+                              type: string
+                            regex:
+                              description: RE2 style regex-based match (https://github.com/google/re2/wiki/Syntax).
+                              format: string
+                              type: string
+                          type: object
+                        withoutHeaders:
+                          additionalProperties:
+                            oneOf:
+                            - not:
+                                anyOf:
+                                - required:
+                                  - exact
+                                - required:
+                                  - prefix
+                                - required:
+                                  - regex
+                            - required:
+                              - exact
+                            - required:
+                              - prefix
+                            - required:
+                              - regex
+                            properties:
+                              exact:
+                                format: string
+                                type: string
+                              prefix:
+                                format: string
+                                type: string
+                              regex:
+                                description: RE2 style regex-based match (https://github.com/google/re2/wiki/Syntax).
+                                format: string
+                                type: string
+                            type: object
+                          description: withoutHeader has the same syntax with the
+                            header, but has opposite meaning.
+                          type: object
                       type: object
-                    retries:
-                      description: Retry policy for HTTP requests.
+                    type: array
+                  mirror:
+                    properties:
+                      host:
+                        description: The name of a service from the service registry.
+                        format: string
+                        type: string
+                      port:
+                        description: Specifies the port on the host that is being
+                          addressed.
+                        properties:
+                          number:
+                            type: integer
+                        type: object
+                      subset:
+                        description: The name of a subset within the service.
+                        format: string
+                        type: string
+                    type: object
+                  mirror_percent:
+                    description: Percentage of the traffic to be mirrored by the `mirror`
+                      field.
+                    nullable: true
+                    type: integer
+                  mirrorPercent:
+                    description: Percentage of the traffic to be mirrored by the `mirror`
+                      field.
+                    nullable: true
+                    type: integer
+                  mirrorPercentage:
+                    description: Percentage of the traffic to be mirrored by the `mirror`
+                      field.
+                    properties:
+                      value:
+                        format: double
+                        type: number
+                    type: object
+                  name:
+                    description: The name assigned to the route for debugging purposes.
+                    format: string
+                    type: string
+                  redirect:
+                    description: A HTTP rule can either redirect or forward (default)
+                      traffic.
+                    properties:
+                      authority:
+                        format: string
+                        type: string
+                      redirectCode:
+                        type: integer
+                      uri:
+                        format: string
+                        type: string
+                    type: object
+                  retries:
+                    description: Retry policy for HTTP requests.
+                    properties:
+                      attempts:
+                        description: Number of retries to be allowed for a given request.
+                        format: int32
+                        type: integer
+                      perTryTimeout:
+                        description: Timeout per retry attempt for a given request.
+                        type: string
+                      retryOn:
+                        description: Specifies the conditions under which retry takes
+                          place.
+                        format: string
+                        type: string
+                      retryRemoteLocalities:
+                        description: Flag to specify whether the retries should retry
+                          to other localities.
+                        nullable: true
+                        type: boolean
+                    type: object
+                  rewrite:
+                    description: Rewrite HTTP URIs and Authority headers.
+                    properties:
+                      authority:
+                        description: rewrite the Authority/Host header with this value.
+                        format: string
+                        type: string
+                      uri:
+                        format: string
+                        type: string
+                    type: object
+                  route:
+                    description: A HTTP rule can either redirect or forward (default)
+                      traffic.
+                    items:
                       properties:
-                        attempts:
-                          description: Number of retries for a given request.
+                        destination:
+                          properties:
+                            host:
+                              description: The name of a service from the service
+                                registry.
+                              format: string
+                              type: string
+                            port:
+                              description: Specifies the port on the host that is
+                                being addressed.
+                              properties:
+                                number:
+                                  type: integer
+                              type: object
+                            subset:
+                              description: The name of a subset within the service.
+                              format: string
+                              type: string
+                          type: object
+                        headers:
+                          properties:
+                            request:
+                              properties:
+                                add:
+                                  additionalProperties:
+                                    format: string
+                                    type: string
+                                  type: object
+                                remove:
+                                  items:
+                                    format: string
+                                    type: string
+                                  type: array
+                                set:
+                                  additionalProperties:
+                                    format: string
+                                    type: string
+                                  type: object
+                              type: object
+                            response:
+                              properties:
+                                add:
+                                  additionalProperties:
+                                    format: string
+                                    type: string
+                                  type: object
+                                remove:
+                                  items:
+                                    format: string
+                                    type: string
+                                  type: array
+                                set:
+                                  additionalProperties:
+                                    format: string
+                                    type: string
+                                  type: object
+                              type: object
+                          type: object
+                        weight:
                           format: int32
                           type: integer
-                        perTryTimeout:
-                          description: Timeout per retry attempt for a given request.
-                          type: string
-                        retryOn:
-                          description: Specifies the conditions under which retry takes place.
-                          format: string
-                          type: string
-                        retryRemoteLocalities:
-                          description: Flag to specify whether the retries should retry to other localities.
-                          nullable: true
-                          type: boolean
                       type: object
-                    rewrite:
-                      description: Rewrite HTTP URIs and Authority headers.
+                    type: array
+                  timeout:
+                    description: Timeout for HTTP requests, default is disabled.
+                    type: string
+                type: object
+              type: array
+            tcp:
+              description: An ordered list of route rules for opaque TCP traffic.
+              items:
+                properties:
+                  match:
+                    items:
                       properties:
-                        authority:
-                          description: rewrite the Authority/Host header with this value.
+                        destinationSubnets:
+                          description: IPv4 or IPv6 ip addresses of destination with
+                            optional subnet.
+                          items:
+                            format: string
+                            type: string
+                          type: array
+                        gateways:
+                          description: Names of gateways where the rule should be
+                            applied.
+                          items:
+                            format: string
+                            type: string
+                          type: array
+                        port:
+                          description: Specifies the port on the host that is being
+                            addressed.
+                          type: integer
+                        sourceLabels:
+                          additionalProperties:
+                            format: string
+                            type: string
+                          type: object
+                        sourceNamespace:
+                          description: Source namespace constraining the applicability
+                            of a rule to workloads in that namespace.
                           format: string
                           type: string
-                        uri:
+                        sourceSubnet:
+                          description: IPv4 or IPv6 ip address of source with optional
+                            subnet.
                           format: string
                           type: string
                       type: object
-                    route:
-                      description: A HTTP rule can either redirect or forward (default) traffic.
-                      items:
-                        properties:
-                          destination:
-                            properties:
-                              host:
-                                description: The name of a service from the service registry.
-                                format: string
-                                type: string
-                              port:
-                                description: Specifies the port on the host that is being addressed.
-                                properties:
-                                  number:
-                                    type: integer
-                                type: object
-                              subset:
-                                description: The name of a subset within the service.
-                                format: string
-                                type: string
-                            type: object
-                          headers:
-                            properties:
-                              request:
-                                properties:
-                                  add:
-                                    additionalProperties:
-                                      format: string
-                                      type: string
-                                    type: object
-                                  remove:
-                                    items:
-                                      format: string
-                                      type: string
-                                    type: array
-                                  set:
-                                    additionalProperties:
-                                      format: string
-                                      type: string
-                                    type: object
-                                type: object
-                              response:
-                                properties:
-                                  add:
-                                    additionalProperties:
-                                      format: string
-                                      type: string
-                                    type: object
-                                  remove:
-                                    items:
-                                      format: string
-                                      type: string
-                                    type: array
-                                  set:
-                                    additionalProperties:
-                                      format: string
-                                      type: string
-                                    type: object
-                                type: object
-                            type: object
-                          weight:
-                            format: int32
-                            type: integer
-                        type: object
-                      type: array
-                    timeout:
-                      description: Timeout for HTTP requests, default is disabled.
-                      type: string
-                  type: object
-                type: array
-              tcp:
-                description: An ordered list of route rules for opaque TCP traffic.
-                items:
-                  properties:
-                    match:
-                      items:
-                        properties:
-                          destinationSubnets:
-                            description: IPv4 or IPv6 ip addresses of destination with optional subnet.
-                            items:
+                    type: array
+                  route:
+                    description: The destination to which the connection should be
+                      forwarded to.
+                    items:
+                      properties:
+                        destination:
+                          properties:
+                            host:
+                              description: The name of a service from the service
+                                registry.
                               format: string
                               type: string
-                            type: array
-                          gateways:
-                            description: Names of gateways where the rule should be applied.
-                            items:
+                            port:
+                              description: Specifies the port on the host that is
+                                being addressed.
+                              properties:
+                                number:
+                                  type: integer
+                              type: object
+                            subset:
+                              description: The name of a subset within the service.
                               format: string
                               type: string
-                            type: array
-                          port:
-                            description: Specifies the port on the host that is being addressed.
-                            type: integer
-                          sourceLabels:
-                            additionalProperties:
-                              format: string
-                              type: string
-                            type: object
-                          sourceNamespace:
-                            description: Source namespace constraining the applicability of a rule to workloads in that namespace.
+                          type: object
+                        weight:
+                          format: int32
+                          type: integer
+                      type: object
+                    type: array
+                type: object
+              type: array
+            tls:
+              items:
+                properties:
+                  match:
+                    items:
+                      properties:
+                        destinationSubnets:
+                          description: IPv4 or IPv6 ip addresses of destination with
+                            optional subnet.
+                          items:
                             format: string
                             type: string
-                          sourceSubnet:
-                            description: IPv4 or IPv6 ip address of source with optional subnet.
+                          type: array
+                        gateways:
+                          description: Names of gateways where the rule should be
+                            applied.
+                          items:
                             format: string
                             type: string
-                        type: object
-                      type: array
-                    route:
-                      description: The destination to which the connection should be forwarded to.
-                      items:
-                        properties:
-                          destination:
-                            properties:
-                              host:
-                                description: The name of a service from the service registry.
-                                format: string
-                                type: string
-                              port:
-                                description: Specifies the port on the host that is being addressed.
-                                properties:
-                                  number:
-                                    type: integer
-                                type: object
-                              subset:
-                                description: The name of a subset within the service.
-                                format: string
-                                type: string
-                            type: object
-                          weight:
-                            format: int32
-                            type: integer
-                        type: object
-                      type: array
-                  type: object
-                type: array
-              tls:
-                items:
-                  properties:
-                    match:
-                      items:
-                        properties:
-                          destinationSubnets:
-                            description: IPv4 or IPv6 ip addresses of destination with optional subnet.
-                            items:
-                              format: string
-                              type: string
-                            type: array
-                          gateways:
-                            description: Names of gateways where the rule should be applied.
-                            items:
-                              format: string
-                              type: string
-                            type: array
-                          port:
-                            description: Specifies the port on the host that is being addressed.
-                            type: integer
-                          sniHosts:
-                            description: SNI (server name indicator) to match on.
-                            items:
-                              format: string
-                              type: string
-                            type: array
-                          sourceLabels:
-                            additionalProperties:
-                              format: string
-                              type: string
-                            type: object
-                          sourceNamespace:
-                            description: Source namespace constraining the applicability of a rule to workloads in that namespace.
+                          type: array
+                        port:
+                          description: Specifies the port on the host that is being
+                            addressed.
+                          type: integer
+                        sniHosts:
+                          description: SNI (server name indicator) to match on.
+                          items:
                             format: string
                             type: string
-                        type: object
-                      type: array
-                    route:
-                      description: The destination to which the connection should be forwarded to.
-                      items:
-                        properties:
-                          destination:
-                            properties:
-                              host:
-                                description: The name of a service from the service registry.
-                                format: string
-                                type: string
-                              port:
-                                description: Specifies the port on the host that is being addressed.
-                                properties:
-                                  number:
-                                    type: integer
-                                type: object
-                              subset:
-                                description: The name of a subset within the service.
-                                format: string
-                                type: string
-                            type: object
-                          weight:
-                            format: int32
-                            type: integer
-                        type: object
-                      type: array
-                  type: object
-                type: array
-            type: object
-          status:
-            type: object
-            x-kubernetes-preserve-unknown-fields: true
-        type: object
+                          type: array
+                        sourceLabels:
+                          additionalProperties:
+                            format: string
+                            type: string
+                          type: object
+                        sourceNamespace:
+                          description: Source namespace constraining the applicability
+                            of a rule to workloads in that namespace.
+                          format: string
+                          type: string
+                      type: object
+                    type: array
+                  route:
+                    description: The destination to which the connection should be
+                      forwarded to.
+                    items:
+                      properties:
+                        destination:
+                          properties:
+                            host:
+                              description: The name of a service from the service
+                                registry.
+                              format: string
+                              type: string
+                            port:
+                              description: Specifies the port on the host that is
+                                being addressed.
+                              properties:
+                                number:
+                                  type: integer
+                              type: object
+                            subset:
+                              description: The name of a subset within the service.
+                              format: string
+                              type: string
+                          type: object
+                        weight:
+                          format: int32
+                          type: integer
+                      type: object
+                    type: array
+                type: object
+              type: array
+          type: object
+        status:
+          type: object
+          x-kubernetes-preserve-unknown-fields: true
+      type: object
+  versions:
+  - name: v1alpha3
     served: true
     storage: true
-    subresources:
-      status: {}
-  - additionalPrinterColumns:
-    - description: The names of gateways and sidecars that should apply these routes
-      jsonPath: .spec.gateways
-      name: Gateways
-      type: string
-    - description: The destination hosts to which traffic is being sent
-      jsonPath: .spec.hosts
-      name: Hosts
-      type: string
-    - description: 'CreationTimestamp is a timestamp representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations. Clients may not set this value. It is represented in RFC3339 form and is in UTC. Populated by the system. Read-only. Null for lists. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata'
-      jsonPath: .metadata.creationTimestamp
-      name: Age
-      type: date
-    name: v1beta1
-    schema:
-      openAPIV3Schema:
-        properties:
-          spec:
-            description: 'Configuration affecting label/content routing, sni routing, etc. See more details at: https://istio.io/docs/reference/config/networking/virtual-service.html'
-            properties:
-              exportTo:
-                description: A list of namespaces to which this virtual service is exported.
-                items:
-                  format: string
-                  type: string
-                type: array
-              gateways:
-                description: The names of gateways and sidecars that should apply these routes.
-                items:
-                  format: string
-                  type: string
-                type: array
-              hosts:
-                description: The destination hosts to which traffic is being sent.
-                items:
-                  format: string
-                  type: string
-                type: array
-              http:
-                description: An ordered list of route rules for HTTP traffic.
-                items:
-                  properties:
-                    corsPolicy:
-                      description: Cross-Origin Resource Sharing policy (CORS).
-                      properties:
-                        allowCredentials:
-                          nullable: true
-                          type: boolean
-                        allowHeaders:
-                          items:
-                            format: string
-                            type: string
-                          type: array
-                        allowMethods:
-                          description: List of HTTP methods allowed to access the resource.
-                          items:
-                            format: string
-                            type: string
-                          type: array
-                        allowOrigin:
-                          description: The list of origins that are allowed to perform CORS requests.
-                          items:
-                            format: string
-                            type: string
-                          type: array
-                        allowOrigins:
-                          description: String patterns that match allowed origins.
-                          items:
-                            oneOf:
-                            - not:
-                                anyOf:
-                                - required:
-                                  - exact
-                                - required:
-                                  - prefix
-                                - required:
-                                  - regex
-                            - required:
-                              - exact
-                            - required:
-                              - prefix
-                            - required:
-                              - regex
-                            properties:
-                              exact:
-                                format: string
-                                type: string
-                              prefix:
-                                format: string
-                                type: string
-                              regex:
-                                description: RE2 style regex-based match (https://github.com/google/re2/wiki/Syntax).
-                                format: string
-                                type: string
-                            type: object
-                          type: array
-                        exposeHeaders:
-                          items:
-                            format: string
-                            type: string
-                          type: array
-                        maxAge:
-                          type: string
-                      type: object
-                    delegate:
-                      properties:
-                        name:
-                          description: Name specifies the name of the delegate VirtualService.
-                          format: string
-                          type: string
-                        namespace:
-                          description: Namespace specifies the namespace where the delegate VirtualService resides.
-                          format: string
-                          type: string
-                      type: object
-                    fault:
-                      description: Fault injection policy to apply on HTTP traffic at the client side.
-                      properties:
-                        abort:
-                          oneOf:
-                          - not:
-                              anyOf:
-                              - required:
-                                - httpStatus
-                              - required:
-                                - grpcStatus
-                              - required:
-                                - http2Error
-                          - required:
-                            - httpStatus
-                          - required:
-                            - grpcStatus
-                          - required:
-                            - http2Error
-                          properties:
-                            grpcStatus:
-                              format: string
-                              type: string
-                            http2Error:
-                              format: string
-                              type: string
-                            httpStatus:
-                              description: HTTP status code to use to abort the Http request.
-                              format: int32
-                              type: integer
-                            percentage:
-                              description: Percentage of requests to be aborted with the error code provided.
-                              properties:
-                                value:
-                                  format: double
-                                  type: number
-                              type: object
-                          type: object
-                        delay:
-                          oneOf:
-                          - not:
-                              anyOf:
-                              - required:
-                                - fixedDelay
-                              - required:
-                                - exponentialDelay
-                          - required:
-                            - fixedDelay
-                          - required:
-                            - exponentialDelay
-                          properties:
-                            exponentialDelay:
-                              type: string
-                            fixedDelay:
-                              description: Add a fixed delay before forwarding the request.
-                              type: string
-                            percent:
-                              description: Percentage of requests on which the delay will be injected (0-100).
-                              format: int32
-                              type: integer
-                            percentage:
-                              description: Percentage of requests on which the delay will be injected.
-                              properties:
-                                value:
-                                  format: double
-                                  type: number
-                              type: object
-                          type: object
-                      type: object
-                    headers:
-                      properties:
-                        request:
-                          properties:
-                            add:
-                              additionalProperties:
-                                format: string
-                                type: string
-                              type: object
-                            remove:
-                              items:
-                                format: string
-                                type: string
-                              type: array
-                            set:
-                              additionalProperties:
-                                format: string
-                                type: string
-                              type: object
-                          type: object
-                        response:
-                          properties:
-                            add:
-                              additionalProperties:
-                                format: string
-                                type: string
-                              type: object
-                            remove:
-                              items:
-                                format: string
-                                type: string
-                              type: array
-                            set:
-                              additionalProperties:
-                                format: string
-                                type: string
-                              type: object
-                          type: object
-                      type: object
-                    match:
-                      items:
-                        properties:
-                          authority:
-                            oneOf:
-                            - not:
-                                anyOf:
-                                - required:
-                                  - exact
-                                - required:
-                                  - prefix
-                                - required:
-                                  - regex
-                            - required:
-                              - exact
-                            - required:
-                              - prefix
-                            - required:
-                              - regex
-                            properties:
-                              exact:
-                                format: string
-                                type: string
-                              prefix:
-                                format: string
-                                type: string
-                              regex:
-                                description: RE2 style regex-based match (https://github.com/google/re2/wiki/Syntax).
-                                format: string
-                                type: string
-                            type: object
-                          gateways:
-                            description: Names of gateways where the rule should be applied.
-                            items:
-                              format: string
-                              type: string
-                            type: array
-                          headers:
-                            additionalProperties:
-                              oneOf:
-                              - not:
-                                  anyOf:
-                                  - required:
-                                    - exact
-                                  - required:
-                                    - prefix
-                                  - required:
-                                    - regex
-                              - required:
-                                - exact
-                              - required:
-                                - prefix
-                              - required:
-                                - regex
-                              properties:
-                                exact:
-                                  format: string
-                                  type: string
-                                prefix:
-                                  format: string
-                                  type: string
-                                regex:
-                                  description: RE2 style regex-based match (https://github.com/google/re2/wiki/Syntax).
-                                  format: string
-                                  type: string
-                              type: object
-                            type: object
-                          ignoreUriCase:
-                            description: Flag to specify whether the URI matching should be case-insensitive.
-                            type: boolean
-                          method:
-                            oneOf:
-                            - not:
-                                anyOf:
-                                - required:
-                                  - exact
-                                - required:
-                                  - prefix
-                                - required:
-                                  - regex
-                            - required:
-                              - exact
-                            - required:
-                              - prefix
-                            - required:
-                              - regex
-                            properties:
-                              exact:
-                                format: string
-                                type: string
-                              prefix:
-                                format: string
-                                type: string
-                              regex:
-                                description: RE2 style regex-based match (https://github.com/google/re2/wiki/Syntax).
-                                format: string
-                                type: string
-                            type: object
-                          name:
-                            description: The name assigned to a match.
-                            format: string
-                            type: string
-                          port:
-                            description: Specifies the ports on the host that is being addressed.
-                            type: integer
-                          queryParams:
-                            additionalProperties:
-                              oneOf:
-                              - not:
-                                  anyOf:
-                                  - required:
-                                    - exact
-                                  - required:
-                                    - prefix
-                                  - required:
-                                    - regex
-                              - required:
-                                - exact
-                              - required:
-                                - prefix
-                              - required:
-                                - regex
-                              properties:
-                                exact:
-                                  format: string
-                                  type: string
-                                prefix:
-                                  format: string
-                                  type: string
-                                regex:
-                                  description: RE2 style regex-based match (https://github.com/google/re2/wiki/Syntax).
-                                  format: string
-                                  type: string
-                              type: object
-                            description: Query parameters for matching.
-                            type: object
-                          scheme:
-                            oneOf:
-                            - not:
-                                anyOf:
-                                - required:
-                                  - exact
-                                - required:
-                                  - prefix
-                                - required:
-                                  - regex
-                            - required:
-                              - exact
-                            - required:
-                              - prefix
-                            - required:
-                              - regex
-                            properties:
-                              exact:
-                                format: string
-                                type: string
-                              prefix:
-                                format: string
-                                type: string
-                              regex:
-                                description: RE2 style regex-based match (https://github.com/google/re2/wiki/Syntax).
-                                format: string
-                                type: string
-                            type: object
-                          sourceLabels:
-                            additionalProperties:
-                              format: string
-                              type: string
-                            type: object
-                          sourceNamespace:
-                            description: Source namespace constraining the applicability of a rule to workloads in that namespace.
-                            format: string
-                            type: string
-                          uri:
-                            oneOf:
-                            - not:
-                                anyOf:
-                                - required:
-                                  - exact
-                                - required:
-                                  - prefix
-                                - required:
-                                  - regex
-                            - required:
-                              - exact
-                            - required:
-                              - prefix
-                            - required:
-                              - regex
-                            properties:
-                              exact:
-                                format: string
-                                type: string
-                              prefix:
-                                format: string
-                                type: string
-                              regex:
-                                description: RE2 style regex-based match (https://github.com/google/re2/wiki/Syntax).
-                                format: string
-                                type: string
-                            type: object
-                          withoutHeaders:
-                            additionalProperties:
-                              oneOf:
-                              - not:
-                                  anyOf:
-                                  - required:
-                                    - exact
-                                  - required:
-                                    - prefix
-                                  - required:
-                                    - regex
-                              - required:
-                                - exact
-                              - required:
-                                - prefix
-                              - required:
-                                - regex
-                              properties:
-                                exact:
-                                  format: string
-                                  type: string
-                                prefix:
-                                  format: string
-                                  type: string
-                                regex:
-                                  description: RE2 style regex-based match (https://github.com/google/re2/wiki/Syntax).
-                                  format: string
-                                  type: string
-                              type: object
-                            description: withoutHeader has the same syntax with the header, but has opposite meaning.
-                            type: object
-                        type: object
-                      type: array
-                    mirror:
-                      properties:
-                        host:
-                          description: The name of a service from the service registry.
-                          format: string
-                          type: string
-                        port:
-                          description: Specifies the port on the host that is being addressed.
-                          properties:
-                            number:
-                              type: integer
-                          type: object
-                        subset:
-                          description: The name of a subset within the service.
-                          format: string
-                          type: string
-                      type: object
-                    mirror_percent:
-                      description: Percentage of the traffic to be mirrored by the `mirror` field.
-                      nullable: true
-                      type: integer
-                    mirrorPercent:
-                      description: Percentage of the traffic to be mirrored by the `mirror` field.
-                      nullable: true
-                      type: integer
-                    mirrorPercentage:
-                      description: Percentage of the traffic to be mirrored by the `mirror` field.
-                      properties:
-                        value:
-                          format: double
-                          type: number
-                      type: object
-                    name:
-                      description: The name assigned to the route for debugging purposes.
-                      format: string
-                      type: string
-                    redirect:
-                      description: A HTTP rule can either redirect or forward (default) traffic.
-                      properties:
-                        authority:
-                          format: string
-                          type: string
-                        redirectCode:
-                          type: integer
-                        uri:
-                          format: string
-                          type: string
-                      type: object
-                    retries:
-                      description: Retry policy for HTTP requests.
-                      properties:
-                        attempts:
-                          description: Number of retries for a given request.
-                          format: int32
-                          type: integer
-                        perTryTimeout:
-                          description: Timeout per retry attempt for a given request.
-                          type: string
-                        retryOn:
-                          description: Specifies the conditions under which retry takes place.
-                          format: string
-                          type: string
-                        retryRemoteLocalities:
-                          description: Flag to specify whether the retries should retry to other localities.
-                          nullable: true
-                          type: boolean
-                      type: object
-                    rewrite:
-                      description: Rewrite HTTP URIs and Authority headers.
-                      properties:
-                        authority:
-                          description: rewrite the Authority/Host header with this value.
-                          format: string
-                          type: string
-                        uri:
-                          format: string
-                          type: string
-                      type: object
-                    route:
-                      description: A HTTP rule can either redirect or forward (default) traffic.
-                      items:
-                        properties:
-                          destination:
-                            properties:
-                              host:
-                                description: The name of a service from the service registry.
-                                format: string
-                                type: string
-                              port:
-                                description: Specifies the port on the host that is being addressed.
-                                properties:
-                                  number:
-                                    type: integer
-                                type: object
-                              subset:
-                                description: The name of a subset within the service.
-                                format: string
-                                type: string
-                            type: object
-                          headers:
-                            properties:
-                              request:
-                                properties:
-                                  add:
-                                    additionalProperties:
-                                      format: string
-                                      type: string
-                                    type: object
-                                  remove:
-                                    items:
-                                      format: string
-                                      type: string
-                                    type: array
-                                  set:
-                                    additionalProperties:
-                                      format: string
-                                      type: string
-                                    type: object
-                                type: object
-                              response:
-                                properties:
-                                  add:
-                                    additionalProperties:
-                                      format: string
-                                      type: string
-                                    type: object
-                                  remove:
-                                    items:
-                                      format: string
-                                      type: string
-                                    type: array
-                                  set:
-                                    additionalProperties:
-                                      format: string
-                                      type: string
-                                    type: object
-                                type: object
-                            type: object
-                          weight:
-                            format: int32
-                            type: integer
-                        type: object
-                      type: array
-                    timeout:
-                      description: Timeout for HTTP requests, default is disabled.
-                      type: string
-                  type: object
-                type: array
-              tcp:
-                description: An ordered list of route rules for opaque TCP traffic.
-                items:
-                  properties:
-                    match:
-                      items:
-                        properties:
-                          destinationSubnets:
-                            description: IPv4 or IPv6 ip addresses of destination with optional subnet.
-                            items:
-                              format: string
-                              type: string
-                            type: array
-                          gateways:
-                            description: Names of gateways where the rule should be applied.
-                            items:
-                              format: string
-                              type: string
-                            type: array
-                          port:
-                            description: Specifies the port on the host that is being addressed.
-                            type: integer
-                          sourceLabels:
-                            additionalProperties:
-                              format: string
-                              type: string
-                            type: object
-                          sourceNamespace:
-                            description: Source namespace constraining the applicability of a rule to workloads in that namespace.
-                            format: string
-                            type: string
-                          sourceSubnet:
-                            description: IPv4 or IPv6 ip address of source with optional subnet.
-                            format: string
-                            type: string
-                        type: object
-                      type: array
-                    route:
-                      description: The destination to which the connection should be forwarded to.
-                      items:
-                        properties:
-                          destination:
-                            properties:
-                              host:
-                                description: The name of a service from the service registry.
-                                format: string
-                                type: string
-                              port:
-                                description: Specifies the port on the host that is being addressed.
-                                properties:
-                                  number:
-                                    type: integer
-                                type: object
-                              subset:
-                                description: The name of a subset within the service.
-                                format: string
-                                type: string
-                            type: object
-                          weight:
-                            format: int32
-                            type: integer
-                        type: object
-                      type: array
-                  type: object
-                type: array
-              tls:
-                items:
-                  properties:
-                    match:
-                      items:
-                        properties:
-                          destinationSubnets:
-                            description: IPv4 or IPv6 ip addresses of destination with optional subnet.
-                            items:
-                              format: string
-                              type: string
-                            type: array
-                          gateways:
-                            description: Names of gateways where the rule should be applied.
-                            items:
-                              format: string
-                              type: string
-                            type: array
-                          port:
-                            description: Specifies the port on the host that is being addressed.
-                            type: integer
-                          sniHosts:
-                            description: SNI (server name indicator) to match on.
-                            items:
-                              format: string
-                              type: string
-                            type: array
-                          sourceLabels:
-                            additionalProperties:
-                              format: string
-                              type: string
-                            type: object
-                          sourceNamespace:
-                            description: Source namespace constraining the applicability of a rule to workloads in that namespace.
-                            format: string
-                            type: string
-                        type: object
-                      type: array
-                    route:
-                      description: The destination to which the connection should be forwarded to.
-                      items:
-                        properties:
-                          destination:
-                            properties:
-                              host:
-                                description: The name of a service from the service registry.
-                                format: string
-                                type: string
-                              port:
-                                description: Specifies the port on the host that is being addressed.
-                                properties:
-                                  number:
-                                    type: integer
-                                type: object
-                              subset:
-                                description: The name of a subset within the service.
-                                format: string
-                                type: string
-                            type: object
-                          weight:
-                            format: int32
-                            type: integer
-                        type: object
-                      type: array
-                  type: object
-                type: array
-            type: object
-          status:
-            type: object
-            x-kubernetes-preserve-unknown-fields: true
-        type: object
+  - name: v1beta1
     served: true
     storage: false
-    subresources:
-      status: {}
 ---
-apiVersion: apiextensions.k8s.io/v1
+apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   annotations:
@@ -6280,11 +3222,24 @@ metadata:
   labels:
     app: istio-pilot
     chart: istio
-    cloudfoundry.org/istio_version: 1.7.3
+    cloudfoundry.org/istio_version: 1.8.4
     heritage: Tiller
     release: istio
   name: workloadentries.networking.istio.io
 spec:
+  additionalPrinterColumns:
+  - JSONPath: .metadata.creationTimestamp
+    description: 'CreationTimestamp is a timestamp representing the server time when
+      this object was created. It is not guaranteed to be set in happens-before order
+      across separate operations. Clients may not set this value. It is represented
+      in RFC3339 form and is in UTC. Populated by the system. Read-only. Null for
+      lists. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata'
+    name: Age
+    type: date
+  - JSONPath: .spec.address
+    description: Address associated with the network endpoint.
+    name: Address
+    type: string
   group: networking.istio.io
   names:
     categories:
@@ -6296,120 +3251,257 @@ spec:
     shortNames:
     - we
     singular: workloadentry
+  preserveUnknownFields: false
   scope: Namespaced
-  versions:
-  - additionalPrinterColumns:
-    - description: 'CreationTimestamp is a timestamp representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations. Clients may not set this value. It is represented in RFC3339 form and is in UTC. Populated by the system. Read-only. Null for lists. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata'
-      jsonPath: .metadata.creationTimestamp
-      name: Age
-      type: date
-    - description: Address associated with the network endpoint.
-      jsonPath: .spec.address
-      name: Address
-      type: string
-    name: v1alpha3
-    schema:
-      openAPIV3Schema:
-        properties:
-          spec:
-            description: 'Configuration affecting VMs onboarded into the mesh. See more details at: https://istio.io/docs/reference/config/networking/workload-entry.html'
-            properties:
-              address:
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      properties:
+        spec:
+          description: 'Configuration affecting VMs onboarded into the mesh. See more
+            details at: https://istio.io/docs/reference/config/networking/workload-entry.html'
+          properties:
+            address:
+              format: string
+              type: string
+            labels:
+              additionalProperties:
                 format: string
                 type: string
-              labels:
-                additionalProperties:
-                  format: string
-                  type: string
-                description: One or more labels associated with the endpoint.
-                type: object
-              locality:
-                description: The locality associated with the endpoint.
-                format: string
-                type: string
-              network:
-                format: string
-                type: string
-              ports:
-                additionalProperties:
-                  type: integer
-                description: Set of ports associated with the endpoint.
-                type: object
-              serviceAccount:
-                format: string
-                type: string
-              weight:
-                description: The load balancing weight associated with the endpoint.
+              description: One or more labels associated with the endpoint.
+              type: object
+            locality:
+              description: The locality associated with the endpoint.
+              format: string
+              type: string
+            network:
+              format: string
+              type: string
+            ports:
+              additionalProperties:
                 type: integer
-            type: object
-          status:
-            type: object
-            x-kubernetes-preserve-unknown-fields: true
-        type: object
+              description: Set of ports associated with the endpoint.
+              type: object
+            serviceAccount:
+              format: string
+              type: string
+            weight:
+              description: The load balancing weight associated with the endpoint.
+              type: integer
+          type: object
+        status:
+          type: object
+          x-kubernetes-preserve-unknown-fields: true
+      type: object
+  versions:
+  - name: v1alpha3
     served: true
     storage: true
-    subresources:
-      status: {}
-  - additionalPrinterColumns:
-    - description: 'CreationTimestamp is a timestamp representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations. Clients may not set this value. It is represented in RFC3339 form and is in UTC. Populated by the system. Read-only. Null for lists. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata'
-      jsonPath: .metadata.creationTimestamp
-      name: Age
-      type: date
-    - description: Address associated with the network endpoint.
-      jsonPath: .spec.address
-      name: Address
-      type: string
-    name: v1beta1
-    schema:
-      openAPIV3Schema:
-        properties:
-          spec:
-            description: 'Configuration affecting VMs onboarded into the mesh. See more details at: https://istio.io/docs/reference/config/networking/workload-entry.html'
-            properties:
-              address:
-                format: string
-                type: string
-              labels:
-                additionalProperties:
-                  format: string
-                  type: string
-                description: One or more labels associated with the endpoint.
-                type: object
-              locality:
-                description: The locality associated with the endpoint.
-                format: string
-                type: string
-              network:
-                format: string
-                type: string
-              ports:
-                additionalProperties:
-                  type: integer
-                description: Set of ports associated with the endpoint.
-                type: object
-              serviceAccount:
-                format: string
-                type: string
-              weight:
-                description: The load balancing weight associated with the endpoint.
-                type: integer
-            type: object
-          status:
-            type: object
-            x-kubernetes-preserve-unknown-fields: true
-        type: object
+  - name: v1beta1
     served: true
     storage: false
-    subresources:
-      status: {}
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  labels:
+    app: istio-pilot
+    chart: istio
+    cloudfoundry.org/istio_version: 1.8.4
+    heritage: Tiller
+    release: istio
+  name: workloadgroups.networking.istio.io
+spec:
+  additionalPrinterColumns:
+  - JSONPath: .metadata.creationTimestamp
+    description: 'CreationTimestamp is a timestamp representing the server time when
+      this object was created. It is not guaranteed to be set in happens-before order
+      across separate operations. Clients may not set this value. It is represented
+      in RFC3339 form and is in UTC. Populated by the system. Read-only. Null for
+      lists. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata'
+    name: Age
+    type: date
+  group: networking.istio.io
+  names:
+    categories:
+    - istio-io
+    - networking-istio-io
+    kind: WorkloadGroup
+    listKind: WorkloadGroupList
+    plural: workloadgroups
+    shortNames:
+    - wg
+    singular: workloadgroup
+  preserveUnknownFields: false
+  scope: Namespaced
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      properties:
+        spec:
+          description: 'Describes a collection of workload instances. See more details
+            at: https://istio.io/docs/reference/config/networking/workload-group.html'
+          properties:
+            metadata:
+              description: Metadata that will be used for all corresponding `WorkloadEntries`.
+              properties:
+                annotations:
+                  additionalProperties:
+                    format: string
+                    type: string
+                  type: object
+                labels:
+                  additionalProperties:
+                    format: string
+                    type: string
+                  type: object
+              type: object
+            probe:
+              description: '`ReadinessProbe` describes the configuration the user
+                must provide for healthchecking on their workload.'
+              oneOf:
+              - not:
+                  anyOf:
+                  - required:
+                    - httpGet
+                  - required:
+                    - tcpSocket
+                  - required:
+                    - exec
+              - required:
+                - httpGet
+              - required:
+                - tcpSocket
+              - required:
+                - exec
+              properties:
+                exec:
+                  description: health is determined by how the command that is executed
+                    exited.
+                  properties:
+                    command:
+                      description: command to run.
+                      items:
+                        format: string
+                        type: string
+                      type: array
+                  type: object
+                failureThreshold:
+                  description: Minimum consecutive failures for the probe to be considered
+                    failed after having succeeded.
+                  format: int32
+                  type: integer
+                httpGet:
+                  properties:
+                    host:
+                      description: Host name to connect to, defaults to the pod IP.
+                      format: string
+                      type: string
+                    httpHeaders:
+                      description: headers the proxy will pass on to make the request.
+                      items:
+                        properties:
+                          name:
+                            format: string
+                            type: string
+                          value:
+                            format: string
+                            type: string
+                        type: object
+                      type: array
+                    path:
+                      description: Path to access on the HTTP server.
+                      format: string
+                      type: string
+                    port:
+                      description: port on which the endpoint lives.
+                      type: integer
+                    scheme:
+                      format: string
+                      type: string
+                  type: object
+                initialDelaySeconds:
+                  description: Number of seconds after the container has started before
+                    readiness probes are initiated.
+                  format: int32
+                  type: integer
+                periodSeconds:
+                  description: How often (in seconds) to perform the probe.
+                  format: int32
+                  type: integer
+                successThreshold:
+                  description: Minimum consecutive successes for the probe to be considered
+                    successful after having failed.
+                  format: int32
+                  type: integer
+                tcpSocket:
+                  description: health is determined by if the proxy is able to connect.
+                  properties:
+                    host:
+                      format: string
+                      type: string
+                    port:
+                      type: integer
+                  type: object
+                timeoutSeconds:
+                  description: Number of seconds after which the probe times out.
+                  format: int32
+                  type: integer
+              type: object
+            template:
+              description: Template to be used for the generation of `WorkloadEntry`
+                resources that belong to this `WorkloadGroup`.
+              properties:
+                address:
+                  format: string
+                  type: string
+                labels:
+                  additionalProperties:
+                    format: string
+                    type: string
+                  description: One or more labels associated with the endpoint.
+                  type: object
+                locality:
+                  description: The locality associated with the endpoint.
+                  format: string
+                  type: string
+                network:
+                  format: string
+                  type: string
+                ports:
+                  additionalProperties:
+                    type: integer
+                  description: Set of ports associated with the endpoint.
+                  type: object
+                serviceAccount:
+                  format: string
+                  type: string
+                weight:
+                  description: The load balancing weight associated with the endpoint.
+                  type: integer
+              type: object
+          type: object
+        status:
+          type: object
+          x-kubernetes-preserve-unknown-fields: true
+      type: object
+  versions:
+  - name: v1alpha3
+    served: true
+    storage: true
 ---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   labels:
     app: istio-ingressgateway
-    cloudfoundry.org/istio_version: 1.7.3
+    cloudfoundry.org/istio_version: 1.8.4
+    install.operator.istio.io/owning-resource: unknown
     istio: ingressgateway
+    istio.io/rev: default
+    operator.istio.io/component: IngressGateways
     release: istio
   name: istio-ingressgateway-service-account
   namespace: istio-system
@@ -6419,7 +3511,7 @@ kind: ServiceAccount
 metadata:
   labels:
     app: istio-reader
-    cloudfoundry.org/istio_version: 1.7.3
+    cloudfoundry.org/istio_version: 1.8.4
     release: istio
   name: istio-reader-service-account
   namespace: istio-system
@@ -6429,7 +3521,7 @@ kind: ServiceAccount
 metadata:
   labels:
     app: istiod
-    cloudfoundry.org/istio_version: 1.7.3
+    cloudfoundry.org/istio_version: 1.8.4
     release: istio
   name: istiod-service-account
   namespace: istio-system
@@ -6439,7 +3531,7 @@ kind: ClusterRole
 metadata:
   labels:
     app: istio-reader
-    cloudfoundry.org/istio_version: 1.7.3
+    cloudfoundry.org/istio_version: 1.8.4
     release: istio
   name: istio-reader-istio-system
 rules:
@@ -6448,6 +3540,7 @@ rules:
   - security.istio.io
   - networking.istio.io
   - authentication.istio.io
+  - rbac.istio.io
   resources:
   - '*'
   verbs:
@@ -6463,6 +3556,15 @@ rules:
   - nodes
   - replicationcontrollers
   - namespaces
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - discovery.k8s.io
+  resources:
+  - endpointslices
   verbs:
   - get
   - list
@@ -6475,13 +3577,25 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - authentication.k8s.io
+  resources:
+  - tokenreviews
+  verbs:
+  - create
+- apiGroups:
+  - authorization.k8s.io
+  resources:
+  - subjectaccessreviews
+  verbs:
+  - create
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
     app: istiod
-    cloudfoundry.org/istio_version: 1.7.3
+    cloudfoundry.org/istio_version: 1.8.4
     release: istio
   name: istiod-istio-system
 rules:
@@ -6508,12 +3622,37 @@ rules:
   - security.istio.io
   - networking.istio.io
   - authentication.istio.io
+  - rbac.istio.io
   resources:
   - '*'
   verbs:
   - get
   - watch
   - list
+- apiGroups:
+  - networking.istio.io
+  resources:
+  - workloadentries
+  verbs:
+  - get
+  - watch
+  - list
+  - update
+  - patch
+  - create
+  - delete
+- apiGroups:
+  - networking.istio.io
+  resources:
+  - workloadentries/status
+  verbs:
+  - get
+  - watch
+  - list
+  - update
+  - patch
+  - create
+  - delete
 - apiGroups:
   - apiextensions.k8s.io
   resources:
@@ -6594,6 +3733,12 @@ rules:
   verbs:
   - create
 - apiGroups:
+  - authorization.k8s.io
+  resources:
+  - subjectaccessreviews
+  verbs:
+  - create
+- apiGroups:
   - networking.x-k8s.io
   resources:
   - '*'
@@ -6615,7 +3760,7 @@ kind: ClusterRoleBinding
 metadata:
   labels:
     app: istio-reader
-    cloudfoundry.org/istio_version: 1.7.3
+    cloudfoundry.org/istio_version: 1.8.4
     release: istio
   name: istio-reader-istio-system
 roleRef:
@@ -6631,10 +3776,10 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
-    app: pilot
-    cloudfoundry.org/istio_version: 1.7.3
+    app: istiod
+    cloudfoundry.org/istio_version: 1.8.4
     release: istio
-  name: istiod-pilot-istio-system
+  name: istiod-istio-system
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -6649,7 +3794,7 @@ kind: ValidatingWebhookConfiguration
 metadata:
   labels:
     app: istiod
-    cloudfoundry.org/istio_version: 1.7.3
+    cloudfoundry.org/istio_version: 1.8.4
     istio: istiod
     release: istio
   name: istiod-istio-system
@@ -6667,9 +3812,7 @@ webhooks:
   name: validation.istio.io
   rules:
   - apiGroups:
-    - config.istio.io
     - security.istio.io
-    - authentication.istio.io
     - networking.istio.io
     apiVersions:
     - '*'
@@ -6684,8 +3827,10 @@ apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:
   labels:
-    cloudfoundry.org/istio_version: 1.7.3
+    cloudfoundry.org/istio_version: 1.8.4
+    install.operator.istio.io/owning-resource: unknown
     istio.io/rev: default
+    operator.istio.io/component: Pilot
   name: metadata-exchange-1.6
   namespace: istio-system
 spec:
@@ -6720,8 +3865,10 @@ apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:
   labels:
-    cloudfoundry.org/istio_version: 1.7.3
+    cloudfoundry.org/istio_version: 1.8.4
+    install.operator.istio.io/owning-resource: unknown
     istio.io/rev: default
+    operator.istio.io/component: Pilot
   name: metadata-exchange-1.7
   namespace: istio-system
 spec:
@@ -6812,7 +3959,101 @@ apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:
   labels:
-    cloudfoundry.org/istio_version: 1.7.3
+    cloudfoundry.org/istio_version: 1.8.4
+    install.operator.istio.io/owning-resource: unknown
+    istio.io/rev: default
+    operator.istio.io/component: Pilot
+  name: metadata-exchange-1.8
+  namespace: istio-system
+spec:
+  configPatches:
+  - applyTo: HTTP_FILTER
+    match:
+      context: SIDECAR_INBOUND
+      listener:
+        filterChain:
+          filter:
+            name: envoy.http_connection_manager
+      proxy:
+        proxyVersion: ^1\.8.*
+    patch:
+      operation: INSERT_BEFORE
+      value:
+        name: istio.metadata_exchange
+        typed_config:
+          '@type': type.googleapis.com/udpa.type.v1.TypedStruct
+          type_url: type.googleapis.com/envoy.extensions.filters.http.wasm.v3.Wasm
+          value:
+            config:
+              configuration:
+                '@type': type.googleapis.com/google.protobuf.StringValue
+                value: |
+                  {}
+              vm_config:
+                code:
+                  local:
+                    inline_string: envoy.wasm.metadata_exchange
+                runtime: envoy.wasm.runtime.null
+  - applyTo: HTTP_FILTER
+    match:
+      context: SIDECAR_OUTBOUND
+      listener:
+        filterChain:
+          filter:
+            name: envoy.http_connection_manager
+      proxy:
+        proxyVersion: ^1\.8.*
+    patch:
+      operation: INSERT_BEFORE
+      value:
+        name: istio.metadata_exchange
+        typed_config:
+          '@type': type.googleapis.com/udpa.type.v1.TypedStruct
+          type_url: type.googleapis.com/envoy.extensions.filters.http.wasm.v3.Wasm
+          value:
+            config:
+              configuration:
+                '@type': type.googleapis.com/google.protobuf.StringValue
+                value: |
+                  {}
+              vm_config:
+                code:
+                  local:
+                    inline_string: envoy.wasm.metadata_exchange
+                runtime: envoy.wasm.runtime.null
+  - applyTo: HTTP_FILTER
+    match:
+      context: GATEWAY
+      listener:
+        filterChain:
+          filter:
+            name: envoy.http_connection_manager
+      proxy:
+        proxyVersion: ^1\.8.*
+    patch:
+      operation: INSERT_BEFORE
+      value:
+        name: istio.metadata_exchange
+        typed_config:
+          '@type': type.googleapis.com/udpa.type.v1.TypedStruct
+          type_url: type.googleapis.com/envoy.extensions.filters.http.wasm.v3.Wasm
+          value:
+            config:
+              configuration:
+                '@type': type.googleapis.com/google.protobuf.StringValue
+                value: |
+                  {}
+              vm_config:
+                code:
+                  local:
+                    inline_string: envoy.wasm.metadata_exchange
+                runtime: envoy.wasm.runtime.null
+---
+apiVersion: networking.istio.io/v1alpha3
+kind: EnvoyFilter
+metadata:
+  labels:
+    cloudfoundry.org/istio_version: 1.8.4
     istio.io/rev: default
   name: stats-filter-1.6
   namespace: istio-system
@@ -6920,7 +4161,7 @@ apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:
   labels:
-    cloudfoundry.org/istio_version: 1.7.3
+    cloudfoundry.org/istio_version: 1.8.4
     istio.io/rev: default
   name: stats-filter-1.7
   namespace: istio-system
@@ -7034,7 +4275,115 @@ apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:
   labels:
-    cloudfoundry.org/istio_version: 1.7.3
+    cloudfoundry.org/istio_version: 1.8.4
+    istio.io/rev: default
+  name: stats-filter-1.8
+  namespace: istio-system
+spec:
+  configPatches:
+  - applyTo: HTTP_FILTER
+    match:
+      context: SIDECAR_OUTBOUND
+      listener:
+        filterChain:
+          filter:
+            name: envoy.http_connection_manager
+            subFilter:
+              name: envoy.router
+      proxy:
+        proxyVersion: ^1\.8.*
+    patch:
+      operation: INSERT_BEFORE
+      value:
+        name: istio.stats
+        typed_config:
+          '@type': type.googleapis.com/udpa.type.v1.TypedStruct
+          type_url: type.googleapis.com/envoy.extensions.filters.http.wasm.v3.Wasm
+          value:
+            config:
+              configuration:
+                '@type': type.googleapis.com/google.protobuf.StringValue
+                value: |
+                  {
+                  }
+              root_id: stats_outbound
+              vm_config:
+                code:
+                  local:
+                    inline_string: envoy.wasm.stats
+                runtime: envoy.wasm.runtime.null
+                vm_id: stats_outbound
+  - applyTo: HTTP_FILTER
+    match:
+      context: SIDECAR_INBOUND
+      listener:
+        filterChain:
+          filter:
+            name: envoy.http_connection_manager
+            subFilter:
+              name: envoy.router
+      proxy:
+        proxyVersion: ^1\.8.*
+    patch:
+      operation: INSERT_BEFORE
+      value:
+        name: istio.stats
+        typed_config:
+          '@type': type.googleapis.com/udpa.type.v1.TypedStruct
+          type_url: type.googleapis.com/envoy.extensions.filters.http.wasm.v3.Wasm
+          value:
+            config:
+              configuration:
+                '@type': type.googleapis.com/google.protobuf.StringValue
+                value: |
+                  {
+                  }
+              root_id: stats_inbound
+              vm_config:
+                code:
+                  local:
+                    inline_string: envoy.wasm.stats
+                runtime: envoy.wasm.runtime.null
+                vm_id: stats_inbound
+  - applyTo: HTTP_FILTER
+    match:
+      context: GATEWAY
+      listener:
+        filterChain:
+          filter:
+            name: envoy.http_connection_manager
+            subFilter:
+              name: envoy.router
+      proxy:
+        proxyVersion: ^1\.8.*
+    patch:
+      operation: INSERT_BEFORE
+      value:
+        name: istio.stats
+        typed_config:
+          '@type': type.googleapis.com/udpa.type.v1.TypedStruct
+          type_url: type.googleapis.com/envoy.extensions.filters.http.wasm.v3.Wasm
+          value:
+            config:
+              configuration:
+                '@type': type.googleapis.com/google.protobuf.StringValue
+                value: |
+                  {
+                    "disable_host_header_fallback": true
+                  }
+              root_id: stats_outbound
+              vm_config:
+                code:
+                  local:
+                    inline_string: envoy.wasm.stats
+                runtime: envoy.wasm.runtime.null
+                vm_id: stats_outbound
+---
+apiVersion: networking.istio.io/v1alpha3
+kind: EnvoyFilter
+metadata:
+  labels:
+    cloudfoundry.org/istio_version: 1.8.4
     istio.io/rev: default
   name: tcp-metadata-exchange-1.6
   namespace: istio-system
@@ -7092,7 +4441,7 @@ apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:
   labels:
-    cloudfoundry.org/istio_version: 1.7.3
+    cloudfoundry.org/istio_version: 1.8.4
     istio.io/rev: default
   name: tcp-metadata-exchange-1.7
   namespace: istio-system
@@ -7150,7 +4499,65 @@ apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:
   labels:
-    cloudfoundry.org/istio_version: 1.7.3
+    cloudfoundry.org/istio_version: 1.8.4
+    istio.io/rev: default
+  name: tcp-metadata-exchange-1.8
+  namespace: istio-system
+spec:
+  configPatches:
+  - applyTo: NETWORK_FILTER
+    match:
+      context: SIDECAR_INBOUND
+      listener: {}
+      proxy:
+        proxyVersion: ^1\.8.*
+    patch:
+      operation: INSERT_BEFORE
+      value:
+        name: istio.metadata_exchange
+        typed_config:
+          '@type': type.googleapis.com/udpa.type.v1.TypedStruct
+          type_url: type.googleapis.com/envoy.tcp.metadataexchange.config.MetadataExchange
+          value:
+            protocol: istio-peer-exchange
+  - applyTo: CLUSTER
+    match:
+      cluster: {}
+      context: SIDECAR_OUTBOUND
+      proxy:
+        proxyVersion: ^1\.8.*
+    patch:
+      operation: MERGE
+      value:
+        filters:
+        - name: istio.metadata_exchange
+          typed_config:
+            '@type': type.googleapis.com/udpa.type.v1.TypedStruct
+            type_url: type.googleapis.com/envoy.tcp.metadataexchange.config.MetadataExchange
+            value:
+              protocol: istio-peer-exchange
+  - applyTo: CLUSTER
+    match:
+      cluster: {}
+      context: GATEWAY
+      proxy:
+        proxyVersion: ^1\.8.*
+    patch:
+      operation: MERGE
+      value:
+        filters:
+        - name: istio.metadata_exchange
+          typed_config:
+            '@type': type.googleapis.com/udpa.type.v1.TypedStruct
+            type_url: type.googleapis.com/envoy.tcp.metadataexchange.config.MetadataExchange
+            value:
+              protocol: istio-peer-exchange
+---
+apiVersion: networking.istio.io/v1alpha3
+kind: EnvoyFilter
+metadata:
+  labels:
+    cloudfoundry.org/istio_version: 1.8.4
     istio.io/rev: default
   name: tcp-stats-filter-1.6
   namespace: istio-system
@@ -7251,7 +4658,7 @@ apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:
   labels:
-    cloudfoundry.org/istio_version: 1.7.3
+    cloudfoundry.org/istio_version: 1.8.4
     istio.io/rev: default
   name: tcp-stats-filter-1.7
   namespace: istio-system
@@ -7354,6 +4761,107 @@ spec:
                 runtime: envoy.wasm.runtime.null
                 vm_id: tcp_stats_outbound
 ---
+apiVersion: networking.istio.io/v1alpha3
+kind: EnvoyFilter
+metadata:
+  labels:
+    cloudfoundry.org/istio_version: 1.8.4
+    istio.io/rev: default
+  name: tcp-stats-filter-1.8
+  namespace: istio-system
+spec:
+  configPatches:
+  - applyTo: NETWORK_FILTER
+    match:
+      context: SIDECAR_INBOUND
+      listener:
+        filterChain:
+          filter:
+            name: envoy.tcp_proxy
+      proxy:
+        proxyVersion: ^1\.8.*
+    patch:
+      operation: INSERT_BEFORE
+      value:
+        name: istio.stats
+        typed_config:
+          '@type': type.googleapis.com/udpa.type.v1.TypedStruct
+          type_url: type.googleapis.com/envoy.extensions.filters.network.wasm.v3.Wasm
+          value:
+            config:
+              configuration:
+                '@type': type.googleapis.com/google.protobuf.StringValue
+                value: |
+                  {
+                  }
+              root_id: stats_inbound
+              vm_config:
+                code:
+                  local:
+                    inline_string: envoy.wasm.stats
+                runtime: envoy.wasm.runtime.null
+                vm_id: tcp_stats_inbound
+  - applyTo: NETWORK_FILTER
+    match:
+      context: SIDECAR_OUTBOUND
+      listener:
+        filterChain:
+          filter:
+            name: envoy.tcp_proxy
+      proxy:
+        proxyVersion: ^1\.8.*
+    patch:
+      operation: INSERT_BEFORE
+      value:
+        name: istio.stats
+        typed_config:
+          '@type': type.googleapis.com/udpa.type.v1.TypedStruct
+          type_url: type.googleapis.com/envoy.extensions.filters.network.wasm.v3.Wasm
+          value:
+            config:
+              configuration:
+                '@type': type.googleapis.com/google.protobuf.StringValue
+                value: |
+                  {
+                  }
+              root_id: stats_outbound
+              vm_config:
+                code:
+                  local:
+                    inline_string: envoy.wasm.stats
+                runtime: envoy.wasm.runtime.null
+                vm_id: tcp_stats_outbound
+  - applyTo: NETWORK_FILTER
+    match:
+      context: GATEWAY
+      listener:
+        filterChain:
+          filter:
+            name: envoy.tcp_proxy
+      proxy:
+        proxyVersion: ^1\.8.*
+    patch:
+      operation: INSERT_BEFORE
+      value:
+        name: istio.stats
+        typed_config:
+          '@type': type.googleapis.com/udpa.type.v1.TypedStruct
+          type_url: type.googleapis.com/envoy.extensions.filters.network.wasm.v3.Wasm
+          value:
+            config:
+              configuration:
+                '@type': type.googleapis.com/google.protobuf.StringValue
+                value: |
+                  {
+                  }
+              root_id: stats_outbound
+              vm_config:
+                code:
+                  local:
+                    inline_string: envoy.wasm.stats
+                runtime: envoy.wasm.runtime.null
+                vm_id: tcp_stats_outbound
+---
 apiVersion: v1
 data:
   mesh: |-
@@ -7401,7 +4909,6 @@ data:
       tracing:
         zipkin:
           address: zipkin.istio-system:9411
-    disableMixerHttpReports: true
     enableAutoMtls: true
     enablePrometheusMerge: true
     rootNamespace: istio-system
@@ -7410,8 +4917,10 @@ data:
 kind: ConfigMap
 metadata:
   labels:
-    cloudfoundry.org/istio_version: 1.7.3
+    cloudfoundry.org/istio_version: 1.8.4
+    install.operator.istio.io/owning-resource: unknown
     istio.io/rev: default
+    operator.istio.io/component: Pilot
     release: istio
   name: istio
   namespace: istio-system
@@ -7427,6 +4936,7 @@ data:
     injectedAnnotations:
 
     template: |
+      {{- $holdProxy := or .ProxyConfig.HoldApplicationUntilProxyStarts.GetValue .Values.global.proxy.holdApplicationUntilProxyStarts }}
       rewriteAppHTTPProbe: {{ valueOrDefault .Values.sidecarInjectorWebhook.rewriteAppHTTPProbe false }}
       initContainers:
       {{ if ne (annotation .ObjectMeta `sidecar.istio.io/interceptionMode` .ProxyConfig.InterceptionMode) `NONE` }}
@@ -7443,11 +4953,11 @@ data:
         args:
         - istio-iptables
         - "-p"
-        - 15001
+        - "15001"
         - "-z"
         - "15006"
         - "-u"
-        - 1337
+        - "1337"
         - "-m"
         - "{{ annotation .ObjectMeta `sidecar.istio.io/interceptionMode` .ProxyConfig.InterceptionMode }}"
         - "-i"
@@ -7486,11 +4996,30 @@ data:
           value: "{{ $value }}"
         {{- end }}
       {{- end }}
-      {{- if .Values.global.proxy_init.resources }}
         resources:
-          {{ toYaml .Values.global.proxy_init.resources | indent 4 }}
+      {{- if or (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit`) }}
+        {{- if or (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory`) }}
+          requests:
+            {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU`) -}}
+            cpu: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyCPU` }}"
+            {{ end }}
+            {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory`) -}}
+            memory: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyMemory` }}"
+            {{ end }}
+        {{- end }}
+        {{- if or (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit`) (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit`) }}
+          limits:
+            {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit`) -}}
+            cpu: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyCPULimit` }}"
+            {{ end }}
+            {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit`) -}}
+            memory: "{{ index .ObjectMeta.Annotations `sidecar.istio.io/proxyMemoryLimit` }}"
+            {{ end }}
+        {{- end }}
       {{- else }}
-        resources: {}
+        {{- if .Values.global.proxy.resources }}
+          {{ toYaml .Values.global.proxy.resources | indent 4 }}
+        {{- end }}
       {{- end }}
         securityContext:
           allowPrivilegeEscalation: {{ .Values.global.proxy.privileged }}
@@ -7570,9 +5099,6 @@ data:
       {{- if .Values.global.sts.servicePort }}
         - --stsPort={{ .Values.global.sts.servicePort }}
       {{- end }}
-      {{- if .Values.global.trustDomain }}
-        - --trust-domain={{ .Values.global.trustDomain }}
-      {{- end }}
       {{- if .Values.global.logAsJson }}
         - --log_as_json
       {{- end }}
@@ -7583,7 +5109,7 @@ data:
       {{- if .Values.global.proxy.lifecycle }}
         lifecycle:
           {{ toYaml .Values.global.proxy.lifecycle | indent 4 }}
-      {{- else if .Values.global.proxy.holdApplicationUntilProxyStarts}}
+      {{- else if $holdProxy }}
         lifecycle:
           postStart:
             exec:
@@ -7663,7 +5189,7 @@ data:
         {{ end }}
         {{- if .DeploymentMeta.Name }}
         - name: ISTIO_META_WORKLOAD_NAME
-          value: {{ .DeploymentMeta.Name }}
+          value: "{{ .DeploymentMeta.Name }}"
         {{ end }}
         {{- if and .TypeMeta.APIVersion .DeploymentMeta.Name }}
         - name: ISTIO_META_OWNER
@@ -7676,9 +5202,13 @@ data:
         {{- if .Values.global.meshID }}
         - name: ISTIO_META_MESH_ID
           value: "{{ .Values.global.meshID }}"
-        {{- else if .Values.global.trustDomain }}
+        {{- else if (valueOrDefault .MeshConfig.TrustDomain .Values.global.trustDomain) }}
         - name: ISTIO_META_MESH_ID
-          value: "{{ .Values.global.trustDomain }}"
+          value: "{{ (valueOrDefault .MeshConfig.TrustDomain .Values.global.trustDomain) }}"
+        {{- end }}
+        {{- with (valueOrDefault .MeshConfig.TrustDomain .Values.global.trustDomain)  }}
+        - name: TRUST_DOMAIN
+          value: "{{ . }}"
         {{- end }}
         {{- if and (eq .Values.global.proxy.tracer "datadog") (isset .ObjectMeta.Annotations `apm.datadoghq.com/env`) }}
         {{- range $key, $value := fromJSON (index .ObjectMeta.Annotations `apm.datadoghq.com/env`) }}
@@ -7698,6 +5228,7 @@ data:
             port: 15021
           initialDelaySeconds: {{ annotation .ObjectMeta `readiness.status.sidecar.istio.io/initialDelaySeconds` .Values.global.proxy.readinessInitialDelaySeconds }}
           periodSeconds: {{ annotation .ObjectMeta `readiness.status.sidecar.istio.io/periodSeconds` .Values.global.proxy.readinessPeriodSeconds }}
+          timeoutSeconds: 3
           failureThreshold: {{ annotation .ObjectMeta `readiness.status.sidecar.istio.io/failureThreshold` .Values.global.proxy.readinessFailureThreshold }}
         {{ end -}}
         securityContext:
@@ -7787,12 +5318,6 @@ data:
           {{ toYaml $value | indent 4 }}
           {{ end }}
           {{- end }}
-      {{- if .ProxyConfig.ProxyMetadata.ISTIO_META_DNS_CAPTURE }}
-      dnsConfig:
-        options:
-        - name: "ndots"
-          value: "4"
-      {{- end }}
       volumes:
       {{- if (isset .ObjectMeta.Annotations `sidecar.istio.io/bootstrapOverride`) }}
       - name: custom-bootstrap-volume
@@ -7851,20 +5376,9 @@ data:
           optional: true
           secretName: lightstep.cacert
       {{- end }}
-      {{- if .Values.global.podDNSSearchNamespaces }}
-      dnsConfig:
-        searches:
-          {{- range .Values.global.podDNSSearchNamespaces }}
-          - {{ render . }}
-          {{- end }}
-      {{- end }}
       podRedirectAnnot:
       {{- if and (.Values.istio_cni.enabled) (not .Values.istio_cni.chained) }}
-      {{ if isset .ObjectMeta.Annotations `k8s.v1.cni.cncf.io/networks` }}
-        k8s.v1.cni.cncf.io/networks: "{{ index .ObjectMeta.Annotations `k8s.v1.cni.cncf.io/networks`}}, istio-cni"
-      {{- else }}
-        k8s.v1.cni.cncf.io/networks: "istio-cni"
-      {{- end }}
+        k8s.v1.cni.cncf.io/networks: '{{ appendMultusNetwork (index .ObjectMeta.Annotations `k8s.v1.cni.cncf.io/networks`) `istio-cni` }}'
       {{- end }}
         sidecar.istio.io/interceptionMode: "{{ annotation .ObjectMeta `sidecar.istio.io/interceptionMode` .ProxyConfig.InterceptionMode }}"
         traffic.sidecar.istio.io/includeOutboundIPRanges: "{{ annotation .ObjectMeta `traffic.sidecar.istio.io/includeOutboundIPRanges` .Values.global.proxy.includeIPRanges }}"
@@ -7895,8 +5409,6 @@ data:
         "caAddress": "",
         "centralIstiod": false,
         "configValidation": true,
-        "controlPlaneSecurityEnabled": true,
-        "createRemoteSvcEndpoints": false,
         "defaultNodeSelector": {},
         "defaultPodDisruptionBudget": {
           "enabled": true
@@ -7906,8 +5418,8 @@ data:
             "cpu": "10m"
           }
         },
-        "enableHelmTest": false,
         "enabled": true,
+        "externalIstiod": false,
         "hub": "index.docker.io/istio",
         "imagePullPolicy": "",
         "imagePullSecrets": [],
@@ -7937,7 +5449,6 @@ data:
         "oneNamespace": false,
         "operatorManageWebhooks": false,
         "pilotCertProvider": "istiod",
-        "policyNamespace": "istio-system",
         "priorityClassName": "",
         "proxy": {
           "autoInject": "enabled",
@@ -7982,8 +5493,6 @@ data:
           }
         },
         "remotePilotAddress": "",
-        "remotePolicyAddress": "",
-        "remoteTelemetryAddress": "",
         "sds": {
           "token": {
             "aud": "istio-ca"
@@ -7992,8 +5501,7 @@ data:
         "sts": {
           "servicePort": 0
         },
-        "tag": "1.7.3",
-        "telemetryNamespace": "istio-system",
+        "tag": "1.8.4",
         "tracer": {
           "datadog": {
             "address": "$(HOST_IP):8126"
@@ -8012,7 +5520,7 @@ data:
             "address": ""
           }
         },
-        "trustDomain": "cluster.local",
+        "trustDomain": "",
         "useMCP": false
       },
       "istio_cni": {
@@ -8022,7 +5530,6 @@ data:
       "sidecarInjectorWebhook": {
         "alwaysInjectSelector": [],
         "enableNamespacesByDefault": false,
-        "injectLabel": "istio-injection",
         "injectedAnnotations": {},
         "neverInjectSelector": [],
         "objectSelector": {
@@ -8035,8 +5542,10 @@ data:
 kind: ConfigMap
 metadata:
   labels:
-    cloudfoundry.org/istio_version: 1.7.3
+    cloudfoundry.org/istio_version: 1.8.4
+    install.operator.istio.io/owning-resource: unknown
     istio.io/rev: default
+    operator.istio.io/component: Pilot
     release: istio
   name: istio-sidecar-injector
   namespace: istio-system
@@ -8046,8 +5555,10 @@ kind: MutatingWebhookConfiguration
 metadata:
   labels:
     app: sidecar-injector
-    cloudfoundry.org/istio_version: 1.7.3
+    cloudfoundry.org/istio_version: 1.8.4
+    install.operator.istio.io/owning-resource: unknown
     istio.io/rev: default
+    operator.istio.io/component: Pilot
     release: istio
   name: istio-sidecar-injector
 webhooks:
@@ -8081,14 +5592,17 @@ metadata:
   annotations:
     kbld.k14s.io/images: |
       - Metas:
-        - Tag: 1.7.3
+        - Tag: 1.8.4
           Type: resolved
-          URL: index.docker.io/istio/proxyv2:1.7.3
-        URL: index.docker.io/istio/proxyv2@sha256:6169d096fe60f128f1311f76c97ee1c3e5d760a45042d5c9182492745d34c658
+          URL: index.docker.io/istio/proxyv2:1.8.4
+        URL: index.docker.io/istio/proxyv2@sha256:6a4ac67c1a74f95d3b307a77ad87e3abb4fcd64ddffe707f99a4458f39d9ce85
   labels:
     app: istio-ingressgateway
-    cloudfoundry.org/istio_version: 1.7.3
+    cloudfoundry.org/istio_version: 1.8.4
+    install.operator.istio.io/owning-resource: unknown
     istio: ingressgateway
+    istio.io/rev: default
+    operator.istio.io/component: IngressGateways
     release: istio
   name: istio-ingressgateway
   namespace: istio-system
@@ -8101,15 +5615,18 @@ spec:
     metadata:
       annotations:
         prometheus.io/path: /stats/prometheus
-        prometheus.io/port: "15090"
+        prometheus.io/port: "15020"
         prometheus.io/scrape: "true"
         sidecar.istio.io/inject: "false"
       labels:
         app: istio-ingressgateway
         chart: gateways
-        cloudfoundry.org/istio_version: 1.7.3
+        cloudfoundry.org/istio_version: 1.8.4
         heritage: Tiller
+        install.operator.istio.io/owning-resource: unknown
         istio: ingressgateway
+        istio.io/rev: default
+        operator.istio.io/component: IngressGateways
         release: istio
         service.istio.io/canonical-name: istio-ingressgateway
         service.istio.io/canonical-revision: latest
@@ -8158,7 +5675,6 @@ spec:
         - --log_output_level=default:info
         - --serviceCluster
         - istio-ingressgateway
-        - --trust-domain=cluster.local
         env:
         - name: JWT_POLICY
           value: third-party-jwt
@@ -8207,15 +5723,13 @@ spec:
           value: istio-ingressgateway
         - name: ISTIO_META_OWNER
           value: kubernetes://apis/apps/v1/namespaces/istio-system/deployments/istio-ingressgateway
-        - name: ISTIO_META_MESH_ID
-          value: cluster.local
         - name: ISTIO_META_ROUTER_MODE
-          value: sni-dnat
+          value: standard
         - name: ISTIO_META_CLUSTER_ID
           value: Kubernetes
         - name: TERMINATION_DRAIN_DURATION_SECONDS
           value: "60"
-        image: index.docker.io/istio/proxyv2@sha256:6169d096fe60f128f1311f76c97ee1c3e5d760a45042d5c9182492745d34c658
+        image: index.docker.io/istio/proxyv2@sha256:6a4ac67c1a74f95d3b307a77ad87e3abb4fcd64ddffe707f99a4458f39d9ce85
         lifecycle:
           preStop:
             exec:
@@ -8226,11 +5740,15 @@ spec:
         name: istio-proxy
         ports:
         - containerPort: 15021
+          protocol: TCP
         - containerPort: 8080
           hostPort: 80
+          protocol: TCP
         - containerPort: 8443
           hostPort: 443
+          protocol: TCP
         - containerPort: 15443
+          protocol: TCP
         - containerPort: 15090
           name: http-envoy-prom
           protocol: TCP
@@ -8270,6 +5788,8 @@ spec:
           readOnly: true
         - mountPath: /var/run/ingress_gateway
           name: gatewaysdsudspath
+        - mountPath: /var/lib/istio/data
+          name: istio-data
         - mountPath: /etc/istio/pod
           name: podinfo
         - mountPath: /etc/istio/ingressgateway-certs
@@ -8316,6 +5836,8 @@ spec:
         name: istio-envoy
       - emptyDir: {}
         name: gatewaysdsudspath
+      - emptyDir: {}
+        name: istio-data
       - name: istio-token
         projected:
           sources:
@@ -8354,15 +5876,17 @@ metadata:
   annotations:
     kbld.k14s.io/images: |
       - Metas:
-        - Tag: 1.7.3
+        - Tag: 1.8.4
           Type: resolved
-          URL: index.docker.io/istio/pilot:1.7.3
-        URL: index.docker.io/istio/pilot@sha256:ba83d2a63ef324eb14128d0804aea5d1170b43ca532823dd186a516d354be610
+          URL: index.docker.io/istio/pilot:1.8.4
+        URL: index.docker.io/istio/pilot@sha256:32fe6db58bd5be49079614f0254d7ce5f98a2bee10c3c389f5237b6122ffd7cc
   labels:
     app: istiod
-    cloudfoundry.org/istio_version: 1.7.3
+    cloudfoundry.org/istio_version: 1.8.4
+    install.operator.istio.io/owning-resource: unknown
     istio: pilot
     istio.io/rev: default
+    operator.istio.io/component: Pilot
     release: istio
   name: istiod
   namespace: istio-system
@@ -8382,9 +5906,11 @@ spec:
         sidecar.istio.io/inject: "false"
       labels:
         app: istiod
-        cloudfoundry.org/istio_version: 1.7.3
+        cloudfoundry.org/istio_version: 1.8.4
+        install.operator.istio.io/owning-resource: unknown
         istio: pilot
         istio.io/rev: default
+        operator.istio.io/component: Pilot
     spec:
       containers:
       - args:
@@ -8393,7 +5919,6 @@ spec:
         - --log_output_level=default:info
         - --domain
         - cluster.local
-        - --trust-domain=cluster.local
         - --keepaliveMaxServerConnectionAge
         - 30m
         env:
@@ -8434,15 +5959,23 @@ spec:
           value: "false"
         - name: CLUSTER_ID
           value: Kubernetes
+        - name: EXTERNAL_ISTIOD
+          value: "false"
         - name: CENTRAL_ISTIOD
           value: "false"
-        image: index.docker.io/istio/pilot@sha256:ba83d2a63ef324eb14128d0804aea5d1170b43ca532823dd186a516d354be610
+        - name: PILOT_ENDPOINT_TELEMETRY_LABEL
+          value: "true"
+        image: index.docker.io/istio/pilot@sha256:32fe6db58bd5be49079614f0254d7ce5f98a2bee10c3c389f5237b6122ffd7cc
         name: discovery
         ports:
         - containerPort: 8080
+          protocol: TCP
         - containerPort: 15010
+          protocol: TCP
         - containerPort: 15017
+          protocol: TCP
         - containerPort: 15053
+          protocol: TCP
         readinessProbe:
           httpGet:
             path: /ready
@@ -8514,8 +6047,11 @@ metadata:
     kapp.k14s.io/update-strategy: fallback-on-replace
   labels:
     app: istio-ingressgateway
-    cloudfoundry.org/istio_version: 1.7.3
+    cloudfoundry.org/istio_version: 1.8.4
+    install.operator.istio.io/owning-resource: unknown
     istio: ingressgateway
+    istio.io/rev: default
+    operator.istio.io/component: IngressGateways
     release: istio
   name: istio-ingressgateway
   namespace: istio-system
@@ -8533,9 +6069,11 @@ metadata:
     kapp.k14s.io/update-strategy: fallback-on-replace
   labels:
     app: istiod
-    cloudfoundry.org/istio_version: 1.7.3
+    cloudfoundry.org/istio_version: 1.8.4
+    install.operator.istio.io/owning-resource: unknown
     istio: pilot
     istio.io/rev: default
+    operator.istio.io/component: Pilot
     release: istio
   name: istiod
   namespace: istio-system
@@ -8550,7 +6088,10 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   labels:
-    cloudfoundry.org/istio_version: 1.7.3
+    cloudfoundry.org/istio_version: 1.8.4
+    install.operator.istio.io/owning-resource: unknown
+    istio.io/rev: default
+    operator.istio.io/component: IngressGateways
     release: istio
   name: istio-ingressgateway-sds
   namespace: istio-system
@@ -8569,7 +6110,7 @@ kind: Role
 metadata:
   labels:
     app: istiod
-    cloudfoundry.org/istio_version: 1.7.3
+    cloudfoundry.org/istio_version: 1.8.4
     release: istio
   name: istiod-istio-system
   namespace: istio-system
@@ -8596,7 +6137,10 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
-    cloudfoundry.org/istio_version: 1.7.3
+    cloudfoundry.org/istio_version: 1.8.4
+    install.operator.istio.io/owning-resource: unknown
+    istio.io/rev: default
+    operator.istio.io/component: IngressGateways
     release: istio
   name: istio-ingressgateway-sds
   namespace: istio-system
@@ -8612,8 +6156,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
-    app: pilot
-    cloudfoundry.org/istio_version: 1.7.3
+    app: istiod
+    cloudfoundry.org/istio_version: 1.8.4
     release: istio
   name: istiod-istio-system
   namespace: istio-system
@@ -8631,8 +6175,11 @@ kind: HorizontalPodAutoscaler
 metadata:
   labels:
     app: istio-ingressgateway
-    cloudfoundry.org/istio_version: 1.7.3
+    cloudfoundry.org/istio_version: 1.8.4
+    install.operator.istio.io/owning-resource: unknown
     istio: ingressgateway
+    istio.io/rev: default
+    operator.istio.io/component: IngressGateways
     release: istio
   name: istio-ingressgateway
   namespace: istio-system
@@ -8654,8 +6201,10 @@ kind: HorizontalPodAutoscaler
 metadata:
   labels:
     app: istiod
-    cloudfoundry.org/istio_version: 1.7.3
+    cloudfoundry.org/istio_version: 1.8.4
+    install.operator.istio.io/owning-resource: unknown
     istio.io/rev: default
+    operator.istio.io/component: Pilot
     release: istio
   name: istiod
   namespace: istio-system
@@ -8678,8 +6227,11 @@ metadata:
   annotations: null
   labels:
     app: istio-ingressgateway
-    cloudfoundry.org/istio_version: 1.7.3
+    cloudfoundry.org/istio_version: 1.8.4
+    install.operator.istio.io/owning-resource: unknown
     istio: ingressgateway
+    istio.io/rev: default
+    operator.istio.io/component: IngressGateways
     release: istio
   name: istio-ingressgateway
   namespace: istio-system
@@ -8688,15 +6240,19 @@ spec:
   ports:
   - name: status-port
     port: 15021
+    protocol: TCP
     targetPort: 15021
   - name: http2
     port: 80
+    protocol: TCP
     targetPort: 8080
   - name: https
     port: 443
+    protocol: TCP
     targetPort: 8443
   - name: tls
     port: 15443
+    protocol: TCP
     targetPort: 15443
   selector:
     app: istio-ingressgateway
@@ -8708,9 +6264,11 @@ kind: Service
 metadata:
   labels:
     app: istiod
-    cloudfoundry.org/istio_version: 1.7.3
+    cloudfoundry.org/istio_version: 1.8.4
+    install.operator.istio.io/owning-resource: unknown
     istio: pilot
     istio.io/rev: default
+    operator.istio.io/component: Pilot
     release: istio
   name: istiod
   namespace: istio-system
@@ -8718,17 +6276,17 @@ spec:
   ports:
   - name: grpc-xds
     port: 15010
+    protocol: TCP
   - name: https-dns
     port: 15012
+    protocol: TCP
   - name: https-webhook
     port: 443
+    protocol: TCP
     targetPort: 15017
   - name: http-monitoring
     port: 15014
-  - name: dns-tls
-    port: 853
     protocol: TCP
-    targetPort: 15053
   selector:
     app: istiod
     istio: pilot
@@ -8737,14 +6295,14 @@ apiVersion: v1
 kind: Namespace
 metadata:
   labels:
-    cloudfoundry.org/istio_version: 1.7.3
+    cloudfoundry.org/istio_version: 1.8.4
   name: istio-system
 ---
 apiVersion: security.istio.io/v1beta1
 kind: PeerAuthentication
 metadata:
   labels:
-    cloudfoundry.org/istio_version: 1.7.3
+    cloudfoundry.org/istio_version: 1.8.4
   name: default
   namespace: istio-system
 spec:

--- a/config/istio/istio-kapp-ordering.yml
+++ b/config/istio/istio-kapp-ordering.yml
@@ -9,17 +9,21 @@
 
 #@ namespaced = lambda idx,old,new: "namespace" in old["metadata"]
 #@ not_inside_istio_ns = overlay.not_op(overlay.subset({"metadata":{"namespace":"istio-system"}}))
+#@ not_upgrade_sidecar = overlay.not_op(overlay.subset({"metadata":{"namespace": "cf-workloads", "annotations": {"kapp.k14s.io/change-group": "cf-for-k8s.cloudfoundry.org/upgrade-istio-sidecars"}}}))
 
-#@overlay/match by=overlay.and_op(contains_pod, namespaced, not_inside_istio_ns), expects="1+"
+#@overlay/match by=overlay.and_op(contains_pod, namespaced, not_inside_istio_ns, not_upgrade_sidecar), expects="1+"
 ---
 metadata:
   #@overlay/match missing_ok=True
   annotations:
     #@overlay/match missing_ok=True
     kapp.k14s.io/change-rule.istio-sidecar-injector: "upsert after upserting cf-for-k8s.cloudfoundry.org/istio-sidecar-injector"
+    #@overlay/match missing_ok=True
+    kapp.k14s.io/change-rule.upgrade-istio-sidecars: "upsert before upserting cf-for-k8s.cloudfoundry.org/upgrade-istio-sidecars"
 
 #! Because the istio sidecar injector is a mutatingwebhook on pod create, we need to guarantee its creation before we start creating pods
-#! in cf namespaces.
+#! in cf namespaces. Similarly, because the istio sidecars may be incompatible across versions of istio, ensure that all pods are rerolled
+#! once the new sidecar injector is available.
 
 #@overlay/match by=overlay.subset({"kind": "MutatingWebhookConfiguration", "metadata":{"name": "istio-sidecar-injector"}})
 ---

--- a/config/istio/upgrade-istio-sidecars-job.yml
+++ b/config/istio/upgrade-istio-sidecars-job.yml
@@ -1,4 +1,5 @@
 #@ load("/namespaces.star", "workloads_namespace")
+#@ load("/namespaces.star", "system_namespace")
 
 #@ def build_version():
 #@   return "1.8.4"
@@ -62,6 +63,31 @@ subjects:
     name: restart-workloads
     namespace: #@ workloads_namespace()
 ---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: restart-cf-system
+  namespace: #@ system_namespace()
+rules:
+  - apiGroups: ["apps", "extensions", ""]
+    resources: ["daemonsets"]
+    verbs: ["get", "patch", "list"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: restart-cf-system
+  namespace: #@ system_namespace()
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: restart-cf-system
+subjects:
+  - kind: ServiceAccount
+    name: restart-workloads
+    namespace: #@ workloads_namespace()
+
+---
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -69,6 +95,7 @@ metadata:
   namespace: #@ workloads_namespace()
   annotations:
     kapp.k14s.io/update-strategy: "skip"
+    kapp.k14s.io/change-group: cf-for-k8s.cloudfoundry.org/upgrade-istio-sidecars
   labels:
     cloudfoundry.org/istio_version: #@ build_version()
 spec:

--- a/config/istio/upgrade-istio-sidecars-job.yml
+++ b/config/istio/upgrade-istio-sidecars-job.yml
@@ -1,7 +1,7 @@
 #@ load("/namespaces.star", "workloads_namespace")
 
 #@ def build_version():
-#@   return "1.7.3"
+#@   return "1.8.4"
 #@ end
 
 ---


### PR DESCRIPTION
- support for Istio v1.7 is ending today, Feb 19

Closes #622

# Todo
- [ ] resurrect cf-k8s-networking istio pipelines that generate images such as `gcr.io/cf-routing/pilot`
- [ ] put kbld back

## Does this PR introduce a change to `config/values.yml`?
Nope

## Acceptance Steps
PR tests pass, and I see that Istio has been upgraded to v1.8.0+

## Tag your pair, your PM, and/or team
👀 @braunsonm

## Things to remember
- Make sure this PR is based off the `develop` branch
- Include any links to related PRs, issues, stories, slack discussions, etc... that will help establish context.
- Is there anything else of note that the reviewers should know about this change?
- Our CI uses concourse task files from HEAD of the `develop` branch. If your PR includes/requires CI changes, please ping the RelInt interrupt and they'll help apply the CI changes for you.
- Checkout the [contributing guidelines](https://github.com/cloudfoundry/cf-for-k8s/blob/develop/community/CONTRIBUTING.md)
