### PR TITLE
Added OCI labels to capi nginx kbld config

### DIFF
--- a/images/build/capi/generate-kbld-config.sh
+++ b/images/build/capi/generate-kbld-config.sh
@@ -20,7 +20,8 @@ function generate_kbld_config() {
   kbld_config_values=$(cat <<EOF
 #@data/values
 ---
-git_sha: ${git_sha}
+git_ref: ${git_sha}
+git_url: https://github.com/cloudfoundry/capi-k8s-release.git
 EOF
 )
 

--- a/images/build/capi/kbld.yml
+++ b/images/build/capi/kbld.yml
@@ -11,7 +11,7 @@ sources:
       builder: paketobuildpacks/builder:full
       rawOptions:
       - --env
-      - #@ "BP_OCI_REVISION=" + data.values.git_sha
+      - #@ "BP_OCI_REVISION=" + data.values.git_ref
       - --env
       - "BP_OCI_SOURCE=https://github.com/cloudfoundry/capi-k8s-release"
 - imageRepo: cloudfoundry/cf-api-backup-metadata-generator
@@ -26,7 +26,7 @@ sources:
       - "--default-process"
       - "wait"
       - --env
-      - #@ "BP_OCI_REVISION=" + data.values.git_sha
+      - #@ "BP_OCI_REVISION=" + data.values.git_ref
       - --env
       - "BP_OCI_SOURCE=https://github.com/cloudfoundry/capi-k8s-release"
 - imageRepo: cloudfoundry/cf-api-package-registry-buddy
@@ -36,12 +36,18 @@ sources:
       builder: paketobuildpacks/builder:full
       rawOptions:
       - --env
-      - #@ "BP_OCI_REVISION=" + data.values.git_sha
+      - #@ "BP_OCI_REVISION=" + data.values.git_ref
       - --env
       - "BP_OCI_SOURCE=https://github.com/cloudfoundry/capi-k8s-release"
 - imageRepo: cloudfoundry/capi-nginx
   path: sources/capi-k8s-release/dockerfiles/nginx
-  docker: {}
+  docker:
+    build:
+      rawOptions:
+        - --label
+        - #@ "org.opencontainers.image.source={}".format(data.values.git_url)
+        - --label
+        - #@ "org.opencontainers.image.revision={}".format(data.values.git_ref)
 destinations:
   - imageRepo: cloudfoundry/cf-api-controllers
     newImage: index.docker.io/cloudfoundry/cf-api-controllers


### PR DESCRIPTION
[finishes #177481547](https://www.pivotaltracker.com/story/show/177481547)

Signed-off-by: Andrew Costa <ancosta@vmware.com>
Co-authored-by: Andrew Costa <ancosta@vmware.com>



> Thanks for contributing to cf-for-k8s!
>
> We've designed this PR template to speed up the PR review and merge process - please use it.

## WHAT is this change about?
Add OCI labels to nginx images built with Carvel toolchain.

## Does this PR introduce a change to `config/values.yml`?
No.

## Acceptance Steps
Docker inspect a produced image (pipe to `jq .[].Config.Labels`) and search for opencontainers annotations.

## Things to remember
- Make sure this PR is based off the `develop` branch
- Include any links to related PRs, issues, stories, slack discussions, etc... that will help establish context.
- Is there anything else of note that the reviewers should know about this change?
- Our CI uses concourse task files from HEAD of the `develop` branch. If your PR includes/requires CI changes, please ping the RelInt interrupt and they'll help apply the CI changes for you.
- Checkout the [contributing guidelines](https://github.com/cloudfoundry/cf-for-k8s/blob/develop/community/CONTRIBUTING.md)
