### PR TITLE
Adopt restructuring of Eirini config maps

### DIFF
--- a/build/eirini/overlays/disable-cc-api-tls.yml
+++ b/build/eirini/overlays/disable-cc-api-tls.yml
@@ -1,0 +1,31 @@
+#@ load("@ytt:overlay", "overlay")
+#@ load("@ytt:yaml", "yaml")
+
+#@ def disable_tls():
+#@overlay/match missing_ok=True
+cc_tls_disabled: true
+#@ end
+
+#! Use http/port 8080 for eirini-capi communications and let istio do the encryption
+#@overlay/match by=overlay.subset({"kind": "ConfigMap", "metadata":{"name":"api"}})
+#@yaml/text-templated-strings
+---
+data:
+  #@overlay/replace via=lambda eirini_config_map_content,_: yaml.encode(overlay.apply(yaml.decode(eirini_config_map_content), disable_tls()))
+  api.yml:
+
+#! Use http/port 8080 for eirini-capi communications and let istio do the encryption
+#@overlay/match by=overlay.subset({"kind": "ConfigMap", "metadata":{"name":"eirini-event-reporter"}})
+#@yaml/text-templated-strings
+---
+data:
+  #@overlay/replace via=lambda eirini_config_map_content,_: yaml.encode(overlay.apply(yaml.decode(eirini_config_map_content), disable_tls()))
+  events.yml:
+
+#! Use http/port 8080 for eirini-capi communications and let istio do the encryption
+#@overlay/match by=overlay.subset({"kind": "ConfigMap", "metadata":{"name":"task-reporter"}})
+#@yaml/text-templated-strings
+---
+data:
+  #@overlay/replace via=lambda eirini_config_map_content,_: yaml.encode(overlay.apply(yaml.decode(eirini_config_map_content), disable_tls()))
+  task-reporter.yml:

--- a/config/eirini/enable-automount-service-account-token.yml
+++ b/config/eirini/enable-automount-service-account-token.yml
@@ -7,17 +7,22 @@
 #!   - Kind does not support setting it to false right now
 
 #@ def update_eirini_config():
-opi:
-  #@overlay/match missing_ok=True
-  #@overlay/replace
-  unsafe_allow_automount_service_account_token: true
+#@overlay/match missing_ok=True
+#@overlay/replace
+unsafe_allow_automount_service_account_token: true
 #@ end
 
-#@overlay/match by=overlay.subset({"kind": "ConfigMap","metadata":{"name":"eirini"}})
+#@overlay/match by=overlay.subset({"kind": "ConfigMap","metadata":{"name":"api"}})
 ---
 data:
   #@overlay/replace via=lambda a,_: yaml.encode(overlay.apply(yaml.decode(a), update_eirini_config()))
-  opi.yml:
+  api.yml:
+
+#@overlay/match by=overlay.subset({"kind": "ConfigMap","metadata":{"name":"controller"}})
+---
+data:
+  #@overlay/replace via=lambda a,_: yaml.encode(overlay.apply(yaml.decode(a), update_eirini_config()))
+  controller.yml:
 
 #@overlay/match by=overlay.subset({"kind":"ServiceAccount", "metadata": {"name":"eirini"}}),expects="0+"
 ---


### PR DESCRIPTION
## WHAT is this change about?
In order to support different configurations in the CRD flow, Eirini
configmaps have been split into two (one for the traditional REST API
and one for the CRD flow). This PR adopts that change and sets the
`unsafe_allow_automount_service_account_token` to `true` in both REST
and CRD configurations on Kind.

**NOTE**: Please only merge this PR when bumping Eirini to the successor of the v3.0.0 release!

Related Eirini backlog item: https://www.pivotaltracker.com/story/show/176961023

## Does this PR introduce a change to `config/values.yml`?
No

## Acceptance Steps
1. Bump Eirini to the v3.0.0 successor (e.g. v3.0.1 when out, or develop if you are feeling lucky)
2. Deploy on Kind
3. See `unsafe_allow_automount_service_account_token` has been set to true in both `api` and `controller` configmaps


## Tag your pair, your PM, and/or team
@cloudfoundry/eirini 
