### PR TITLE
MAINT: remove KinD patch to disable snapshot annos

### DIFF
--- a/deploy/kind/cluster.yml
+++ b/deploy/kind/cluster.yml
@@ -15,7 +15,3 @@ nodes:
   - protocol: TCP
     containerPort: 443
     hostPort: 443
-containerdConfigPatches:
-  - |-
-    [plugins."io.containerd.grpc.v1.cri".containerd]
-    disable_snapshot_annotations = true


### PR DESCRIPTION
- Kind should now be using a new enough version of containerd (v1.4.2+) such that this work-around isn't required
- Related to #444

## Acceptance Steps
PR tests pass, specifically the KinD tests
