### PR TITLE
Update the holdApplicationUntilProxyStarts Istio setting

### DIFF
--- a/build/istio/istioctl-values.yaml
+++ b/build/istio/istioctl-values.yaml
@@ -76,6 +76,5 @@ spec:
           "x_forwarded_for": "%REQ(X-FORWARDED-FOR)%",
           "x_forwarded_proto": "%REQ(X-FORWARDED-PROTO)%"
         }
-    global:
-      proxy:
+      defaultConfig:
         holdApplicationUntilProxyStarts: true

--- a/config/istio/istio-generated/xxx-generated-istio.yaml
+++ b/config/istio/istio-generated/xxx-generated-istio.yaml
@@ -4494,6 +4494,7 @@ data:
       }
     defaultConfig:
       discoveryAddress: istiod.istio-system.svc:15012
+      holdApplicationUntilProxyStarts: true
       proxyMetadata: {}
       tracing:
         zipkin:
@@ -5308,7 +5309,7 @@ data:
           "excludeIPRanges": "",
           "excludeInboundPorts": "",
           "excludeOutboundPorts": "",
-          "holdApplicationUntilProxyStarts": true,
+          "holdApplicationUntilProxyStarts": false,
           "image": "proxyv2",
           "includeIPRanges": "*",
           "logLevel": "warning",


### PR DESCRIPTION
## WHAT is this change about?
When we run the `build/istio/build.sh` script with istioctl 1.9.4, we saw a deprecation warning about the `holdApplicationUntilProxyStarts` configuration:
```
$ ./build/istio/build.sh
generating Istio resource definitions...
! values.global.proxy.holdApplicationUntilProxyStarts is deprecated; use meshConfig.defaultConfig.holdApplicationUntilProxyStarts instead
resolve | final: cloudfoundry/cf-k8s-networking-fluentbit@sha256:2b8563a032c007bdb5f8a1cdbd093edd8505fadd21a3443a2b891e87caee7504 -> index.docker.io/cloudfoundry/cf-k8s-networking-fluentbit@sha256:2b8563a032c007bdb5f8a1cdbd093edd8505fadd21a3443a2b891e87caee7504
resolve | final: index.docker.io/istio/pilot:1.9.4 -> index.docker.io/istio/pilot@sha256:a613e4535cad4028d0aca7e16450f16f41ed2466fa522f6c22c2b96bfbc26eba
resolve | final: index.docker.io/istio/proxyv2:1.9.4 -> index.docker.io/istio/proxyv2@sha256:5e5d6153164c6a71fb1538cb11b3b8c13edc7f9628a4927c180df7ea5c02bae2
```

This PR updates the Istio configuration to use the new property.

[#178029864](https://www.pivotaltracker.com/story/show/178029864)

## Does this PR introduce a change to `config/values.yml`?
No

## Acceptance Steps
Deploy as normal.

## Tag your pair, your PM, and/or team
@Birdrock 