### PR TITLE
Remove cf api server update strategy

### DIFF
--- a/config/capi/capi.yml
+++ b/config/capi/capi.yml
@@ -72,6 +72,26 @@ kpack:
 ---
 spec:
   replicas: 1
+  #@overlay/remove
+  strategy:
+
+#@overlay/match by=overlay.subset({"kind":"Deployment","metadata":{"name":"cf-api-clock"}})
+---
+spec:
+  #@overlay/remove
+  strategy:
+
+#@overlay/match by=overlay.subset({"kind":"Deployment","metadata":{"name":"cf-api-controllers"}})
+---
+spec:
+  #@overlay/remove
+  strategy:
+
+#@overlay/match by=overlay.subset({"kind":"Deployment","metadata":{"name":"cf-api-deployment-updater"}})
+---
+spec:
+  #@overlay/remove
+  strategy:
 
 #@ capi = library.get("capi-k8s-release")
 --- #@ template.replace(capi.with_data_values(capi_values()).eval())

--- a/config/capi/capi.yml
+++ b/config/capi/capi.yml
@@ -71,7 +71,7 @@ kpack:
 #@overlay/match by=overlay.subset({"kind":"Deployment","metadata":{"name":"cf-api-server"}})
 ---
 spec:
-  replicas: #@ data.values.capi.cf_api_server.replicas
+  replicas: 1
 
 #@ capi = library.get("capi-k8s-release")
 --- #@ template.replace(capi.with_data_values(capi_values()).eval())

--- a/config/values/00-values.yml
+++ b/config/values/00-values.yml
@@ -37,8 +37,6 @@ gateway:
   https_only: true
 
 capi:
-  cf_api_server:
-    replicas: 1
   database:
     #! or mysql2, as needed
     adapter: postgres

--- a/tests/ytt/capi/capi-values.yml
+++ b/tests/ytt/capi/capi-values.yml
@@ -7,8 +7,6 @@ app_domains: [""]
 cf_admin_password: ""
 
 capi:
-  cf_api_server:
-    replicas: 1
   cc_username_lookup_client_secret:
   cf_api_controllers_client_secret:
   cf_api_backup_metadata_generator_client_secret:

--- a/tests/ytt/capi_test.go
+++ b/tests/ytt/capi_test.go
@@ -47,17 +47,6 @@ var _ = Describe("CAPI", func() {
 		Expect(err).NotTo(HaveOccurred())
 	})
 
-	Context("Scaling cf-api-server", func() {
-			BeforeEach(func() {
-				data = map[string]interface{}{}
-				data["capi.cf_api_server.replicas"] = 2
-			})
-
-			It("updates the deployment spec", func(){
-				Expect(ctx).To(ProduceYAML(WithDeployment("cf-api-server", "cf-system").WithSpecYaml(`replicas: 2`)))
-			})
-	})
-
 	Context("Secrets", func() {
 		Context("when using quarks secrets", func() {
 			BeforeEach(func() {


### PR DESCRIPTION
## WHAT is this change about?
This PR removes the update strategy from the CF API pods as it can cause API downtime during upgrades. See [#177444748](https://www.pivotaltracker.com/story/show/177444748) for details.

## Does this PR introduce a change to `config/values.yml`?
No

## Acceptance Steps
Deploy v2.1.1, then deploy this change while monitoring the `cf-api-server` pod. You should see that the old pod is not terminated until the new pod is ready.

## Tag your pair, your PM, and/or team
