### PR TITLE
ENH: Make postgres images configurable

### DIFF
--- a/config/postgres/inject-images.yml
+++ b/config/postgres/inject-images.yml
@@ -1,0 +1,12 @@
+#@ load("@ytt:data", "data")
+#@ load("@ytt:overlay", "overlay")
+
+#@overlay/match by=overlay.subset({"kind": "StatefulSet", "metadata": {"name": "cf-db-postgresql"}}),expects="0+"
+---
+spec:
+  template:
+    spec:
+      containers:
+        #@overlay/match by="name"
+        - name: cf-db-postgresql
+          image: #@ data.values.images.postgres.postgres

--- a/config/values/10-postgres-images.yml
+++ b/config/values/10-postgres-images.yml
@@ -1,0 +1,6 @@
+#@data/values
+#@overlay/match-child-defaults missing_ok=True
+---
+images:
+  postgres:
+    postgres: index.docker.io/bitnami/postgresql@sha256:0f76a419cfd9996036e3a53672f50cf69ed7699f1241cbf8e20af17bbbdf0683

--- a/tests/ytt/external_db_test.go
+++ b/tests/ytt/external_db_test.go
@@ -24,6 +24,7 @@ var _ = Describe("External DB", func() {
 
 		valueFiles = []string{
 			pathToFile("tests/ytt/postgres/postgres-values.yml"),
+			pathToFile("config/values/10-postgres-images.yml"),
 		}
 	})
 


### PR DESCRIPTION
[#177585539](https://www.pivotaltracker.com/story/show/177585539)

Co-authored-by: Andrew Costa <ancosta@vmware.com>

## WHAT is this change about?
Make the images used by the postgres templates configurable via data value driven ytt overlays.

## Does this PR introduce a change to `config/values.yml`?
Yes. Adds values block for minio image.

## Tag your pair, your PM, and/or team
@acosta11
[#177585539](https://www.pivotaltracker.com/story/show/177585539)
