### PR TITLE
ENH: Make minio images configurable

### DIFF
--- a/config/minio/inject-images.yml
+++ b/config/minio/inject-images.yml
@@ -1,0 +1,12 @@
+#@ load("@ytt:data", "data")
+#@ load("@ytt:overlay", "overlay")
+
+#@overlay/match by=overlay.subset({"kind": "Deployment", "metadata": {"name": "cf-blobstore-minio"}}),expects="0+"
+---
+spec:
+  template:
+    spec:
+      containers:
+        #@overlay/match by="name"
+        - name: minio
+          image: #@ data.values.images.minio.minio

--- a/config/values/10-minio-images.yml
+++ b/config/values/10-minio-images.yml
@@ -1,0 +1,6 @@
+#@data/values
+#@overlay/match-child-defaults missing_ok=True
+---
+images:
+  minio:
+    minio: "cloudfoundry/minio-cf-for-k8s@sha256:5cb64001e21d6e3adb05717ca49aca34d52f576cf8365af28860d4afad383ea4"

--- a/tests/ytt/external_blobstore_test.go
+++ b/tests/ytt/external_blobstore_test.go
@@ -24,6 +24,7 @@ var _ = Describe("External Blobstore", func() {
 
 		valueFiles = []string{
 			pathToFile("tests/ytt/blobstore/blobstore-values.yml"),
+			pathToFile("config/values/10-minio-images.yml"),
 		}
 	})
 


### PR DESCRIPTION
[#177585539](https://www.pivotaltracker.com/story/show/177585539)

Co-authored-by: Andrew Costa <ancosta@vmware.com>


## WHAT is this change about?
Make the images used by the minio templates configurable via data value driven ytt overlays.

## Does this PR introduce a change to `config/values.yml`?
Yes. Adds values block for minio image.

## Acceptance Steps
Deploy as normal and ensure still working.

## Tag your pair, your PM, and/or team
@acosta11
[#177585539](https://www.pivotaltracker.com/story/show/177585539)