### PR TITLE
ENH: Add an Istio version label to all system components

### DIFF
--- a/build/istio/build.sh
+++ b/build/istio/build.sh
@@ -5,7 +5,11 @@ SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 
 ${SCRIPT_DIR}/generate.sh "$@" | kbld -f - > "${SCRIPT_DIR}/../../config/istio/istio-generated/xxx-generated-istio.yaml"
 
-# save the current Istio version in the networking configs
+# Save the current Istio version in the networking configs
 # NOTE: this project uses python yq module (https://kislyuk.github.io/yq/)
 ISTIO_VERSION="$(< "${SCRIPT_DIR}/values.yaml" yq -r .istio_version)"
-sed -r -i'' 's/(return)(.*\..*\..*)$/\1 "'${ISTIO_VERSION}'"/' "${SCRIPT_DIR}/../../config/istio/upgrade-istio-sidecars-job.yml"
+cat <<EOF > "${SCRIPT_DIR}/../../config/istio/istio-version.star"
+def istio_version():
+  return "${ISTIO_VERSION}"
+end
+EOF

--- a/config/istio/add-istio-version-to-podspecs.yml
+++ b/config/istio/add-istio-version-to-podspecs.yml
@@ -1,0 +1,19 @@
+#@ load("@ytt:overlay", "overlay")
+#@ load("istio-version.star", "istio_version")
+
+#@ is_deployment = overlay.subset({"kind":"Deployment"})
+#@ is_daemonset = overlay.subset({"kind":"DaemonSet"})
+#@ is_statefulset = overlay.subset({"kind":"StatefulSet"})
+#@ is_podspec = overlay.or_op(is_deployment, is_daemonset, is_statefulset)
+#@ not_istio_ns = overlay.not_op(overlay.subset({"metadata":{"namespace":"istio-system"}}))
+
+#@overlay/match by=overlay.and_op(is_podspec, not_istio_ns), expects="1+"
+---
+spec:
+  template:
+    #@overlay/match missing_ok=True
+    metadata:
+      #@overlay/match missing_ok=True
+      labels:
+        #@overlay/match missing_ok=True
+        cloudfoundry.org/istio_version: #@ istio_version()

--- a/config/istio/istio-version.star
+++ b/config/istio/istio-version.star
@@ -1,0 +1,3 @@
+def istio_version():
+  return "1.9.4"
+end

--- a/config/istio/upgrade-istio-sidecars-job.yml
+++ b/config/istio/upgrade-istio-sidecars-job.yml
@@ -1,9 +1,7 @@
+#@ load("@ytt:overlay", "overlay")
 #@ load("/namespaces.star", "workloads_namespace")
 #@ load("/namespaces.star", "system_namespace")
-
-#@ def build_version():
-#@   return "1.9.4"
-#@ end
+#@ load("istio-version.star", "istio_version")
 
 ---
 kind: ServiceAccount
@@ -91,13 +89,13 @@ subjects:
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: #@ "restart-workloads-for-istio" + build_version().replace(".", "-")
+  name: #@ "restart-workloads-for-istio" + istio_version().replace(".", "-")
   namespace: #@ workloads_namespace()
   annotations:
     kapp.k14s.io/update-strategy: "skip"
     kapp.k14s.io/change-group: cf-for-k8s.cloudfoundry.org/upgrade-istio-sidecars
   labels:
-    cloudfoundry.org/istio_version: #@ build_version()
+    cloudfoundry.org/istio_version: #@ istio_version()
 spec:
   backoffLimit: 2
   template:
@@ -112,4 +110,4 @@ spec:
           image: cloudfoundry/cf-k8s-networking-upgrade-sidecars@sha256:b5f0e3204a0e9c6d7bc5fa828f70898d0f714e859060fa218c4341fd95b630e8
           env:
           - name: ISTIO_VERSION
-            value: #@ build_version()
+            value: #@ istio_version()


### PR DESCRIPTION
## WHAT is this change about?
This PR adds an Istio version label to all system components. This will cause kapp to roll the components whenever the Istio version changes, which will result in the new version of the proxy sidecar being injected into the pods.

[#177914742](https://www.pivotaltracker.com/story/show/177914742)

## Does this PR introduce a change to `config/values.yml`?
No

## Acceptance Steps
Deploy a previous version of cf-for-k8s that includes an old version of Istio, then upgrade to this version and confirm that all system component pods are rolled during the upgrade, and that kapp waits for them all to be ready again before proceeding.

## Tag your pair, your PM, and/or team
@Birdrock 