### PR TITLE
ENH: Make istio images configurable

### DIFF
--- a/config/istio/inject-images.yml
+++ b/config/istio/inject-images.yml
@@ -1,0 +1,44 @@
+#@ load("@ytt:data", "data")
+#@ load("@ytt:overlay", "overlay")
+#@ load("@ytt:json", "json")
+
+#@ def istio_values_overlay():
+global:
+  proxy:
+    #@overlay/replace
+    image: #@ data.values.images.istio.proxy
+  proxy_init:
+    #@overlay/replace
+    image: #@ data.values.images.istio.proxy
+#@ end
+
+#@ def overlay_istio_values(old, new):
+#@   return json.encode(overlay.apply(json.decode(old), istio_values_overlay()))
+#@ end
+
+#@overlay/match by=overlay.subset({"kind":"ConfigMap", "metadata":{"namespace": "istio-system", "name": "istio-sidecar-injector"}})
+---
+data:
+  #@overlay/replace via=overlay_istio_values
+  values:
+
+#@overlay/match by=overlay.subset({"kind":"Deployment", "metadata":{"namespace": "istio-system", "name": "istiod"}})
+---
+spec:
+  template:
+    spec:
+      containers:
+      #@overlay/match by="name"
+      - name: "discovery"
+        image: #@ data.values.images.istio.pilot
+
+
+#@overlay/match by=overlay.subset({"kind":"DaemonSet", "metadata":{"namespace": "istio-system", "name": "istio-ingressgateway"}})
+---
+spec:
+  template:
+    spec:
+      containers:
+      #@overlay/match by="name"
+      - name: "istio-proxy"
+        image: #@ data.values.images.istio.proxy

--- a/config/values/10-images.yml
+++ b/config/values/10-images.yml
@@ -4,4 +4,3 @@
 images:
   shared:
     statsd_exporter: cloudfoundry/statsd_exporter-cf-for-k8s@sha256:6678b114a38c219d4349a928faa4d36f60b42e70846a86166540aa2e72fdc546
-

--- a/config/values/10-istio-images.yml
+++ b/config/values/10-istio-images.yml
@@ -1,0 +1,7 @@
+#@data/values
+#@overlay/match-child-defaults missing_ok=True
+---
+images:
+  istio:
+    proxy: index.docker.io/istio/proxyv2@sha256:6a4ac67c1a74f95d3b307a77ad87e3abb4fcd64ddffe707f99a4458f39d9ce85
+    pilot: index.docker.io/istio/pilot@sha256:32fe6db58bd5be49079614f0254d7ce5f98a2bee10c3c389f5237b6122ffd7cc


### PR DESCRIPTION
## WHAT is this change about?
Make the images used by the istio templates configurable via data value driven ytt overlays.

## Does this PR introduce a change to `config/values.yml`?
Yes, adds a new data values block for istio images.

## Acceptance Steps
Rendering and deploying cf-for-k8s continues to work normally by default.

Update the `10-istio-images.yml` data values and notice that rendering cf-for-k8s now updates the images used in the istio-ingressgateway daemonset, istiod deployment, and the sidecar pods injected to workloads.

## Tag your pair, your PM, and/or team
@Birdrock 
[#177585539](https://www.pivotaltracker.com/story/show/177585539)