### PR TITLE
Bump Istio to 1.10.2.

### DIFF
--- a/build/istio/overlays/kapp-compatible.yaml
+++ b/build/istio/overlays/kapp-compatible.yaml
@@ -8,7 +8,34 @@
 ---
 webhooks:
 #@overlay/match by="name"
-- name: sidecar-injector.istio.io
+- name: rev.namespace.sidecar-injector.istio.io
+  clientConfig:
+    #@overlay/remove
+    caBundle:
+
+#@overlay/match by=overlay.subset({"kind":"MutatingWebhookConfiguration", "metadata":{"name": "istio-sidecar-injector"}})
+---
+webhooks:
+#@overlay/match by="name"
+- name: rev.object.sidecar-injector.istio.io
+  clientConfig:
+    #@overlay/remove
+    caBundle:
+
+#@overlay/match by=overlay.subset({"kind":"MutatingWebhookConfiguration", "metadata":{"name": "istio-sidecar-injector"}})
+---
+webhooks:
+#@overlay/match by="name"
+- name: namespace.sidecar-injector.istio.io
+  clientConfig:
+    #@overlay/remove
+    caBundle:
+
+#@overlay/match by=overlay.subset({"kind":"MutatingWebhookConfiguration", "metadata":{"name": "istio-sidecar-injector"}})
+---
+webhooks:
+#@overlay/match by="name"
+- name: object.sidecar-injector.istio.io
   clientConfig:
     #@overlay/remove
     caBundle:

--- a/build/istio/values.yaml
+++ b/build/istio/values.yaml
@@ -5,7 +5,7 @@
 #! These values cannot be changed later when rendering cf-for-k8s templates.
 #! Values related to CF should NOT be in this file.
 
-istio_version: 1.9.5
+istio_version: 1.10.2
 
 fluentbit:
   image: cloudfoundry/cf-k8s-networking-fluentbit@sha256:64d67dc076d4160c351272261d7730c08c1b906a881d1812778b6da93871d4e4

--- a/config/istio/istio-generated/xxx-generated-istio.yaml
+++ b/config/istio/istio-generated/xxx-generated-istio.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
@@ -7,7 +7,7 @@ metadata:
   labels:
     app: istio-pilot
     chart: istio
-    cloudfoundry.org/istio_version: 1.9.5
+    cloudfoundry.org/istio_version: 1.10.2
     heritage: Tiller
     istio: security
     release: istio
@@ -22,215 +22,214 @@ spec:
     listKind: AuthorizationPolicyList
     plural: authorizationpolicies
     singular: authorizationpolicy
-  preserveUnknownFields: false
   scope: Namespaced
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      properties:
-        spec:
-          description: 'Configuration for access control on workloads. See more details at: https://istio.io/docs/reference/config/security/authorization-policy.html'
-          oneOf:
-          - not:
-              anyOf:
-              - required:
-                - provider
-          - required:
-            - provider
-          properties:
-            action:
-              description: Optional.
-              enum:
-              - ALLOW
-              - DENY
-              - AUDIT
-              - CUSTOM
-              type: string
-            provider:
-              description: Specifies detailed configuration of the CUSTOM action.
-              properties:
-                name:
-                  description: Specifies the name of the extension provider.
-                  format: string
-                  type: string
-              type: object
-            rules:
-              description: Optional.
-              items:
-                properties:
-                  from:
-                    description: Optional.
-                    items:
-                      properties:
-                        source:
-                          description: Source specifies the source of a request.
-                          properties:
-                            ipBlocks:
-                              description: Optional.
-                              items:
-                                format: string
-                                type: string
-                              type: array
-                            namespaces:
-                              description: Optional.
-                              items:
-                                format: string
-                                type: string
-                              type: array
-                            notIpBlocks:
-                              description: Optional.
-                              items:
-                                format: string
-                                type: string
-                              type: array
-                            notNamespaces:
-                              description: Optional.
-                              items:
-                                format: string
-                                type: string
-                              type: array
-                            notPrincipals:
-                              description: Optional.
-                              items:
-                                format: string
-                                type: string
-                              type: array
-                            notRemoteIpBlocks:
-                              description: Optional.
-                              items:
-                                format: string
-                                type: string
-                              type: array
-                            notRequestPrincipals:
-                              description: Optional.
-                              items:
-                                format: string
-                                type: string
-                              type: array
-                            principals:
-                              description: Optional.
-                              items:
-                                format: string
-                                type: string
-                              type: array
-                            remoteIpBlocks:
-                              description: Optional.
-                              items:
-                                format: string
-                                type: string
-                              type: array
-                            requestPrincipals:
-                              description: Optional.
-                              items:
-                                format: string
-                                type: string
-                              type: array
-                          type: object
-                      type: object
-                    type: array
-                  to:
-                    description: Optional.
-                    items:
-                      properties:
-                        operation:
-                          description: Operation specifies the operation of a request.
-                          properties:
-                            hosts:
-                              description: Optional.
-                              items:
-                                format: string
-                                type: string
-                              type: array
-                            methods:
-                              description: Optional.
-                              items:
-                                format: string
-                                type: string
-                              type: array
-                            notHosts:
-                              description: Optional.
-                              items:
-                                format: string
-                                type: string
-                              type: array
-                            notMethods:
-                              description: Optional.
-                              items:
-                                format: string
-                                type: string
-                              type: array
-                            notPaths:
-                              description: Optional.
-                              items:
-                                format: string
-                                type: string
-                              type: array
-                            notPorts:
-                              description: Optional.
-                              items:
-                                format: string
-                                type: string
-                              type: array
-                            paths:
-                              description: Optional.
-                              items:
-                                format: string
-                                type: string
-                              type: array
-                            ports:
-                              description: Optional.
-                              items:
-                                format: string
-                                type: string
-                              type: array
-                          type: object
-                      type: object
-                    type: array
-                  when:
-                    description: Optional.
-                    items:
-                      properties:
-                        key:
-                          description: The name of an Istio attribute.
-                          format: string
-                          type: string
-                        notValues:
-                          description: Optional.
-                          items:
-                            format: string
-                            type: string
-                          type: array
-                        values:
-                          description: Optional.
-                          items:
-                            format: string
-                            type: string
-                          type: array
-                      type: object
-                    type: array
-                type: object
-              type: array
-            selector:
-              description: Optional.
-              properties:
-                matchLabels:
-                  additionalProperties:
-                    format: string
-                    type: string
-                  type: object
-              type: object
-          type: object
-        status:
-          type: object
-          x-kubernetes-preserve-unknown-fields: true
-      type: object
   versions:
   - name: v1beta1
+    schema:
+      openAPIV3Schema:
+        properties:
+          spec:
+            description: 'Configuration for access control on workloads. See more details at: https://istio.io/docs/reference/config/security/authorization-policy.html'
+            oneOf:
+            - not:
+                anyOf:
+                - required:
+                  - provider
+            - required:
+              - provider
+            properties:
+              action:
+                description: Optional.
+                enum:
+                - ALLOW
+                - DENY
+                - AUDIT
+                - CUSTOM
+                type: string
+              provider:
+                description: Specifies detailed configuration of the CUSTOM action.
+                properties:
+                  name:
+                    description: Specifies the name of the extension provider.
+                    format: string
+                    type: string
+                type: object
+              rules:
+                description: Optional.
+                items:
+                  properties:
+                    from:
+                      description: Optional.
+                      items:
+                        properties:
+                          source:
+                            description: Source specifies the source of a request.
+                            properties:
+                              ipBlocks:
+                                description: Optional.
+                                items:
+                                  format: string
+                                  type: string
+                                type: array
+                              namespaces:
+                                description: Optional.
+                                items:
+                                  format: string
+                                  type: string
+                                type: array
+                              notIpBlocks:
+                                description: Optional.
+                                items:
+                                  format: string
+                                  type: string
+                                type: array
+                              notNamespaces:
+                                description: Optional.
+                                items:
+                                  format: string
+                                  type: string
+                                type: array
+                              notPrincipals:
+                                description: Optional.
+                                items:
+                                  format: string
+                                  type: string
+                                type: array
+                              notRemoteIpBlocks:
+                                description: Optional.
+                                items:
+                                  format: string
+                                  type: string
+                                type: array
+                              notRequestPrincipals:
+                                description: Optional.
+                                items:
+                                  format: string
+                                  type: string
+                                type: array
+                              principals:
+                                description: Optional.
+                                items:
+                                  format: string
+                                  type: string
+                                type: array
+                              remoteIpBlocks:
+                                description: Optional.
+                                items:
+                                  format: string
+                                  type: string
+                                type: array
+                              requestPrincipals:
+                                description: Optional.
+                                items:
+                                  format: string
+                                  type: string
+                                type: array
+                            type: object
+                        type: object
+                      type: array
+                    to:
+                      description: Optional.
+                      items:
+                        properties:
+                          operation:
+                            description: Operation specifies the operation of a request.
+                            properties:
+                              hosts:
+                                description: Optional.
+                                items:
+                                  format: string
+                                  type: string
+                                type: array
+                              methods:
+                                description: Optional.
+                                items:
+                                  format: string
+                                  type: string
+                                type: array
+                              notHosts:
+                                description: Optional.
+                                items:
+                                  format: string
+                                  type: string
+                                type: array
+                              notMethods:
+                                description: Optional.
+                                items:
+                                  format: string
+                                  type: string
+                                type: array
+                              notPaths:
+                                description: Optional.
+                                items:
+                                  format: string
+                                  type: string
+                                type: array
+                              notPorts:
+                                description: Optional.
+                                items:
+                                  format: string
+                                  type: string
+                                type: array
+                              paths:
+                                description: Optional.
+                                items:
+                                  format: string
+                                  type: string
+                                type: array
+                              ports:
+                                description: Optional.
+                                items:
+                                  format: string
+                                  type: string
+                                type: array
+                            type: object
+                        type: object
+                      type: array
+                    when:
+                      description: Optional.
+                      items:
+                        properties:
+                          key:
+                            description: The name of an Istio attribute.
+                            format: string
+                            type: string
+                          notValues:
+                            description: Optional.
+                            items:
+                              format: string
+                              type: string
+                            type: array
+                          values:
+                            description: Optional.
+                            items:
+                              format: string
+                              type: string
+                            type: array
+                        type: object
+                      type: array
+                  type: object
+                type: array
+              selector:
+                description: Optional.
+                properties:
+                  matchLabels:
+                    additionalProperties:
+                      format: string
+                      type: string
+                    type: object
+                type: object
+            type: object
+          status:
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
+        type: object
     served: true
     storage: true
+    subresources:
+      status: {}
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
@@ -238,20 +237,11 @@ metadata:
   labels:
     app: istio-pilot
     chart: istio
-    cloudfoundry.org/istio_version: 1.9.5
+    cloudfoundry.org/istio_version: 1.10.2
     heritage: Tiller
     release: istio
   name: destinationrules.networking.istio.io
 spec:
-  additionalPrinterColumns:
-  - JSONPath: .spec.host
-    description: The name of a service from the service registry
-    name: Host
-    type: string
-  - JSONPath: .metadata.creationTimestamp
-    description: 'CreationTimestamp is a timestamp representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations. Clients may not set this value. It is represented in RFC3339 form and is in UTC. Populated by the system. Read-only. Null for lists. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata'
-    name: Age
-    type: date
   group: networking.istio.io
   names:
     categories:
@@ -263,345 +253,111 @@ spec:
     shortNames:
     - dr
     singular: destinationrule
-  preserveUnknownFields: false
   scope: Namespaced
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      properties:
-        spec:
-          description: 'Configuration affecting load balancing, outlier detection, etc. See more details at: https://istio.io/docs/reference/config/networking/destination-rule.html'
-          properties:
-            exportTo:
-              description: A list of namespaces to which this destination rule is exported.
-              items:
+  versions:
+  - additionalPrinterColumns:
+    - description: The name of a service from the service registry
+      jsonPath: .spec.host
+      name: Host
+      type: string
+    - description: 'CreationTimestamp is a timestamp representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations. Clients may not set this value. It is represented in RFC3339 form and is in UTC. Populated by the system. Read-only. Null for lists. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata'
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha3
+    schema:
+      openAPIV3Schema:
+        properties:
+          spec:
+            description: 'Configuration affecting load balancing, outlier detection, etc. See more details at: https://istio.io/docs/reference/config/networking/destination-rule.html'
+            properties:
+              exportTo:
+                description: A list of namespaces to which this destination rule is exported.
+                items:
+                  format: string
+                  type: string
+                type: array
+              host:
+                description: The name of a service from the service registry.
                 format: string
                 type: string
-              type: array
-            host:
-              description: The name of a service from the service registry.
-              format: string
-              type: string
-            subsets:
-              items:
-                properties:
-                  labels:
-                    additionalProperties:
+              subsets:
+                items:
+                  properties:
+                    labels:
+                      additionalProperties:
+                        format: string
+                        type: string
+                      type: object
+                    name:
+                      description: Name of the subset.
                       format: string
                       type: string
-                    type: object
-                  name:
-                    description: Name of the subset.
-                    format: string
-                    type: string
-                  trafficPolicy:
-                    description: Traffic policies that apply to this subset.
-                    properties:
-                      connectionPool:
-                        properties:
-                          http:
-                            description: HTTP connection pool settings.
-                            properties:
-                              h2UpgradePolicy:
-                                description: Specify if http1.1 connection should be upgraded to http2 for the associated destination.
-                                enum:
-                                - DEFAULT
-                                - DO_NOT_UPGRADE
-                                - UPGRADE
-                                type: string
-                              http1MaxPendingRequests:
-                                description: Maximum number of pending HTTP requests to a destination.
-                                format: int32
-                                type: integer
-                              http2MaxRequests:
-                                description: Maximum number of requests to a backend.
-                                format: int32
-                                type: integer
-                              idleTimeout:
-                                description: The idle timeout for upstream connection pool connections.
-                                type: string
-                              maxRequestsPerConnection:
-                                description: Maximum number of requests per connection to a backend.
-                                format: int32
-                                type: integer
-                              maxRetries:
-                                format: int32
-                                type: integer
-                              useClientProtocol:
-                                description: If set to true, client protocol will be preserved while initiating connection to backend.
-                                type: boolean
-                            type: object
-                          tcp:
-                            description: Settings common to both HTTP and TCP upstream connections.
-                            properties:
-                              connectTimeout:
-                                description: TCP connection timeout.
-                                type: string
-                              maxConnections:
-                                description: Maximum number of HTTP1 /TCP connections to a destination host.
-                                format: int32
-                                type: integer
-                              tcpKeepalive:
-                                description: If set then set SO_KEEPALIVE on the socket to enable TCP Keepalives.
-                                properties:
-                                  interval:
-                                    description: The time duration between keep-alive probes.
-                                    type: string
-                                  probes:
-                                    type: integer
-                                  time:
-                                    type: string
-                                type: object
-                            type: object
-                        type: object
-                      loadBalancer:
-                        description: Settings controlling the load balancer algorithms.
-                        oneOf:
-                        - not:
-                            anyOf:
-                            - required:
-                              - simple
-                            - properties:
-                                consistentHash:
-                                  oneOf:
-                                  - not:
-                                      anyOf:
-                                      - required:
-                                        - httpHeaderName
-                                      - required:
-                                        - httpCookie
-                                      - required:
-                                        - useSourceIp
-                                      - required:
-                                        - httpQueryParameterName
-                                  - required:
-                                    - httpHeaderName
-                                  - required:
-                                    - httpCookie
-                                  - required:
-                                    - useSourceIp
-                                  - required:
-                                    - httpQueryParameterName
-                              required:
-                              - consistentHash
-                        - required:
-                          - simple
-                        - properties:
-                            consistentHash:
-                              oneOf:
-                              - not:
-                                  anyOf:
-                                  - required:
-                                    - httpHeaderName
-                                  - required:
-                                    - httpCookie
-                                  - required:
-                                    - useSourceIp
-                                  - required:
-                                    - httpQueryParameterName
-                              - required:
-                                - httpHeaderName
-                              - required:
-                                - httpCookie
-                              - required:
-                                - useSourceIp
-                              - required:
-                                - httpQueryParameterName
-                          required:
-                          - consistentHash
-                        properties:
-                          consistentHash:
-                            properties:
-                              httpCookie:
-                                description: Hash based on HTTP cookie.
-                                properties:
-                                  name:
-                                    description: Name of the cookie.
-                                    format: string
-                                    type: string
-                                  path:
-                                    description: Path to set for the cookie.
-                                    format: string
-                                    type: string
-                                  ttl:
-                                    description: Lifetime of the cookie.
-                                    type: string
-                                type: object
-                              httpHeaderName:
-                                description: Hash based on a specific HTTP header.
-                                format: string
-                                type: string
-                              httpQueryParameterName:
-                                description: Hash based on a specific HTTP query parameter.
-                                format: string
-                                type: string
-                              minimumRingSize:
-                                type: integer
-                              useSourceIp:
-                                description: Hash based on the source IP address.
-                                type: boolean
-                            type: object
-                          localityLbSetting:
-                            properties:
-                              distribute:
-                                description: 'Optional: only one of distribute or failover can be set.'
-                                items:
-                                  properties:
-                                    from:
-                                      description: Originating locality, '/' separated, e.g.
-                                      format: string
-                                      type: string
-                                    to:
-                                      additionalProperties:
-                                        type: integer
-                                      description: Map of upstream localities to traffic distribution weights.
-                                      type: object
-                                  type: object
-                                type: array
-                              enabled:
-                                description: enable locality load balancing, this is DestinationRule-level and will override mesh wide settings in entirety.
-                                nullable: true
-                                type: boolean
-                              failover:
-                                description: 'Optional: only failover or distribute can be set.'
-                                items:
-                                  properties:
-                                    from:
-                                      description: Originating region.
-                                      format: string
-                                      type: string
-                                    to:
-                                      format: string
-                                      type: string
-                                  type: object
-                                type: array
-                            type: object
-                          simple:
-                            enum:
-                            - ROUND_ROBIN
-                            - LEAST_CONN
-                            - RANDOM
-                            - PASSTHROUGH
-                            type: string
-                        type: object
-                      outlierDetection:
-                        properties:
-                          baseEjectionTime:
-                            description: Minimum ejection duration.
-                            type: string
-                          consecutive5xxErrors:
-                            description: Number of 5xx errors before a host is ejected from the connection pool.
-                            nullable: true
-                            type: integer
-                          consecutiveErrors:
-                            format: int32
-                            type: integer
-                          consecutiveGatewayErrors:
-                            description: Number of gateway errors before a host is ejected from the connection pool.
-                            nullable: true
-                            type: integer
-                          interval:
-                            description: Time interval between ejection sweep analysis.
-                            type: string
-                          maxEjectionPercent:
-                            format: int32
-                            type: integer
-                          minHealthPercent:
-                            format: int32
-                            type: integer
-                        type: object
-                      portLevelSettings:
-                        description: Traffic policies specific to individual ports.
-                        items:
+                    trafficPolicy:
+                      description: Traffic policies that apply to this subset.
+                      properties:
+                        connectionPool:
                           properties:
-                            connectionPool:
+                            http:
+                              description: HTTP connection pool settings.
                               properties:
-                                http:
-                                  description: HTTP connection pool settings.
+                                h2UpgradePolicy:
+                                  description: Specify if http1.1 connection should be upgraded to http2 for the associated destination.
+                                  enum:
+                                  - DEFAULT
+                                  - DO_NOT_UPGRADE
+                                  - UPGRADE
+                                  type: string
+                                http1MaxPendingRequests:
+                                  description: Maximum number of pending HTTP requests to a destination.
+                                  format: int32
+                                  type: integer
+                                http2MaxRequests:
+                                  description: Maximum number of requests to a backend.
+                                  format: int32
+                                  type: integer
+                                idleTimeout:
+                                  description: The idle timeout for upstream connection pool connections.
+                                  type: string
+                                maxRequestsPerConnection:
+                                  description: Maximum number of requests per connection to a backend.
+                                  format: int32
+                                  type: integer
+                                maxRetries:
+                                  format: int32
+                                  type: integer
+                                useClientProtocol:
+                                  description: If set to true, client protocol will be preserved while initiating connection to backend.
+                                  type: boolean
+                              type: object
+                            tcp:
+                              description: Settings common to both HTTP and TCP upstream connections.
+                              properties:
+                                connectTimeout:
+                                  description: TCP connection timeout.
+                                  type: string
+                                maxConnections:
+                                  description: Maximum number of HTTP1 /TCP connections to a destination host.
+                                  format: int32
+                                  type: integer
+                                tcpKeepalive:
+                                  description: If set then set SO_KEEPALIVE on the socket to enable TCP Keepalives.
                                   properties:
-                                    h2UpgradePolicy:
-                                      description: Specify if http1.1 connection should be upgraded to http2 for the associated destination.
-                                      enum:
-                                      - DEFAULT
-                                      - DO_NOT_UPGRADE
-                                      - UPGRADE
+                                    interval:
+                                      description: The time duration between keep-alive probes.
                                       type: string
-                                    http1MaxPendingRequests:
-                                      description: Maximum number of pending HTTP requests to a destination.
-                                      format: int32
+                                    probes:
                                       type: integer
-                                    http2MaxRequests:
-                                      description: Maximum number of requests to a backend.
-                                      format: int32
-                                      type: integer
-                                    idleTimeout:
-                                      description: The idle timeout for upstream connection pool connections.
+                                    time:
                                       type: string
-                                    maxRequestsPerConnection:
-                                      description: Maximum number of requests per connection to a backend.
-                                      format: int32
-                                      type: integer
-                                    maxRetries:
-                                      format: int32
-                                      type: integer
-                                    useClientProtocol:
-                                      description: If set to true, client protocol will be preserved while initiating connection to backend.
-                                      type: boolean
-                                  type: object
-                                tcp:
-                                  description: Settings common to both HTTP and TCP upstream connections.
-                                  properties:
-                                    connectTimeout:
-                                      description: TCP connection timeout.
-                                      type: string
-                                    maxConnections:
-                                      description: Maximum number of HTTP1 /TCP connections to a destination host.
-                                      format: int32
-                                      type: integer
-                                    tcpKeepalive:
-                                      description: If set then set SO_KEEPALIVE on the socket to enable TCP Keepalives.
-                                      properties:
-                                        interval:
-                                          description: The time duration between keep-alive probes.
-                                          type: string
-                                        probes:
-                                          type: integer
-                                        time:
-                                          type: string
-                                      type: object
                                   type: object
                               type: object
-                            loadBalancer:
-                              description: Settings controlling the load balancer algorithms.
-                              oneOf:
-                              - not:
-                                  anyOf:
-                                  - required:
-                                    - simple
-                                  - properties:
-                                      consistentHash:
-                                        oneOf:
-                                        - not:
-                                            anyOf:
-                                            - required:
-                                              - httpHeaderName
-                                            - required:
-                                              - httpCookie
-                                            - required:
-                                              - useSourceIp
-                                            - required:
-                                              - httpQueryParameterName
-                                        - required:
-                                          - httpHeaderName
-                                        - required:
-                                          - httpCookie
-                                        - required:
-                                          - useSourceIp
-                                        - required:
-                                          - httpQueryParameterName
-                                    required:
-                                    - consistentHash
+                          type: object
+                        loadBalancer:
+                          description: Settings controlling the load balancer algorithms.
+                          oneOf:
+                          - not:
+                              anyOf:
                               - required:
                                 - simple
                               - properties:
@@ -627,256 +383,21 @@ spec:
                                       - httpQueryParameterName
                                 required:
                                 - consistentHash
-                              properties:
-                                consistentHash:
-                                  properties:
-                                    httpCookie:
-                                      description: Hash based on HTTP cookie.
-                                      properties:
-                                        name:
-                                          description: Name of the cookie.
-                                          format: string
-                                          type: string
-                                        path:
-                                          description: Path to set for the cookie.
-                                          format: string
-                                          type: string
-                                        ttl:
-                                          description: Lifetime of the cookie.
-                                          type: string
-                                      type: object
-                                    httpHeaderName:
-                                      description: Hash based on a specific HTTP header.
-                                      format: string
-                                      type: string
-                                    httpQueryParameterName:
-                                      description: Hash based on a specific HTTP query parameter.
-                                      format: string
-                                      type: string
-                                    minimumRingSize:
-                                      type: integer
-                                    useSourceIp:
-                                      description: Hash based on the source IP address.
-                                      type: boolean
-                                  type: object
-                                localityLbSetting:
-                                  properties:
-                                    distribute:
-                                      description: 'Optional: only one of distribute or failover can be set.'
-                                      items:
-                                        properties:
-                                          from:
-                                            description: Originating locality, '/' separated, e.g.
-                                            format: string
-                                            type: string
-                                          to:
-                                            additionalProperties:
-                                              type: integer
-                                            description: Map of upstream localities to traffic distribution weights.
-                                            type: object
-                                        type: object
-                                      type: array
-                                    enabled:
-                                      description: enable locality load balancing, this is DestinationRule-level and will override mesh wide settings in entirety.
-                                      nullable: true
-                                      type: boolean
-                                    failover:
-                                      description: 'Optional: only failover or distribute can be set.'
-                                      items:
-                                        properties:
-                                          from:
-                                            description: Originating region.
-                                            format: string
-                                            type: string
-                                          to:
-                                            format: string
-                                            type: string
-                                        type: object
-                                      type: array
-                                  type: object
-                                simple:
-                                  enum:
-                                  - ROUND_ROBIN
-                                  - LEAST_CONN
-                                  - RANDOM
-                                  - PASSTHROUGH
-                                  type: string
-                              type: object
-                            outlierDetection:
-                              properties:
-                                baseEjectionTime:
-                                  description: Minimum ejection duration.
-                                  type: string
-                                consecutive5xxErrors:
-                                  description: Number of 5xx errors before a host is ejected from the connection pool.
-                                  nullable: true
-                                  type: integer
-                                consecutiveErrors:
-                                  format: int32
-                                  type: integer
-                                consecutiveGatewayErrors:
-                                  description: Number of gateway errors before a host is ejected from the connection pool.
-                                  nullable: true
-                                  type: integer
-                                interval:
-                                  description: Time interval between ejection sweep analysis.
-                                  type: string
-                                maxEjectionPercent:
-                                  format: int32
-                                  type: integer
-                                minHealthPercent:
-                                  format: int32
-                                  type: integer
-                              type: object
-                            port:
-                              properties:
-                                number:
-                                  type: integer
-                              type: object
-                            tls:
-                              description: TLS related settings for connections to the upstream service.
-                              properties:
-                                caCertificates:
-                                  format: string
-                                  type: string
-                                clientCertificate:
-                                  description: REQUIRED if mode is `MUTUAL`.
-                                  format: string
-                                  type: string
-                                credentialName:
-                                  format: string
-                                  type: string
-                                mode:
-                                  enum:
-                                  - DISABLE
-                                  - SIMPLE
-                                  - MUTUAL
-                                  - ISTIO_MUTUAL
-                                  type: string
-                                privateKey:
-                                  description: REQUIRED if mode is `MUTUAL`.
-                                  format: string
-                                  type: string
-                                sni:
-                                  description: SNI string to present to the server during TLS handshake.
-                                  format: string
-                                  type: string
-                                subjectAltNames:
-                                  items:
-                                    format: string
-                                    type: string
-                                  type: array
-                              type: object
-                          type: object
-                        type: array
-                      tls:
-                        description: TLS related settings for connections to the upstream service.
-                        properties:
-                          caCertificates:
-                            format: string
-                            type: string
-                          clientCertificate:
-                            description: REQUIRED if mode is `MUTUAL`.
-                            format: string
-                            type: string
-                          credentialName:
-                            format: string
-                            type: string
-                          mode:
-                            enum:
-                            - DISABLE
-                            - SIMPLE
-                            - MUTUAL
-                            - ISTIO_MUTUAL
-                            type: string
-                          privateKey:
-                            description: REQUIRED if mode is `MUTUAL`.
-                            format: string
-                            type: string
-                          sni:
-                            description: SNI string to present to the server during TLS handshake.
-                            format: string
-                            type: string
-                          subjectAltNames:
-                            items:
-                              format: string
-                              type: string
-                            type: array
-                        type: object
-                    type: object
-                type: object
-              type: array
-            trafficPolicy:
-              properties:
-                connectionPool:
-                  properties:
-                    http:
-                      description: HTTP connection pool settings.
-                      properties:
-                        h2UpgradePolicy:
-                          description: Specify if http1.1 connection should be upgraded to http2 for the associated destination.
-                          enum:
-                          - DEFAULT
-                          - DO_NOT_UPGRADE
-                          - UPGRADE
-                          type: string
-                        http1MaxPendingRequests:
-                          description: Maximum number of pending HTTP requests to a destination.
-                          format: int32
-                          type: integer
-                        http2MaxRequests:
-                          description: Maximum number of requests to a backend.
-                          format: int32
-                          type: integer
-                        idleTimeout:
-                          description: The idle timeout for upstream connection pool connections.
-                          type: string
-                        maxRequestsPerConnection:
-                          description: Maximum number of requests per connection to a backend.
-                          format: int32
-                          type: integer
-                        maxRetries:
-                          format: int32
-                          type: integer
-                        useClientProtocol:
-                          description: If set to true, client protocol will be preserved while initiating connection to backend.
-                          type: boolean
-                      type: object
-                    tcp:
-                      description: Settings common to both HTTP and TCP upstream connections.
-                      properties:
-                        connectTimeout:
-                          description: TCP connection timeout.
-                          type: string
-                        maxConnections:
-                          description: Maximum number of HTTP1 /TCP connections to a destination host.
-                          format: int32
-                          type: integer
-                        tcpKeepalive:
-                          description: If set then set SO_KEEPALIVE on the socket to enable TCP Keepalives.
-                          properties:
-                            interval:
-                              description: The time duration between keep-alive probes.
-                              type: string
-                            probes:
-                              type: integer
-                            time:
-                              type: string
-                          type: object
-                      type: object
-                  type: object
-                loadBalancer:
-                  description: Settings controlling the load balancer algorithms.
-                  oneOf:
-                  - not:
-                      anyOf:
-                      - required:
-                        - simple
-                      - properties:
-                          consistentHash:
-                            oneOf:
-                            - not:
-                                anyOf:
+                          - required:
+                            - simple
+                          - properties:
+                              consistentHash:
+                                oneOf:
+                                - not:
+                                    anyOf:
+                                    - required:
+                                      - httpHeaderName
+                                    - required:
+                                      - httpCookie
+                                    - required:
+                                      - useSourceIp
+                                    - required:
+                                      - httpQueryParameterName
                                 - required:
                                   - httpHeaderName
                                 - required:
@@ -885,215 +406,215 @@ spec:
                                   - useSourceIp
                                 - required:
                                   - httpQueryParameterName
-                            - required:
-                              - httpHeaderName
-                            - required:
-                              - httpCookie
-                            - required:
-                              - useSourceIp
-                            - required:
-                              - httpQueryParameterName
-                        required:
-                        - consistentHash
-                  - required:
-                    - simple
-                  - properties:
-                      consistentHash:
-                        oneOf:
-                        - not:
-                            anyOf:
-                            - required:
-                              - httpHeaderName
-                            - required:
-                              - httpCookie
-                            - required:
-                              - useSourceIp
-                            - required:
-                              - httpQueryParameterName
-                        - required:
-                          - httpHeaderName
-                        - required:
-                          - httpCookie
-                        - required:
-                          - useSourceIp
-                        - required:
-                          - httpQueryParameterName
-                    required:
-                    - consistentHash
-                  properties:
-                    consistentHash:
-                      properties:
-                        httpCookie:
-                          description: Hash based on HTTP cookie.
+                            required:
+                            - consistentHash
                           properties:
-                            name:
-                              description: Name of the cookie.
-                              format: string
-                              type: string
-                            path:
-                              description: Path to set for the cookie.
-                              format: string
-                              type: string
-                            ttl:
-                              description: Lifetime of the cookie.
+                            consistentHash:
+                              properties:
+                                httpCookie:
+                                  description: Hash based on HTTP cookie.
+                                  properties:
+                                    name:
+                                      description: Name of the cookie.
+                                      format: string
+                                      type: string
+                                    path:
+                                      description: Path to set for the cookie.
+                                      format: string
+                                      type: string
+                                    ttl:
+                                      description: Lifetime of the cookie.
+                                      type: string
+                                  type: object
+                                httpHeaderName:
+                                  description: Hash based on a specific HTTP header.
+                                  format: string
+                                  type: string
+                                httpQueryParameterName:
+                                  description: Hash based on a specific HTTP query parameter.
+                                  format: string
+                                  type: string
+                                minimumRingSize:
+                                  type: integer
+                                useSourceIp:
+                                  description: Hash based on the source IP address.
+                                  type: boolean
+                              type: object
+                            localityLbSetting:
+                              properties:
+                                distribute:
+                                  description: 'Optional: only one of distribute or failover can be set.'
+                                  items:
+                                    properties:
+                                      from:
+                                        description: Originating locality, '/' separated, e.g.
+                                        format: string
+                                        type: string
+                                      to:
+                                        additionalProperties:
+                                          type: integer
+                                        description: Map of upstream localities to traffic distribution weights.
+                                        type: object
+                                    type: object
+                                  type: array
+                                enabled:
+                                  description: enable locality load balancing, this is DestinationRule-level and will override mesh wide settings in entirety.
+                                  nullable: true
+                                  type: boolean
+                                failover:
+                                  description: 'Optional: only failover or distribute can be set.'
+                                  items:
+                                    properties:
+                                      from:
+                                        description: Originating region.
+                                        format: string
+                                        type: string
+                                      to:
+                                        format: string
+                                        type: string
+                                    type: object
+                                  type: array
+                              type: object
+                            simple:
+                              enum:
+                              - ROUND_ROBIN
+                              - LEAST_CONN
+                              - RANDOM
+                              - PASSTHROUGH
                               type: string
                           type: object
-                        httpHeaderName:
-                          description: Hash based on a specific HTTP header.
-                          format: string
-                          type: string
-                        httpQueryParameterName:
-                          description: Hash based on a specific HTTP query parameter.
-                          format: string
-                          type: string
-                        minimumRingSize:
-                          type: integer
-                        useSourceIp:
-                          description: Hash based on the source IP address.
-                          type: boolean
-                      type: object
-                    localityLbSetting:
-                      properties:
-                        distribute:
-                          description: 'Optional: only one of distribute or failover can be set.'
+                        outlierDetection:
+                          properties:
+                            baseEjectionTime:
+                              description: Minimum ejection duration.
+                              type: string
+                            consecutive5xxErrors:
+                              description: Number of 5xx errors before a host is ejected from the connection pool.
+                              nullable: true
+                              type: integer
+                            consecutiveErrors:
+                              format: int32
+                              type: integer
+                            consecutiveGatewayErrors:
+                              description: Number of gateway errors before a host is ejected from the connection pool.
+                              nullable: true
+                              type: integer
+                            interval:
+                              description: Time interval between ejection sweep analysis.
+                              type: string
+                            maxEjectionPercent:
+                              format: int32
+                              type: integer
+                            minHealthPercent:
+                              format: int32
+                              type: integer
+                          type: object
+                        portLevelSettings:
+                          description: Traffic policies specific to individual ports.
                           items:
                             properties:
-                              from:
-                                description: Originating locality, '/' separated, e.g.
-                                format: string
-                                type: string
-                              to:
-                                additionalProperties:
-                                  type: integer
-                                description: Map of upstream localities to traffic distribution weights.
-                                type: object
-                            type: object
-                          type: array
-                        enabled:
-                          description: enable locality load balancing, this is DestinationRule-level and will override mesh wide settings in entirety.
-                          nullable: true
-                          type: boolean
-                        failover:
-                          description: 'Optional: only failover or distribute can be set.'
-                          items:
-                            properties:
-                              from:
-                                description: Originating region.
-                                format: string
-                                type: string
-                              to:
-                                format: string
-                                type: string
-                            type: object
-                          type: array
-                      type: object
-                    simple:
-                      enum:
-                      - ROUND_ROBIN
-                      - LEAST_CONN
-                      - RANDOM
-                      - PASSTHROUGH
-                      type: string
-                  type: object
-                outlierDetection:
-                  properties:
-                    baseEjectionTime:
-                      description: Minimum ejection duration.
-                      type: string
-                    consecutive5xxErrors:
-                      description: Number of 5xx errors before a host is ejected from the connection pool.
-                      nullable: true
-                      type: integer
-                    consecutiveErrors:
-                      format: int32
-                      type: integer
-                    consecutiveGatewayErrors:
-                      description: Number of gateway errors before a host is ejected from the connection pool.
-                      nullable: true
-                      type: integer
-                    interval:
-                      description: Time interval between ejection sweep analysis.
-                      type: string
-                    maxEjectionPercent:
-                      format: int32
-                      type: integer
-                    minHealthPercent:
-                      format: int32
-                      type: integer
-                  type: object
-                portLevelSettings:
-                  description: Traffic policies specific to individual ports.
-                  items:
-                    properties:
-                      connectionPool:
-                        properties:
-                          http:
-                            description: HTTP connection pool settings.
-                            properties:
-                              h2UpgradePolicy:
-                                description: Specify if http1.1 connection should be upgraded to http2 for the associated destination.
-                                enum:
-                                - DEFAULT
-                                - DO_NOT_UPGRADE
-                                - UPGRADE
-                                type: string
-                              http1MaxPendingRequests:
-                                description: Maximum number of pending HTTP requests to a destination.
-                                format: int32
-                                type: integer
-                              http2MaxRequests:
-                                description: Maximum number of requests to a backend.
-                                format: int32
-                                type: integer
-                              idleTimeout:
-                                description: The idle timeout for upstream connection pool connections.
-                                type: string
-                              maxRequestsPerConnection:
-                                description: Maximum number of requests per connection to a backend.
-                                format: int32
-                                type: integer
-                              maxRetries:
-                                format: int32
-                                type: integer
-                              useClientProtocol:
-                                description: If set to true, client protocol will be preserved while initiating connection to backend.
-                                type: boolean
-                            type: object
-                          tcp:
-                            description: Settings common to both HTTP and TCP upstream connections.
-                            properties:
-                              connectTimeout:
-                                description: TCP connection timeout.
-                                type: string
-                              maxConnections:
-                                description: Maximum number of HTTP1 /TCP connections to a destination host.
-                                format: int32
-                                type: integer
-                              tcpKeepalive:
-                                description: If set then set SO_KEEPALIVE on the socket to enable TCP Keepalives.
+                              connectionPool:
                                 properties:
-                                  interval:
-                                    description: The time duration between keep-alive probes.
-                                    type: string
-                                  probes:
-                                    type: integer
-                                  time:
-                                    type: string
+                                  http:
+                                    description: HTTP connection pool settings.
+                                    properties:
+                                      h2UpgradePolicy:
+                                        description: Specify if http1.1 connection should be upgraded to http2 for the associated destination.
+                                        enum:
+                                        - DEFAULT
+                                        - DO_NOT_UPGRADE
+                                        - UPGRADE
+                                        type: string
+                                      http1MaxPendingRequests:
+                                        description: Maximum number of pending HTTP requests to a destination.
+                                        format: int32
+                                        type: integer
+                                      http2MaxRequests:
+                                        description: Maximum number of requests to a backend.
+                                        format: int32
+                                        type: integer
+                                      idleTimeout:
+                                        description: The idle timeout for upstream connection pool connections.
+                                        type: string
+                                      maxRequestsPerConnection:
+                                        description: Maximum number of requests per connection to a backend.
+                                        format: int32
+                                        type: integer
+                                      maxRetries:
+                                        format: int32
+                                        type: integer
+                                      useClientProtocol:
+                                        description: If set to true, client protocol will be preserved while initiating connection to backend.
+                                        type: boolean
+                                    type: object
+                                  tcp:
+                                    description: Settings common to both HTTP and TCP upstream connections.
+                                    properties:
+                                      connectTimeout:
+                                        description: TCP connection timeout.
+                                        type: string
+                                      maxConnections:
+                                        description: Maximum number of HTTP1 /TCP connections to a destination host.
+                                        format: int32
+                                        type: integer
+                                      tcpKeepalive:
+                                        description: If set then set SO_KEEPALIVE on the socket to enable TCP Keepalives.
+                                        properties:
+                                          interval:
+                                            description: The time duration between keep-alive probes.
+                                            type: string
+                                          probes:
+                                            type: integer
+                                          time:
+                                            type: string
+                                        type: object
+                                    type: object
                                 type: object
-                            type: object
-                        type: object
-                      loadBalancer:
-                        description: Settings controlling the load balancer algorithms.
-                        oneOf:
-                        - not:
-                            anyOf:
-                            - required:
-                              - simple
-                            - properties:
-                                consistentHash:
-                                  oneOf:
-                                  - not:
-                                      anyOf:
+                              loadBalancer:
+                                description: Settings controlling the load balancer algorithms.
+                                oneOf:
+                                - not:
+                                    anyOf:
+                                    - required:
+                                      - simple
+                                    - properties:
+                                        consistentHash:
+                                          oneOf:
+                                          - not:
+                                              anyOf:
+                                              - required:
+                                                - httpHeaderName
+                                              - required:
+                                                - httpCookie
+                                              - required:
+                                                - useSourceIp
+                                              - required:
+                                                - httpQueryParameterName
+                                          - required:
+                                            - httpHeaderName
+                                          - required:
+                                            - httpCookie
+                                          - required:
+                                            - useSourceIp
+                                          - required:
+                                            - httpQueryParameterName
+                                      required:
+                                      - consistentHash
+                                - required:
+                                  - simple
+                                - properties:
+                                    consistentHash:
+                                      oneOf:
+                                      - not:
+                                          anyOf:
+                                          - required:
+                                            - httpHeaderName
+                                          - required:
+                                            - httpCookie
+                                          - required:
+                                            - useSourceIp
+                                          - required:
+                                            - httpQueryParameterName
                                       - required:
                                         - httpHeaderName
                                       - required:
@@ -1102,16 +623,251 @@ spec:
                                         - useSourceIp
                                       - required:
                                         - httpQueryParameterName
-                                  - required:
-                                    - httpHeaderName
-                                  - required:
-                                    - httpCookie
-                                  - required:
-                                    - useSourceIp
-                                  - required:
-                                    - httpQueryParameterName
-                              required:
-                              - consistentHash
+                                  required:
+                                  - consistentHash
+                                properties:
+                                  consistentHash:
+                                    properties:
+                                      httpCookie:
+                                        description: Hash based on HTTP cookie.
+                                        properties:
+                                          name:
+                                            description: Name of the cookie.
+                                            format: string
+                                            type: string
+                                          path:
+                                            description: Path to set for the cookie.
+                                            format: string
+                                            type: string
+                                          ttl:
+                                            description: Lifetime of the cookie.
+                                            type: string
+                                        type: object
+                                      httpHeaderName:
+                                        description: Hash based on a specific HTTP header.
+                                        format: string
+                                        type: string
+                                      httpQueryParameterName:
+                                        description: Hash based on a specific HTTP query parameter.
+                                        format: string
+                                        type: string
+                                      minimumRingSize:
+                                        type: integer
+                                      useSourceIp:
+                                        description: Hash based on the source IP address.
+                                        type: boolean
+                                    type: object
+                                  localityLbSetting:
+                                    properties:
+                                      distribute:
+                                        description: 'Optional: only one of distribute or failover can be set.'
+                                        items:
+                                          properties:
+                                            from:
+                                              description: Originating locality, '/' separated, e.g.
+                                              format: string
+                                              type: string
+                                            to:
+                                              additionalProperties:
+                                                type: integer
+                                              description: Map of upstream localities to traffic distribution weights.
+                                              type: object
+                                          type: object
+                                        type: array
+                                      enabled:
+                                        description: enable locality load balancing, this is DestinationRule-level and will override mesh wide settings in entirety.
+                                        nullable: true
+                                        type: boolean
+                                      failover:
+                                        description: 'Optional: only failover or distribute can be set.'
+                                        items:
+                                          properties:
+                                            from:
+                                              description: Originating region.
+                                              format: string
+                                              type: string
+                                            to:
+                                              format: string
+                                              type: string
+                                          type: object
+                                        type: array
+                                    type: object
+                                  simple:
+                                    enum:
+                                    - ROUND_ROBIN
+                                    - LEAST_CONN
+                                    - RANDOM
+                                    - PASSTHROUGH
+                                    type: string
+                                type: object
+                              outlierDetection:
+                                properties:
+                                  baseEjectionTime:
+                                    description: Minimum ejection duration.
+                                    type: string
+                                  consecutive5xxErrors:
+                                    description: Number of 5xx errors before a host is ejected from the connection pool.
+                                    nullable: true
+                                    type: integer
+                                  consecutiveErrors:
+                                    format: int32
+                                    type: integer
+                                  consecutiveGatewayErrors:
+                                    description: Number of gateway errors before a host is ejected from the connection pool.
+                                    nullable: true
+                                    type: integer
+                                  interval:
+                                    description: Time interval between ejection sweep analysis.
+                                    type: string
+                                  maxEjectionPercent:
+                                    format: int32
+                                    type: integer
+                                  minHealthPercent:
+                                    format: int32
+                                    type: integer
+                                type: object
+                              port:
+                                properties:
+                                  number:
+                                    type: integer
+                                type: object
+                              tls:
+                                description: TLS related settings for connections to the upstream service.
+                                properties:
+                                  caCertificates:
+                                    format: string
+                                    type: string
+                                  clientCertificate:
+                                    description: REQUIRED if mode is `MUTUAL`.
+                                    format: string
+                                    type: string
+                                  credentialName:
+                                    format: string
+                                    type: string
+                                  mode:
+                                    enum:
+                                    - DISABLE
+                                    - SIMPLE
+                                    - MUTUAL
+                                    - ISTIO_MUTUAL
+                                    type: string
+                                  privateKey:
+                                    description: REQUIRED if mode is `MUTUAL`.
+                                    format: string
+                                    type: string
+                                  sni:
+                                    description: SNI string to present to the server during TLS handshake.
+                                    format: string
+                                    type: string
+                                  subjectAltNames:
+                                    items:
+                                      format: string
+                                      type: string
+                                    type: array
+                                type: object
+                            type: object
+                          type: array
+                        tls:
+                          description: TLS related settings for connections to the upstream service.
+                          properties:
+                            caCertificates:
+                              format: string
+                              type: string
+                            clientCertificate:
+                              description: REQUIRED if mode is `MUTUAL`.
+                              format: string
+                              type: string
+                            credentialName:
+                              format: string
+                              type: string
+                            mode:
+                              enum:
+                              - DISABLE
+                              - SIMPLE
+                              - MUTUAL
+                              - ISTIO_MUTUAL
+                              type: string
+                            privateKey:
+                              description: REQUIRED if mode is `MUTUAL`.
+                              format: string
+                              type: string
+                            sni:
+                              description: SNI string to present to the server during TLS handshake.
+                              format: string
+                              type: string
+                            subjectAltNames:
+                              items:
+                                format: string
+                                type: string
+                              type: array
+                          type: object
+                      type: object
+                  type: object
+                type: array
+              trafficPolicy:
+                properties:
+                  connectionPool:
+                    properties:
+                      http:
+                        description: HTTP connection pool settings.
+                        properties:
+                          h2UpgradePolicy:
+                            description: Specify if http1.1 connection should be upgraded to http2 for the associated destination.
+                            enum:
+                            - DEFAULT
+                            - DO_NOT_UPGRADE
+                            - UPGRADE
+                            type: string
+                          http1MaxPendingRequests:
+                            description: Maximum number of pending HTTP requests to a destination.
+                            format: int32
+                            type: integer
+                          http2MaxRequests:
+                            description: Maximum number of requests to a backend.
+                            format: int32
+                            type: integer
+                          idleTimeout:
+                            description: The idle timeout for upstream connection pool connections.
+                            type: string
+                          maxRequestsPerConnection:
+                            description: Maximum number of requests per connection to a backend.
+                            format: int32
+                            type: integer
+                          maxRetries:
+                            format: int32
+                            type: integer
+                          useClientProtocol:
+                            description: If set to true, client protocol will be preserved while initiating connection to backend.
+                            type: boolean
+                        type: object
+                      tcp:
+                        description: Settings common to both HTTP and TCP upstream connections.
+                        properties:
+                          connectTimeout:
+                            description: TCP connection timeout.
+                            type: string
+                          maxConnections:
+                            description: Maximum number of HTTP1 /TCP connections to a destination host.
+                            format: int32
+                            type: integer
+                          tcpKeepalive:
+                            description: If set then set SO_KEEPALIVE on the socket to enable TCP Keepalives.
+                            properties:
+                              interval:
+                                description: The time duration between keep-alive probes.
+                                type: string
+                              probes:
+                                type: integer
+                              time:
+                                type: string
+                            type: object
+                        type: object
+                    type: object
+                  loadBalancer:
+                    description: Settings controlling the load balancer algorithms.
+                    oneOf:
+                    - not:
+                        anyOf:
                         - required:
                           - simple
                         - properties:
@@ -1137,197 +893,1502 @@ spec:
                                 - httpQueryParameterName
                           required:
                           - consistentHash
+                    - required:
+                      - simple
+                    - properties:
+                        consistentHash:
+                          oneOf:
+                          - not:
+                              anyOf:
+                              - required:
+                                - httpHeaderName
+                              - required:
+                                - httpCookie
+                              - required:
+                                - useSourceIp
+                              - required:
+                                - httpQueryParameterName
+                          - required:
+                            - httpHeaderName
+                          - required:
+                            - httpCookie
+                          - required:
+                            - useSourceIp
+                          - required:
+                            - httpQueryParameterName
+                      required:
+                      - consistentHash
+                    properties:
+                      consistentHash:
                         properties:
-                          consistentHash:
+                          httpCookie:
+                            description: Hash based on HTTP cookie.
                             properties:
-                              httpCookie:
-                                description: Hash based on HTTP cookie.
-                                properties:
-                                  name:
-                                    description: Name of the cookie.
-                                    format: string
-                                    type: string
-                                  path:
-                                    description: Path to set for the cookie.
-                                    format: string
-                                    type: string
-                                  ttl:
-                                    description: Lifetime of the cookie.
-                                    type: string
-                                type: object
-                              httpHeaderName:
-                                description: Hash based on a specific HTTP header.
+                              name:
+                                description: Name of the cookie.
                                 format: string
                                 type: string
-                              httpQueryParameterName:
-                                description: Hash based on a specific HTTP query parameter.
+                              path:
+                                description: Path to set for the cookie.
                                 format: string
                                 type: string
-                              minimumRingSize:
-                                type: integer
-                              useSourceIp:
-                                description: Hash based on the source IP address.
-                                type: boolean
+                              ttl:
+                                description: Lifetime of the cookie.
+                                type: string
                             type: object
-                          localityLbSetting:
-                            properties:
-                              distribute:
-                                description: 'Optional: only one of distribute or failover can be set.'
-                                items:
-                                  properties:
-                                    from:
-                                      description: Originating locality, '/' separated, e.g.
-                                      format: string
-                                      type: string
-                                    to:
-                                      additionalProperties:
-                                        type: integer
-                                      description: Map of upstream localities to traffic distribution weights.
-                                      type: object
-                                  type: object
-                                type: array
-                              enabled:
-                                description: enable locality load balancing, this is DestinationRule-level and will override mesh wide settings in entirety.
-                                nullable: true
-                                type: boolean
-                              failover:
-                                description: 'Optional: only failover or distribute can be set.'
-                                items:
-                                  properties:
-                                    from:
-                                      description: Originating region.
-                                      format: string
-                                      type: string
-                                    to:
-                                      format: string
-                                      type: string
-                                  type: object
-                                type: array
-                            type: object
-                          simple:
-                            enum:
-                            - ROUND_ROBIN
-                            - LEAST_CONN
-                            - RANDOM
-                            - PASSTHROUGH
+                          httpHeaderName:
+                            description: Hash based on a specific HTTP header.
+                            format: string
                             type: string
+                          httpQueryParameterName:
+                            description: Hash based on a specific HTTP query parameter.
+                            format: string
+                            type: string
+                          minimumRingSize:
+                            type: integer
+                          useSourceIp:
+                            description: Hash based on the source IP address.
+                            type: boolean
                         type: object
-                      outlierDetection:
+                      localityLbSetting:
                         properties:
-                          baseEjectionTime:
-                            description: Minimum ejection duration.
-                            type: string
-                          consecutive5xxErrors:
-                            description: Number of 5xx errors before a host is ejected from the connection pool.
-                            nullable: true
-                            type: integer
-                          consecutiveErrors:
-                            format: int32
-                            type: integer
-                          consecutiveGatewayErrors:
-                            description: Number of gateway errors before a host is ejected from the connection pool.
-                            nullable: true
-                            type: integer
-                          interval:
-                            description: Time interval between ejection sweep analysis.
-                            type: string
-                          maxEjectionPercent:
-                            format: int32
-                            type: integer
-                          minHealthPercent:
-                            format: int32
-                            type: integer
-                        type: object
-                      port:
-                        properties:
-                          number:
-                            type: integer
-                        type: object
-                      tls:
-                        description: TLS related settings for connections to the upstream service.
-                        properties:
-                          caCertificates:
-                            format: string
-                            type: string
-                          clientCertificate:
-                            description: REQUIRED if mode is `MUTUAL`.
-                            format: string
-                            type: string
-                          credentialName:
-                            format: string
-                            type: string
-                          mode:
-                            enum:
-                            - DISABLE
-                            - SIMPLE
-                            - MUTUAL
-                            - ISTIO_MUTUAL
-                            type: string
-                          privateKey:
-                            description: REQUIRED if mode is `MUTUAL`.
-                            format: string
-                            type: string
-                          sni:
-                            description: SNI string to present to the server during TLS handshake.
-                            format: string
-                            type: string
-                          subjectAltNames:
+                          distribute:
+                            description: 'Optional: only one of distribute or failover can be set.'
                             items:
-                              format: string
-                              type: string
+                              properties:
+                                from:
+                                  description: Originating locality, '/' separated, e.g.
+                                  format: string
+                                  type: string
+                                to:
+                                  additionalProperties:
+                                    type: integer
+                                  description: Map of upstream localities to traffic distribution weights.
+                                  type: object
+                              type: object
+                            type: array
+                          enabled:
+                            description: enable locality load balancing, this is DestinationRule-level and will override mesh wide settings in entirety.
+                            nullable: true
+                            type: boolean
+                          failover:
+                            description: 'Optional: only failover or distribute can be set.'
+                            items:
+                              properties:
+                                from:
+                                  description: Originating region.
+                                  format: string
+                                  type: string
+                                to:
+                                  format: string
+                                  type: string
+                              type: object
                             type: array
                         type: object
+                      simple:
+                        enum:
+                        - ROUND_ROBIN
+                        - LEAST_CONN
+                        - RANDOM
+                        - PASSTHROUGH
+                        type: string
                     type: object
-                  type: array
-                tls:
-                  description: TLS related settings for connections to the upstream service.
-                  properties:
-                    caCertificates:
-                      format: string
-                      type: string
-                    clientCertificate:
-                      description: REQUIRED if mode is `MUTUAL`.
-                      format: string
-                      type: string
-                    credentialName:
-                      format: string
-                      type: string
-                    mode:
-                      enum:
-                      - DISABLE
-                      - SIMPLE
-                      - MUTUAL
-                      - ISTIO_MUTUAL
-                      type: string
-                    privateKey:
-                      description: REQUIRED if mode is `MUTUAL`.
-                      format: string
-                      type: string
-                    sni:
-                      description: SNI string to present to the server during TLS handshake.
-                      format: string
-                      type: string
-                    subjectAltNames:
-                      items:
+                  outlierDetection:
+                    properties:
+                      baseEjectionTime:
+                        description: Minimum ejection duration.
+                        type: string
+                      consecutive5xxErrors:
+                        description: Number of 5xx errors before a host is ejected from the connection pool.
+                        nullable: true
+                        type: integer
+                      consecutiveErrors:
+                        format: int32
+                        type: integer
+                      consecutiveGatewayErrors:
+                        description: Number of gateway errors before a host is ejected from the connection pool.
+                        nullable: true
+                        type: integer
+                      interval:
+                        description: Time interval between ejection sweep analysis.
+                        type: string
+                      maxEjectionPercent:
+                        format: int32
+                        type: integer
+                      minHealthPercent:
+                        format: int32
+                        type: integer
+                    type: object
+                  portLevelSettings:
+                    description: Traffic policies specific to individual ports.
+                    items:
+                      properties:
+                        connectionPool:
+                          properties:
+                            http:
+                              description: HTTP connection pool settings.
+                              properties:
+                                h2UpgradePolicy:
+                                  description: Specify if http1.1 connection should be upgraded to http2 for the associated destination.
+                                  enum:
+                                  - DEFAULT
+                                  - DO_NOT_UPGRADE
+                                  - UPGRADE
+                                  type: string
+                                http1MaxPendingRequests:
+                                  description: Maximum number of pending HTTP requests to a destination.
+                                  format: int32
+                                  type: integer
+                                http2MaxRequests:
+                                  description: Maximum number of requests to a backend.
+                                  format: int32
+                                  type: integer
+                                idleTimeout:
+                                  description: The idle timeout for upstream connection pool connections.
+                                  type: string
+                                maxRequestsPerConnection:
+                                  description: Maximum number of requests per connection to a backend.
+                                  format: int32
+                                  type: integer
+                                maxRetries:
+                                  format: int32
+                                  type: integer
+                                useClientProtocol:
+                                  description: If set to true, client protocol will be preserved while initiating connection to backend.
+                                  type: boolean
+                              type: object
+                            tcp:
+                              description: Settings common to both HTTP and TCP upstream connections.
+                              properties:
+                                connectTimeout:
+                                  description: TCP connection timeout.
+                                  type: string
+                                maxConnections:
+                                  description: Maximum number of HTTP1 /TCP connections to a destination host.
+                                  format: int32
+                                  type: integer
+                                tcpKeepalive:
+                                  description: If set then set SO_KEEPALIVE on the socket to enable TCP Keepalives.
+                                  properties:
+                                    interval:
+                                      description: The time duration between keep-alive probes.
+                                      type: string
+                                    probes:
+                                      type: integer
+                                    time:
+                                      type: string
+                                  type: object
+                              type: object
+                          type: object
+                        loadBalancer:
+                          description: Settings controlling the load balancer algorithms.
+                          oneOf:
+                          - not:
+                              anyOf:
+                              - required:
+                                - simple
+                              - properties:
+                                  consistentHash:
+                                    oneOf:
+                                    - not:
+                                        anyOf:
+                                        - required:
+                                          - httpHeaderName
+                                        - required:
+                                          - httpCookie
+                                        - required:
+                                          - useSourceIp
+                                        - required:
+                                          - httpQueryParameterName
+                                    - required:
+                                      - httpHeaderName
+                                    - required:
+                                      - httpCookie
+                                    - required:
+                                      - useSourceIp
+                                    - required:
+                                      - httpQueryParameterName
+                                required:
+                                - consistentHash
+                          - required:
+                            - simple
+                          - properties:
+                              consistentHash:
+                                oneOf:
+                                - not:
+                                    anyOf:
+                                    - required:
+                                      - httpHeaderName
+                                    - required:
+                                      - httpCookie
+                                    - required:
+                                      - useSourceIp
+                                    - required:
+                                      - httpQueryParameterName
+                                - required:
+                                  - httpHeaderName
+                                - required:
+                                  - httpCookie
+                                - required:
+                                  - useSourceIp
+                                - required:
+                                  - httpQueryParameterName
+                            required:
+                            - consistentHash
+                          properties:
+                            consistentHash:
+                              properties:
+                                httpCookie:
+                                  description: Hash based on HTTP cookie.
+                                  properties:
+                                    name:
+                                      description: Name of the cookie.
+                                      format: string
+                                      type: string
+                                    path:
+                                      description: Path to set for the cookie.
+                                      format: string
+                                      type: string
+                                    ttl:
+                                      description: Lifetime of the cookie.
+                                      type: string
+                                  type: object
+                                httpHeaderName:
+                                  description: Hash based on a specific HTTP header.
+                                  format: string
+                                  type: string
+                                httpQueryParameterName:
+                                  description: Hash based on a specific HTTP query parameter.
+                                  format: string
+                                  type: string
+                                minimumRingSize:
+                                  type: integer
+                                useSourceIp:
+                                  description: Hash based on the source IP address.
+                                  type: boolean
+                              type: object
+                            localityLbSetting:
+                              properties:
+                                distribute:
+                                  description: 'Optional: only one of distribute or failover can be set.'
+                                  items:
+                                    properties:
+                                      from:
+                                        description: Originating locality, '/' separated, e.g.
+                                        format: string
+                                        type: string
+                                      to:
+                                        additionalProperties:
+                                          type: integer
+                                        description: Map of upstream localities to traffic distribution weights.
+                                        type: object
+                                    type: object
+                                  type: array
+                                enabled:
+                                  description: enable locality load balancing, this is DestinationRule-level and will override mesh wide settings in entirety.
+                                  nullable: true
+                                  type: boolean
+                                failover:
+                                  description: 'Optional: only failover or distribute can be set.'
+                                  items:
+                                    properties:
+                                      from:
+                                        description: Originating region.
+                                        format: string
+                                        type: string
+                                      to:
+                                        format: string
+                                        type: string
+                                    type: object
+                                  type: array
+                              type: object
+                            simple:
+                              enum:
+                              - ROUND_ROBIN
+                              - LEAST_CONN
+                              - RANDOM
+                              - PASSTHROUGH
+                              type: string
+                          type: object
+                        outlierDetection:
+                          properties:
+                            baseEjectionTime:
+                              description: Minimum ejection duration.
+                              type: string
+                            consecutive5xxErrors:
+                              description: Number of 5xx errors before a host is ejected from the connection pool.
+                              nullable: true
+                              type: integer
+                            consecutiveErrors:
+                              format: int32
+                              type: integer
+                            consecutiveGatewayErrors:
+                              description: Number of gateway errors before a host is ejected from the connection pool.
+                              nullable: true
+                              type: integer
+                            interval:
+                              description: Time interval between ejection sweep analysis.
+                              type: string
+                            maxEjectionPercent:
+                              format: int32
+                              type: integer
+                            minHealthPercent:
+                              format: int32
+                              type: integer
+                          type: object
+                        port:
+                          properties:
+                            number:
+                              type: integer
+                          type: object
+                        tls:
+                          description: TLS related settings for connections to the upstream service.
+                          properties:
+                            caCertificates:
+                              format: string
+                              type: string
+                            clientCertificate:
+                              description: REQUIRED if mode is `MUTUAL`.
+                              format: string
+                              type: string
+                            credentialName:
+                              format: string
+                              type: string
+                            mode:
+                              enum:
+                              - DISABLE
+                              - SIMPLE
+                              - MUTUAL
+                              - ISTIO_MUTUAL
+                              type: string
+                            privateKey:
+                              description: REQUIRED if mode is `MUTUAL`.
+                              format: string
+                              type: string
+                            sni:
+                              description: SNI string to present to the server during TLS handshake.
+                              format: string
+                              type: string
+                            subjectAltNames:
+                              items:
+                                format: string
+                                type: string
+                              type: array
+                          type: object
+                      type: object
+                    type: array
+                  tls:
+                    description: TLS related settings for connections to the upstream service.
+                    properties:
+                      caCertificates:
                         format: string
                         type: string
-                      type: array
-                  type: object
-              type: object
-          type: object
-        status:
-          type: object
-          x-kubernetes-preserve-unknown-fields: true
-      type: object
-  versions:
-  - name: v1alpha3
+                      clientCertificate:
+                        description: REQUIRED if mode is `MUTUAL`.
+                        format: string
+                        type: string
+                      credentialName:
+                        format: string
+                        type: string
+                      mode:
+                        enum:
+                        - DISABLE
+                        - SIMPLE
+                        - MUTUAL
+                        - ISTIO_MUTUAL
+                        type: string
+                      privateKey:
+                        description: REQUIRED if mode is `MUTUAL`.
+                        format: string
+                        type: string
+                      sni:
+                        description: SNI string to present to the server during TLS handshake.
+                        format: string
+                        type: string
+                      subjectAltNames:
+                        items:
+                          format: string
+                          type: string
+                        type: array
+                    type: object
+                type: object
+            type: object
+          status:
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
+        type: object
     served: true
     storage: true
-  - name: v1beta1
+    subresources:
+      status: {}
+  - additionalPrinterColumns:
+    - description: The name of a service from the service registry
+      jsonPath: .spec.host
+      name: Host
+      type: string
+    - description: 'CreationTimestamp is a timestamp representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations. Clients may not set this value. It is represented in RFC3339 form and is in UTC. Populated by the system. Read-only. Null for lists. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata'
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        properties:
+          spec:
+            description: 'Configuration affecting load balancing, outlier detection, etc. See more details at: https://istio.io/docs/reference/config/networking/destination-rule.html'
+            properties:
+              exportTo:
+                description: A list of namespaces to which this destination rule is exported.
+                items:
+                  format: string
+                  type: string
+                type: array
+              host:
+                description: The name of a service from the service registry.
+                format: string
+                type: string
+              subsets:
+                items:
+                  properties:
+                    labels:
+                      additionalProperties:
+                        format: string
+                        type: string
+                      type: object
+                    name:
+                      description: Name of the subset.
+                      format: string
+                      type: string
+                    trafficPolicy:
+                      description: Traffic policies that apply to this subset.
+                      properties:
+                        connectionPool:
+                          properties:
+                            http:
+                              description: HTTP connection pool settings.
+                              properties:
+                                h2UpgradePolicy:
+                                  description: Specify if http1.1 connection should be upgraded to http2 for the associated destination.
+                                  enum:
+                                  - DEFAULT
+                                  - DO_NOT_UPGRADE
+                                  - UPGRADE
+                                  type: string
+                                http1MaxPendingRequests:
+                                  description: Maximum number of pending HTTP requests to a destination.
+                                  format: int32
+                                  type: integer
+                                http2MaxRequests:
+                                  description: Maximum number of requests to a backend.
+                                  format: int32
+                                  type: integer
+                                idleTimeout:
+                                  description: The idle timeout for upstream connection pool connections.
+                                  type: string
+                                maxRequestsPerConnection:
+                                  description: Maximum number of requests per connection to a backend.
+                                  format: int32
+                                  type: integer
+                                maxRetries:
+                                  format: int32
+                                  type: integer
+                                useClientProtocol:
+                                  description: If set to true, client protocol will be preserved while initiating connection to backend.
+                                  type: boolean
+                              type: object
+                            tcp:
+                              description: Settings common to both HTTP and TCP upstream connections.
+                              properties:
+                                connectTimeout:
+                                  description: TCP connection timeout.
+                                  type: string
+                                maxConnections:
+                                  description: Maximum number of HTTP1 /TCP connections to a destination host.
+                                  format: int32
+                                  type: integer
+                                tcpKeepalive:
+                                  description: If set then set SO_KEEPALIVE on the socket to enable TCP Keepalives.
+                                  properties:
+                                    interval:
+                                      description: The time duration between keep-alive probes.
+                                      type: string
+                                    probes:
+                                      type: integer
+                                    time:
+                                      type: string
+                                  type: object
+                              type: object
+                          type: object
+                        loadBalancer:
+                          description: Settings controlling the load balancer algorithms.
+                          oneOf:
+                          - not:
+                              anyOf:
+                              - required:
+                                - simple
+                              - properties:
+                                  consistentHash:
+                                    oneOf:
+                                    - not:
+                                        anyOf:
+                                        - required:
+                                          - httpHeaderName
+                                        - required:
+                                          - httpCookie
+                                        - required:
+                                          - useSourceIp
+                                        - required:
+                                          - httpQueryParameterName
+                                    - required:
+                                      - httpHeaderName
+                                    - required:
+                                      - httpCookie
+                                    - required:
+                                      - useSourceIp
+                                    - required:
+                                      - httpQueryParameterName
+                                required:
+                                - consistentHash
+                          - required:
+                            - simple
+                          - properties:
+                              consistentHash:
+                                oneOf:
+                                - not:
+                                    anyOf:
+                                    - required:
+                                      - httpHeaderName
+                                    - required:
+                                      - httpCookie
+                                    - required:
+                                      - useSourceIp
+                                    - required:
+                                      - httpQueryParameterName
+                                - required:
+                                  - httpHeaderName
+                                - required:
+                                  - httpCookie
+                                - required:
+                                  - useSourceIp
+                                - required:
+                                  - httpQueryParameterName
+                            required:
+                            - consistentHash
+                          properties:
+                            consistentHash:
+                              properties:
+                                httpCookie:
+                                  description: Hash based on HTTP cookie.
+                                  properties:
+                                    name:
+                                      description: Name of the cookie.
+                                      format: string
+                                      type: string
+                                    path:
+                                      description: Path to set for the cookie.
+                                      format: string
+                                      type: string
+                                    ttl:
+                                      description: Lifetime of the cookie.
+                                      type: string
+                                  type: object
+                                httpHeaderName:
+                                  description: Hash based on a specific HTTP header.
+                                  format: string
+                                  type: string
+                                httpQueryParameterName:
+                                  description: Hash based on a specific HTTP query parameter.
+                                  format: string
+                                  type: string
+                                minimumRingSize:
+                                  type: integer
+                                useSourceIp:
+                                  description: Hash based on the source IP address.
+                                  type: boolean
+                              type: object
+                            localityLbSetting:
+                              properties:
+                                distribute:
+                                  description: 'Optional: only one of distribute or failover can be set.'
+                                  items:
+                                    properties:
+                                      from:
+                                        description: Originating locality, '/' separated, e.g.
+                                        format: string
+                                        type: string
+                                      to:
+                                        additionalProperties:
+                                          type: integer
+                                        description: Map of upstream localities to traffic distribution weights.
+                                        type: object
+                                    type: object
+                                  type: array
+                                enabled:
+                                  description: enable locality load balancing, this is DestinationRule-level and will override mesh wide settings in entirety.
+                                  nullable: true
+                                  type: boolean
+                                failover:
+                                  description: 'Optional: only failover or distribute can be set.'
+                                  items:
+                                    properties:
+                                      from:
+                                        description: Originating region.
+                                        format: string
+                                        type: string
+                                      to:
+                                        format: string
+                                        type: string
+                                    type: object
+                                  type: array
+                              type: object
+                            simple:
+                              enum:
+                              - ROUND_ROBIN
+                              - LEAST_CONN
+                              - RANDOM
+                              - PASSTHROUGH
+                              type: string
+                          type: object
+                        outlierDetection:
+                          properties:
+                            baseEjectionTime:
+                              description: Minimum ejection duration.
+                              type: string
+                            consecutive5xxErrors:
+                              description: Number of 5xx errors before a host is ejected from the connection pool.
+                              nullable: true
+                              type: integer
+                            consecutiveErrors:
+                              format: int32
+                              type: integer
+                            consecutiveGatewayErrors:
+                              description: Number of gateway errors before a host is ejected from the connection pool.
+                              nullable: true
+                              type: integer
+                            interval:
+                              description: Time interval between ejection sweep analysis.
+                              type: string
+                            maxEjectionPercent:
+                              format: int32
+                              type: integer
+                            minHealthPercent:
+                              format: int32
+                              type: integer
+                          type: object
+                        portLevelSettings:
+                          description: Traffic policies specific to individual ports.
+                          items:
+                            properties:
+                              connectionPool:
+                                properties:
+                                  http:
+                                    description: HTTP connection pool settings.
+                                    properties:
+                                      h2UpgradePolicy:
+                                        description: Specify if http1.1 connection should be upgraded to http2 for the associated destination.
+                                        enum:
+                                        - DEFAULT
+                                        - DO_NOT_UPGRADE
+                                        - UPGRADE
+                                        type: string
+                                      http1MaxPendingRequests:
+                                        description: Maximum number of pending HTTP requests to a destination.
+                                        format: int32
+                                        type: integer
+                                      http2MaxRequests:
+                                        description: Maximum number of requests to a backend.
+                                        format: int32
+                                        type: integer
+                                      idleTimeout:
+                                        description: The idle timeout for upstream connection pool connections.
+                                        type: string
+                                      maxRequestsPerConnection:
+                                        description: Maximum number of requests per connection to a backend.
+                                        format: int32
+                                        type: integer
+                                      maxRetries:
+                                        format: int32
+                                        type: integer
+                                      useClientProtocol:
+                                        description: If set to true, client protocol will be preserved while initiating connection to backend.
+                                        type: boolean
+                                    type: object
+                                  tcp:
+                                    description: Settings common to both HTTP and TCP upstream connections.
+                                    properties:
+                                      connectTimeout:
+                                        description: TCP connection timeout.
+                                        type: string
+                                      maxConnections:
+                                        description: Maximum number of HTTP1 /TCP connections to a destination host.
+                                        format: int32
+                                        type: integer
+                                      tcpKeepalive:
+                                        description: If set then set SO_KEEPALIVE on the socket to enable TCP Keepalives.
+                                        properties:
+                                          interval:
+                                            description: The time duration between keep-alive probes.
+                                            type: string
+                                          probes:
+                                            type: integer
+                                          time:
+                                            type: string
+                                        type: object
+                                    type: object
+                                type: object
+                              loadBalancer:
+                                description: Settings controlling the load balancer algorithms.
+                                oneOf:
+                                - not:
+                                    anyOf:
+                                    - required:
+                                      - simple
+                                    - properties:
+                                        consistentHash:
+                                          oneOf:
+                                          - not:
+                                              anyOf:
+                                              - required:
+                                                - httpHeaderName
+                                              - required:
+                                                - httpCookie
+                                              - required:
+                                                - useSourceIp
+                                              - required:
+                                                - httpQueryParameterName
+                                          - required:
+                                            - httpHeaderName
+                                          - required:
+                                            - httpCookie
+                                          - required:
+                                            - useSourceIp
+                                          - required:
+                                            - httpQueryParameterName
+                                      required:
+                                      - consistentHash
+                                - required:
+                                  - simple
+                                - properties:
+                                    consistentHash:
+                                      oneOf:
+                                      - not:
+                                          anyOf:
+                                          - required:
+                                            - httpHeaderName
+                                          - required:
+                                            - httpCookie
+                                          - required:
+                                            - useSourceIp
+                                          - required:
+                                            - httpQueryParameterName
+                                      - required:
+                                        - httpHeaderName
+                                      - required:
+                                        - httpCookie
+                                      - required:
+                                        - useSourceIp
+                                      - required:
+                                        - httpQueryParameterName
+                                  required:
+                                  - consistentHash
+                                properties:
+                                  consistentHash:
+                                    properties:
+                                      httpCookie:
+                                        description: Hash based on HTTP cookie.
+                                        properties:
+                                          name:
+                                            description: Name of the cookie.
+                                            format: string
+                                            type: string
+                                          path:
+                                            description: Path to set for the cookie.
+                                            format: string
+                                            type: string
+                                          ttl:
+                                            description: Lifetime of the cookie.
+                                            type: string
+                                        type: object
+                                      httpHeaderName:
+                                        description: Hash based on a specific HTTP header.
+                                        format: string
+                                        type: string
+                                      httpQueryParameterName:
+                                        description: Hash based on a specific HTTP query parameter.
+                                        format: string
+                                        type: string
+                                      minimumRingSize:
+                                        type: integer
+                                      useSourceIp:
+                                        description: Hash based on the source IP address.
+                                        type: boolean
+                                    type: object
+                                  localityLbSetting:
+                                    properties:
+                                      distribute:
+                                        description: 'Optional: only one of distribute or failover can be set.'
+                                        items:
+                                          properties:
+                                            from:
+                                              description: Originating locality, '/' separated, e.g.
+                                              format: string
+                                              type: string
+                                            to:
+                                              additionalProperties:
+                                                type: integer
+                                              description: Map of upstream localities to traffic distribution weights.
+                                              type: object
+                                          type: object
+                                        type: array
+                                      enabled:
+                                        description: enable locality load balancing, this is DestinationRule-level and will override mesh wide settings in entirety.
+                                        nullable: true
+                                        type: boolean
+                                      failover:
+                                        description: 'Optional: only failover or distribute can be set.'
+                                        items:
+                                          properties:
+                                            from:
+                                              description: Originating region.
+                                              format: string
+                                              type: string
+                                            to:
+                                              format: string
+                                              type: string
+                                          type: object
+                                        type: array
+                                    type: object
+                                  simple:
+                                    enum:
+                                    - ROUND_ROBIN
+                                    - LEAST_CONN
+                                    - RANDOM
+                                    - PASSTHROUGH
+                                    type: string
+                                type: object
+                              outlierDetection:
+                                properties:
+                                  baseEjectionTime:
+                                    description: Minimum ejection duration.
+                                    type: string
+                                  consecutive5xxErrors:
+                                    description: Number of 5xx errors before a host is ejected from the connection pool.
+                                    nullable: true
+                                    type: integer
+                                  consecutiveErrors:
+                                    format: int32
+                                    type: integer
+                                  consecutiveGatewayErrors:
+                                    description: Number of gateway errors before a host is ejected from the connection pool.
+                                    nullable: true
+                                    type: integer
+                                  interval:
+                                    description: Time interval between ejection sweep analysis.
+                                    type: string
+                                  maxEjectionPercent:
+                                    format: int32
+                                    type: integer
+                                  minHealthPercent:
+                                    format: int32
+                                    type: integer
+                                type: object
+                              port:
+                                properties:
+                                  number:
+                                    type: integer
+                                type: object
+                              tls:
+                                description: TLS related settings for connections to the upstream service.
+                                properties:
+                                  caCertificates:
+                                    format: string
+                                    type: string
+                                  clientCertificate:
+                                    description: REQUIRED if mode is `MUTUAL`.
+                                    format: string
+                                    type: string
+                                  credentialName:
+                                    format: string
+                                    type: string
+                                  mode:
+                                    enum:
+                                    - DISABLE
+                                    - SIMPLE
+                                    - MUTUAL
+                                    - ISTIO_MUTUAL
+                                    type: string
+                                  privateKey:
+                                    description: REQUIRED if mode is `MUTUAL`.
+                                    format: string
+                                    type: string
+                                  sni:
+                                    description: SNI string to present to the server during TLS handshake.
+                                    format: string
+                                    type: string
+                                  subjectAltNames:
+                                    items:
+                                      format: string
+                                      type: string
+                                    type: array
+                                type: object
+                            type: object
+                          type: array
+                        tls:
+                          description: TLS related settings for connections to the upstream service.
+                          properties:
+                            caCertificates:
+                              format: string
+                              type: string
+                            clientCertificate:
+                              description: REQUIRED if mode is `MUTUAL`.
+                              format: string
+                              type: string
+                            credentialName:
+                              format: string
+                              type: string
+                            mode:
+                              enum:
+                              - DISABLE
+                              - SIMPLE
+                              - MUTUAL
+                              - ISTIO_MUTUAL
+                              type: string
+                            privateKey:
+                              description: REQUIRED if mode is `MUTUAL`.
+                              format: string
+                              type: string
+                            sni:
+                              description: SNI string to present to the server during TLS handshake.
+                              format: string
+                              type: string
+                            subjectAltNames:
+                              items:
+                                format: string
+                                type: string
+                              type: array
+                          type: object
+                      type: object
+                  type: object
+                type: array
+              trafficPolicy:
+                properties:
+                  connectionPool:
+                    properties:
+                      http:
+                        description: HTTP connection pool settings.
+                        properties:
+                          h2UpgradePolicy:
+                            description: Specify if http1.1 connection should be upgraded to http2 for the associated destination.
+                            enum:
+                            - DEFAULT
+                            - DO_NOT_UPGRADE
+                            - UPGRADE
+                            type: string
+                          http1MaxPendingRequests:
+                            description: Maximum number of pending HTTP requests to a destination.
+                            format: int32
+                            type: integer
+                          http2MaxRequests:
+                            description: Maximum number of requests to a backend.
+                            format: int32
+                            type: integer
+                          idleTimeout:
+                            description: The idle timeout for upstream connection pool connections.
+                            type: string
+                          maxRequestsPerConnection:
+                            description: Maximum number of requests per connection to a backend.
+                            format: int32
+                            type: integer
+                          maxRetries:
+                            format: int32
+                            type: integer
+                          useClientProtocol:
+                            description: If set to true, client protocol will be preserved while initiating connection to backend.
+                            type: boolean
+                        type: object
+                      tcp:
+                        description: Settings common to both HTTP and TCP upstream connections.
+                        properties:
+                          connectTimeout:
+                            description: TCP connection timeout.
+                            type: string
+                          maxConnections:
+                            description: Maximum number of HTTP1 /TCP connections to a destination host.
+                            format: int32
+                            type: integer
+                          tcpKeepalive:
+                            description: If set then set SO_KEEPALIVE on the socket to enable TCP Keepalives.
+                            properties:
+                              interval:
+                                description: The time duration between keep-alive probes.
+                                type: string
+                              probes:
+                                type: integer
+                              time:
+                                type: string
+                            type: object
+                        type: object
+                    type: object
+                  loadBalancer:
+                    description: Settings controlling the load balancer algorithms.
+                    oneOf:
+                    - not:
+                        anyOf:
+                        - required:
+                          - simple
+                        - properties:
+                            consistentHash:
+                              oneOf:
+                              - not:
+                                  anyOf:
+                                  - required:
+                                    - httpHeaderName
+                                  - required:
+                                    - httpCookie
+                                  - required:
+                                    - useSourceIp
+                                  - required:
+                                    - httpQueryParameterName
+                              - required:
+                                - httpHeaderName
+                              - required:
+                                - httpCookie
+                              - required:
+                                - useSourceIp
+                              - required:
+                                - httpQueryParameterName
+                          required:
+                          - consistentHash
+                    - required:
+                      - simple
+                    - properties:
+                        consistentHash:
+                          oneOf:
+                          - not:
+                              anyOf:
+                              - required:
+                                - httpHeaderName
+                              - required:
+                                - httpCookie
+                              - required:
+                                - useSourceIp
+                              - required:
+                                - httpQueryParameterName
+                          - required:
+                            - httpHeaderName
+                          - required:
+                            - httpCookie
+                          - required:
+                            - useSourceIp
+                          - required:
+                            - httpQueryParameterName
+                      required:
+                      - consistentHash
+                    properties:
+                      consistentHash:
+                        properties:
+                          httpCookie:
+                            description: Hash based on HTTP cookie.
+                            properties:
+                              name:
+                                description: Name of the cookie.
+                                format: string
+                                type: string
+                              path:
+                                description: Path to set for the cookie.
+                                format: string
+                                type: string
+                              ttl:
+                                description: Lifetime of the cookie.
+                                type: string
+                            type: object
+                          httpHeaderName:
+                            description: Hash based on a specific HTTP header.
+                            format: string
+                            type: string
+                          httpQueryParameterName:
+                            description: Hash based on a specific HTTP query parameter.
+                            format: string
+                            type: string
+                          minimumRingSize:
+                            type: integer
+                          useSourceIp:
+                            description: Hash based on the source IP address.
+                            type: boolean
+                        type: object
+                      localityLbSetting:
+                        properties:
+                          distribute:
+                            description: 'Optional: only one of distribute or failover can be set.'
+                            items:
+                              properties:
+                                from:
+                                  description: Originating locality, '/' separated, e.g.
+                                  format: string
+                                  type: string
+                                to:
+                                  additionalProperties:
+                                    type: integer
+                                  description: Map of upstream localities to traffic distribution weights.
+                                  type: object
+                              type: object
+                            type: array
+                          enabled:
+                            description: enable locality load balancing, this is DestinationRule-level and will override mesh wide settings in entirety.
+                            nullable: true
+                            type: boolean
+                          failover:
+                            description: 'Optional: only failover or distribute can be set.'
+                            items:
+                              properties:
+                                from:
+                                  description: Originating region.
+                                  format: string
+                                  type: string
+                                to:
+                                  format: string
+                                  type: string
+                              type: object
+                            type: array
+                        type: object
+                      simple:
+                        enum:
+                        - ROUND_ROBIN
+                        - LEAST_CONN
+                        - RANDOM
+                        - PASSTHROUGH
+                        type: string
+                    type: object
+                  outlierDetection:
+                    properties:
+                      baseEjectionTime:
+                        description: Minimum ejection duration.
+                        type: string
+                      consecutive5xxErrors:
+                        description: Number of 5xx errors before a host is ejected from the connection pool.
+                        nullable: true
+                        type: integer
+                      consecutiveErrors:
+                        format: int32
+                        type: integer
+                      consecutiveGatewayErrors:
+                        description: Number of gateway errors before a host is ejected from the connection pool.
+                        nullable: true
+                        type: integer
+                      interval:
+                        description: Time interval between ejection sweep analysis.
+                        type: string
+                      maxEjectionPercent:
+                        format: int32
+                        type: integer
+                      minHealthPercent:
+                        format: int32
+                        type: integer
+                    type: object
+                  portLevelSettings:
+                    description: Traffic policies specific to individual ports.
+                    items:
+                      properties:
+                        connectionPool:
+                          properties:
+                            http:
+                              description: HTTP connection pool settings.
+                              properties:
+                                h2UpgradePolicy:
+                                  description: Specify if http1.1 connection should be upgraded to http2 for the associated destination.
+                                  enum:
+                                  - DEFAULT
+                                  - DO_NOT_UPGRADE
+                                  - UPGRADE
+                                  type: string
+                                http1MaxPendingRequests:
+                                  description: Maximum number of pending HTTP requests to a destination.
+                                  format: int32
+                                  type: integer
+                                http2MaxRequests:
+                                  description: Maximum number of requests to a backend.
+                                  format: int32
+                                  type: integer
+                                idleTimeout:
+                                  description: The idle timeout for upstream connection pool connections.
+                                  type: string
+                                maxRequestsPerConnection:
+                                  description: Maximum number of requests per connection to a backend.
+                                  format: int32
+                                  type: integer
+                                maxRetries:
+                                  format: int32
+                                  type: integer
+                                useClientProtocol:
+                                  description: If set to true, client protocol will be preserved while initiating connection to backend.
+                                  type: boolean
+                              type: object
+                            tcp:
+                              description: Settings common to both HTTP and TCP upstream connections.
+                              properties:
+                                connectTimeout:
+                                  description: TCP connection timeout.
+                                  type: string
+                                maxConnections:
+                                  description: Maximum number of HTTP1 /TCP connections to a destination host.
+                                  format: int32
+                                  type: integer
+                                tcpKeepalive:
+                                  description: If set then set SO_KEEPALIVE on the socket to enable TCP Keepalives.
+                                  properties:
+                                    interval:
+                                      description: The time duration between keep-alive probes.
+                                      type: string
+                                    probes:
+                                      type: integer
+                                    time:
+                                      type: string
+                                  type: object
+                              type: object
+                          type: object
+                        loadBalancer:
+                          description: Settings controlling the load balancer algorithms.
+                          oneOf:
+                          - not:
+                              anyOf:
+                              - required:
+                                - simple
+                              - properties:
+                                  consistentHash:
+                                    oneOf:
+                                    - not:
+                                        anyOf:
+                                        - required:
+                                          - httpHeaderName
+                                        - required:
+                                          - httpCookie
+                                        - required:
+                                          - useSourceIp
+                                        - required:
+                                          - httpQueryParameterName
+                                    - required:
+                                      - httpHeaderName
+                                    - required:
+                                      - httpCookie
+                                    - required:
+                                      - useSourceIp
+                                    - required:
+                                      - httpQueryParameterName
+                                required:
+                                - consistentHash
+                          - required:
+                            - simple
+                          - properties:
+                              consistentHash:
+                                oneOf:
+                                - not:
+                                    anyOf:
+                                    - required:
+                                      - httpHeaderName
+                                    - required:
+                                      - httpCookie
+                                    - required:
+                                      - useSourceIp
+                                    - required:
+                                      - httpQueryParameterName
+                                - required:
+                                  - httpHeaderName
+                                - required:
+                                  - httpCookie
+                                - required:
+                                  - useSourceIp
+                                - required:
+                                  - httpQueryParameterName
+                            required:
+                            - consistentHash
+                          properties:
+                            consistentHash:
+                              properties:
+                                httpCookie:
+                                  description: Hash based on HTTP cookie.
+                                  properties:
+                                    name:
+                                      description: Name of the cookie.
+                                      format: string
+                                      type: string
+                                    path:
+                                      description: Path to set for the cookie.
+                                      format: string
+                                      type: string
+                                    ttl:
+                                      description: Lifetime of the cookie.
+                                      type: string
+                                  type: object
+                                httpHeaderName:
+                                  description: Hash based on a specific HTTP header.
+                                  format: string
+                                  type: string
+                                httpQueryParameterName:
+                                  description: Hash based on a specific HTTP query parameter.
+                                  format: string
+                                  type: string
+                                minimumRingSize:
+                                  type: integer
+                                useSourceIp:
+                                  description: Hash based on the source IP address.
+                                  type: boolean
+                              type: object
+                            localityLbSetting:
+                              properties:
+                                distribute:
+                                  description: 'Optional: only one of distribute or failover can be set.'
+                                  items:
+                                    properties:
+                                      from:
+                                        description: Originating locality, '/' separated, e.g.
+                                        format: string
+                                        type: string
+                                      to:
+                                        additionalProperties:
+                                          type: integer
+                                        description: Map of upstream localities to traffic distribution weights.
+                                        type: object
+                                    type: object
+                                  type: array
+                                enabled:
+                                  description: enable locality load balancing, this is DestinationRule-level and will override mesh wide settings in entirety.
+                                  nullable: true
+                                  type: boolean
+                                failover:
+                                  description: 'Optional: only failover or distribute can be set.'
+                                  items:
+                                    properties:
+                                      from:
+                                        description: Originating region.
+                                        format: string
+                                        type: string
+                                      to:
+                                        format: string
+                                        type: string
+                                    type: object
+                                  type: array
+                              type: object
+                            simple:
+                              enum:
+                              - ROUND_ROBIN
+                              - LEAST_CONN
+                              - RANDOM
+                              - PASSTHROUGH
+                              type: string
+                          type: object
+                        outlierDetection:
+                          properties:
+                            baseEjectionTime:
+                              description: Minimum ejection duration.
+                              type: string
+                            consecutive5xxErrors:
+                              description: Number of 5xx errors before a host is ejected from the connection pool.
+                              nullable: true
+                              type: integer
+                            consecutiveErrors:
+                              format: int32
+                              type: integer
+                            consecutiveGatewayErrors:
+                              description: Number of gateway errors before a host is ejected from the connection pool.
+                              nullable: true
+                              type: integer
+                            interval:
+                              description: Time interval between ejection sweep analysis.
+                              type: string
+                            maxEjectionPercent:
+                              format: int32
+                              type: integer
+                            minHealthPercent:
+                              format: int32
+                              type: integer
+                          type: object
+                        port:
+                          properties:
+                            number:
+                              type: integer
+                          type: object
+                        tls:
+                          description: TLS related settings for connections to the upstream service.
+                          properties:
+                            caCertificates:
+                              format: string
+                              type: string
+                            clientCertificate:
+                              description: REQUIRED if mode is `MUTUAL`.
+                              format: string
+                              type: string
+                            credentialName:
+                              format: string
+                              type: string
+                            mode:
+                              enum:
+                              - DISABLE
+                              - SIMPLE
+                              - MUTUAL
+                              - ISTIO_MUTUAL
+                              type: string
+                            privateKey:
+                              description: REQUIRED if mode is `MUTUAL`.
+                              format: string
+                              type: string
+                            sni:
+                              description: SNI string to present to the server during TLS handshake.
+                              format: string
+                              type: string
+                            subjectAltNames:
+                              items:
+                                format: string
+                                type: string
+                              type: array
+                          type: object
+                      type: object
+                    type: array
+                  tls:
+                    description: TLS related settings for connections to the upstream service.
+                    properties:
+                      caCertificates:
+                        format: string
+                        type: string
+                      clientCertificate:
+                        description: REQUIRED if mode is `MUTUAL`.
+                        format: string
+                        type: string
+                      credentialName:
+                        format: string
+                        type: string
+                      mode:
+                        enum:
+                        - DISABLE
+                        - SIMPLE
+                        - MUTUAL
+                        - ISTIO_MUTUAL
+                        type: string
+                      privateKey:
+                        description: REQUIRED if mode is `MUTUAL`.
+                        format: string
+                        type: string
+                      sni:
+                        description: SNI string to present to the server during TLS handshake.
+                        format: string
+                        type: string
+                      subjectAltNames:
+                        items:
+                          format: string
+                          type: string
+                        type: array
+                    type: object
+                type: object
+            type: object
+          status:
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
+        type: object
     served: true
     storage: false
+    subresources:
+      status: {}
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
@@ -1335,7 +2396,7 @@ metadata:
   labels:
     app: istio-pilot
     chart: istio
-    cloudfoundry.org/istio_version: 1.9.5
+    cloudfoundry.org/istio_version: 1.10.2
     heritage: Tiller
     release: istio
   name: envoyfilters.networking.istio.io
@@ -1349,228 +2410,228 @@ spec:
     listKind: EnvoyFilterList
     plural: envoyfilters
     singular: envoyfilter
-  preserveUnknownFields: true
   scope: Namespaced
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      properties:
-        spec:
-          description: 'Customizing Envoy configuration generated by Istio. See more details at: https://istio.io/docs/reference/config/networking/envoy-filter.html'
-          properties:
-            configPatches:
-              description: One or more patches with match conditions.
-              items:
-                properties:
-                  applyTo:
-                    enum:
-                    - INVALID
-                    - LISTENER
-                    - FILTER_CHAIN
-                    - NETWORK_FILTER
-                    - HTTP_FILTER
-                    - ROUTE_CONFIGURATION
-                    - VIRTUAL_HOST
-                    - HTTP_ROUTE
-                    - CLUSTER
-                    - EXTENSION_CONFIG
-                    type: string
-                  match:
-                    description: Match on listener/route configuration/cluster.
-                    oneOf:
-                    - not:
-                        anyOf:
-                        - required:
-                          - listener
-                        - required:
-                          - routeConfiguration
-                        - required:
-                          - cluster
-                    - required:
-                      - listener
-                    - required:
-                      - routeConfiguration
-                    - required:
-                      - cluster
-                    properties:
-                      cluster:
-                        description: Match on envoy cluster attributes.
-                        properties:
-                          name:
-                            description: The exact name of the cluster to match.
-                            format: string
-                            type: string
-                          portNumber:
-                            description: The service port for which this cluster was generated.
-                            type: integer
-                          service:
-                            description: The fully qualified service name for this cluster.
-                            format: string
-                            type: string
-                          subset:
-                            description: The subset associated with the service.
-                            format: string
-                            type: string
-                        type: object
-                      context:
-                        description: The specific config generation context to match on.
-                        enum:
-                        - ANY
-                        - SIDECAR_INBOUND
-                        - SIDECAR_OUTBOUND
-                        - GATEWAY
-                        type: string
-                      listener:
-                        description: Match on envoy listener attributes.
-                        properties:
-                          filterChain:
-                            description: Match a specific filter chain in a listener.
-                            properties:
-                              applicationProtocols:
-                                description: Applies only to sidecars.
-                                format: string
-                                type: string
-                              destinationPort:
-                                description: The destination_port value used by a filter chain's match condition.
-                                type: integer
-                              filter:
-                                description: The name of a specific filter to apply the patch to.
-                                properties:
-                                  name:
-                                    description: The filter name to match on.
-                                    format: string
-                                    type: string
-                                  subFilter:
-                                    properties:
-                                      name:
-                                        description: The filter name to match on.
-                                        format: string
-                                        type: string
-                                    type: object
-                                type: object
-                              name:
-                                description: The name assigned to the filter chain.
-                                format: string
-                                type: string
-                              sni:
-                                description: The SNI value used by a filter chain's match condition.
-                                format: string
-                                type: string
-                              transportProtocol:
-                                description: Applies only to `SIDECAR_INBOUND` context.
-                                format: string
-                                type: string
-                            type: object
-                          name:
-                            description: Match a specific listener by its name.
-                            format: string
-                            type: string
-                          portName:
-                            format: string
-                            type: string
-                          portNumber:
-                            type: integer
-                        type: object
-                      proxy:
-                        description: Match on properties associated with a proxy.
-                        properties:
-                          metadata:
-                            additionalProperties:
-                              format: string
-                              type: string
-                            type: object
-                          proxyVersion:
-                            format: string
-                            type: string
-                        type: object
-                      routeConfiguration:
-                        description: Match on envoy HTTP route configuration attributes.
-                        properties:
-                          gateway:
-                            format: string
-                            type: string
-                          name:
-                            description: Route configuration name to match on.
-                            format: string
-                            type: string
-                          portName:
-                            description: Applicable only for GATEWAY context.
-                            format: string
-                            type: string
-                          portNumber:
-                            type: integer
-                          vhost:
-                            properties:
-                              name:
-                                format: string
-                                type: string
-                              route:
-                                description: Match a specific route within the virtual host.
-                                properties:
-                                  action:
-                                    description: Match a route with specific action type.
-                                    enum:
-                                    - ANY
-                                    - ROUTE
-                                    - REDIRECT
-                                    - DIRECT_RESPONSE
-                                    type: string
-                                  name:
-                                    format: string
-                                    type: string
-                                type: object
-                            type: object
-                        type: object
-                    type: object
-                  patch:
-                    description: The patch to apply along with the operation.
-                    properties:
-                      filterClass:
-                        description: Determines the filter insertion order.
-                        enum:
-                        - UNSPECIFIED
-                        - AUTHN
-                        - AUTHZ
-                        - STATS
-                        type: string
-                      operation:
-                        description: Determines how the patch should be applied.
-                        enum:
-                        - INVALID
-                        - MERGE
-                        - ADD
-                        - REMOVE
-                        - INSERT_BEFORE
-                        - INSERT_AFTER
-                        - INSERT_FIRST
-                        - REPLACE
-                        type: string
-                      value:
-                        description: The JSON config of the object being patched.
-                        type: object
-                    type: object
-                type: object
-              type: array
-            workloadSelector:
-              properties:
-                labels:
-                  additionalProperties:
-                    format: string
-                    type: string
-                  type: object
-              type: object
-          type: object
-        status:
-          type: object
-          x-kubernetes-preserve-unknown-fields: true
-      type: object
   versions:
   - name: v1alpha3
+    schema:
+      openAPIV3Schema:
+        properties:
+          spec:
+            description: 'Customizing Envoy configuration generated by Istio. See more details at: https://istio.io/docs/reference/config/networking/envoy-filter.html'
+            properties:
+              configPatches:
+                description: One or more patches with match conditions.
+                items:
+                  properties:
+                    applyTo:
+                      enum:
+                      - INVALID
+                      - LISTENER
+                      - FILTER_CHAIN
+                      - NETWORK_FILTER
+                      - HTTP_FILTER
+                      - ROUTE_CONFIGURATION
+                      - VIRTUAL_HOST
+                      - HTTP_ROUTE
+                      - CLUSTER
+                      - EXTENSION_CONFIG
+                      type: string
+                    match:
+                      description: Match on listener/route configuration/cluster.
+                      oneOf:
+                      - not:
+                          anyOf:
+                          - required:
+                            - listener
+                          - required:
+                            - routeConfiguration
+                          - required:
+                            - cluster
+                      - required:
+                        - listener
+                      - required:
+                        - routeConfiguration
+                      - required:
+                        - cluster
+                      properties:
+                        cluster:
+                          description: Match on envoy cluster attributes.
+                          properties:
+                            name:
+                              description: The exact name of the cluster to match.
+                              format: string
+                              type: string
+                            portNumber:
+                              description: The service port for which this cluster was generated.
+                              type: integer
+                            service:
+                              description: The fully qualified service name for this cluster.
+                              format: string
+                              type: string
+                            subset:
+                              description: The subset associated with the service.
+                              format: string
+                              type: string
+                          type: object
+                        context:
+                          description: The specific config generation context to match on.
+                          enum:
+                          - ANY
+                          - SIDECAR_INBOUND
+                          - SIDECAR_OUTBOUND
+                          - GATEWAY
+                          type: string
+                        listener:
+                          description: Match on envoy listener attributes.
+                          properties:
+                            filterChain:
+                              description: Match a specific filter chain in a listener.
+                              properties:
+                                applicationProtocols:
+                                  description: Applies only to sidecars.
+                                  format: string
+                                  type: string
+                                destinationPort:
+                                  description: The destination_port value used by a filter chain's match condition.
+                                  type: integer
+                                filter:
+                                  description: The name of a specific filter to apply the patch to.
+                                  properties:
+                                    name:
+                                      description: The filter name to match on.
+                                      format: string
+                                      type: string
+                                    subFilter:
+                                      properties:
+                                        name:
+                                          description: The filter name to match on.
+                                          format: string
+                                          type: string
+                                      type: object
+                                  type: object
+                                name:
+                                  description: The name assigned to the filter chain.
+                                  format: string
+                                  type: string
+                                sni:
+                                  description: The SNI value used by a filter chain's match condition.
+                                  format: string
+                                  type: string
+                                transportProtocol:
+                                  description: Applies only to `SIDECAR_INBOUND` context.
+                                  format: string
+                                  type: string
+                              type: object
+                            name:
+                              description: Match a specific listener by its name.
+                              format: string
+                              type: string
+                            portName:
+                              format: string
+                              type: string
+                            portNumber:
+                              type: integer
+                          type: object
+                        proxy:
+                          description: Match on properties associated with a proxy.
+                          properties:
+                            metadata:
+                              additionalProperties:
+                                format: string
+                                type: string
+                              type: object
+                            proxyVersion:
+                              format: string
+                              type: string
+                          type: object
+                        routeConfiguration:
+                          description: Match on envoy HTTP route configuration attributes.
+                          properties:
+                            gateway:
+                              format: string
+                              type: string
+                            name:
+                              description: Route configuration name to match on.
+                              format: string
+                              type: string
+                            portName:
+                              description: Applicable only for GATEWAY context.
+                              format: string
+                              type: string
+                            portNumber:
+                              type: integer
+                            vhost:
+                              properties:
+                                name:
+                                  format: string
+                                  type: string
+                                route:
+                                  description: Match a specific route within the virtual host.
+                                  properties:
+                                    action:
+                                      description: Match a route with specific action type.
+                                      enum:
+                                      - ANY
+                                      - ROUTE
+                                      - REDIRECT
+                                      - DIRECT_RESPONSE
+                                      type: string
+                                    name:
+                                      format: string
+                                      type: string
+                                  type: object
+                              type: object
+                          type: object
+                      type: object
+                    patch:
+                      description: The patch to apply along with the operation.
+                      properties:
+                        filterClass:
+                          description: Determines the filter insertion order.
+                          enum:
+                          - UNSPECIFIED
+                          - AUTHN
+                          - AUTHZ
+                          - STATS
+                          type: string
+                        operation:
+                          description: Determines how the patch should be applied.
+                          enum:
+                          - INVALID
+                          - MERGE
+                          - ADD
+                          - REMOVE
+                          - INSERT_BEFORE
+                          - INSERT_AFTER
+                          - INSERT_FIRST
+                          - REPLACE
+                          type: string
+                        value:
+                          description: The JSON config of the object being patched.
+                          type: object
+                          x-kubernetes-preserve-unknown-fields: true
+                      type: object
+                  type: object
+                type: array
+              workloadSelector:
+                properties:
+                  labels:
+                    additionalProperties:
+                      format: string
+                      type: string
+                    type: object
+                type: object
+            type: object
+          status:
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
+        type: object
     served: true
     storage: true
+    subresources:
+      status: {}
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
@@ -1578,7 +2639,7 @@ metadata:
   labels:
     app: istio-pilot
     chart: istio
-    cloudfoundry.org/istio_version: 1.9.5
+    cloudfoundry.org/istio_version: 1.10.2
     heritage: Tiller
     release: istio
   name: gateways.networking.istio.io
@@ -1594,193 +2655,308 @@ spec:
     shortNames:
     - gw
     singular: gateway
-  preserveUnknownFields: false
   scope: Namespaced
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      properties:
-        spec:
-          description: 'Configuration affecting edge load balancer. See more details at: https://istio.io/docs/reference/config/networking/gateway.html'
-          properties:
-            selector:
-              additionalProperties:
-                format: string
-                type: string
-              type: object
-            servers:
-              description: A list of server specifications.
-              items:
-                properties:
-                  bind:
-                    format: string
-                    type: string
-                  defaultEndpoint:
-                    format: string
-                    type: string
-                  hosts:
-                    description: One or more hosts exposed by this gateway.
-                    items:
-                      format: string
-                      type: string
-                    type: array
-                  name:
-                    description: An optional name of the server, when set must be unique across all servers.
-                    format: string
-                    type: string
-                  port:
-                    properties:
-                      name:
-                        description: Label assigned to the port.
-                        format: string
-                        type: string
-                      number:
-                        description: A valid non-negative integer port number.
-                        type: integer
-                      protocol:
-                        description: The protocol exposed on the port.
-                        format: string
-                        type: string
-                      targetPort:
-                        type: integer
-                    type: object
-                  tls:
-                    description: Set of TLS related options that govern the server's behavior.
-                    properties:
-                      caCertificates:
-                        description: REQUIRED if mode is `MUTUAL`.
-                        format: string
-                        type: string
-                      cipherSuites:
-                        description: 'Optional: If specified, only support the specified cipher list.'
-                        items:
-                          format: string
-                          type: string
-                        type: array
-                      credentialName:
-                        format: string
-                        type: string
-                      httpsRedirect:
-                        type: boolean
-                      maxProtocolVersion:
-                        description: 'Optional: Maximum TLS protocol version.'
-                        enum:
-                        - TLS_AUTO
-                        - TLSV1_0
-                        - TLSV1_1
-                        - TLSV1_2
-                        - TLSV1_3
-                        type: string
-                      minProtocolVersion:
-                        description: 'Optional: Minimum TLS protocol version.'
-                        enum:
-                        - TLS_AUTO
-                        - TLSV1_0
-                        - TLSV1_1
-                        - TLSV1_2
-                        - TLSV1_3
-                        type: string
-                      mode:
-                        enum:
-                        - PASSTHROUGH
-                        - SIMPLE
-                        - MUTUAL
-                        - AUTO_PASSTHROUGH
-                        - ISTIO_MUTUAL
-                        type: string
-                      privateKey:
-                        description: REQUIRED if mode is `SIMPLE` or `MUTUAL`.
-                        format: string
-                        type: string
-                      serverCertificate:
-                        description: REQUIRED if mode is `SIMPLE` or `MUTUAL`.
-                        format: string
-                        type: string
-                      subjectAltNames:
-                        items:
-                          format: string
-                          type: string
-                        type: array
-                      verifyCertificateHash:
-                        items:
-                          format: string
-                          type: string
-                        type: array
-                      verifyCertificateSpki:
-                        items:
-                          format: string
-                          type: string
-                        type: array
-                    type: object
-                type: object
-              type: array
-          type: object
-        status:
-          type: object
-          x-kubernetes-preserve-unknown-fields: true
-      type: object
   versions:
   - name: v1alpha3
+    schema:
+      openAPIV3Schema:
+        properties:
+          spec:
+            description: 'Configuration affecting edge load balancer. See more details at: https://istio.io/docs/reference/config/networking/gateway.html'
+            properties:
+              selector:
+                additionalProperties:
+                  format: string
+                  type: string
+                type: object
+              servers:
+                description: A list of server specifications.
+                items:
+                  properties:
+                    bind:
+                      format: string
+                      type: string
+                    defaultEndpoint:
+                      format: string
+                      type: string
+                    hosts:
+                      description: One or more hosts exposed by this gateway.
+                      items:
+                        format: string
+                        type: string
+                      type: array
+                    name:
+                      description: An optional name of the server, when set must be unique across all servers.
+                      format: string
+                      type: string
+                    port:
+                      properties:
+                        name:
+                          description: Label assigned to the port.
+                          format: string
+                          type: string
+                        number:
+                          description: A valid non-negative integer port number.
+                          type: integer
+                        protocol:
+                          description: The protocol exposed on the port.
+                          format: string
+                          type: string
+                        targetPort:
+                          type: integer
+                      type: object
+                    tls:
+                      description: Set of TLS related options that govern the server's behavior.
+                      properties:
+                        caCertificates:
+                          description: REQUIRED if mode is `MUTUAL`.
+                          format: string
+                          type: string
+                        cipherSuites:
+                          description: 'Optional: If specified, only support the specified cipher list.'
+                          items:
+                            format: string
+                            type: string
+                          type: array
+                        credentialName:
+                          format: string
+                          type: string
+                        httpsRedirect:
+                          type: boolean
+                        maxProtocolVersion:
+                          description: 'Optional: Maximum TLS protocol version.'
+                          enum:
+                          - TLS_AUTO
+                          - TLSV1_0
+                          - TLSV1_1
+                          - TLSV1_2
+                          - TLSV1_3
+                          type: string
+                        minProtocolVersion:
+                          description: 'Optional: Minimum TLS protocol version.'
+                          enum:
+                          - TLS_AUTO
+                          - TLSV1_0
+                          - TLSV1_1
+                          - TLSV1_2
+                          - TLSV1_3
+                          type: string
+                        mode:
+                          enum:
+                          - PASSTHROUGH
+                          - SIMPLE
+                          - MUTUAL
+                          - AUTO_PASSTHROUGH
+                          - ISTIO_MUTUAL
+                          type: string
+                        privateKey:
+                          description: REQUIRED if mode is `SIMPLE` or `MUTUAL`.
+                          format: string
+                          type: string
+                        serverCertificate:
+                          description: REQUIRED if mode is `SIMPLE` or `MUTUAL`.
+                          format: string
+                          type: string
+                        subjectAltNames:
+                          items:
+                            format: string
+                            type: string
+                          type: array
+                        verifyCertificateHash:
+                          items:
+                            format: string
+                            type: string
+                          type: array
+                        verifyCertificateSpki:
+                          items:
+                            format: string
+                            type: string
+                          type: array
+                      type: object
+                  type: object
+                type: array
+            type: object
+          status:
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
+        type: object
     served: true
     storage: true
+    subresources:
+      status: {}
   - name: v1beta1
+    schema:
+      openAPIV3Schema:
+        properties:
+          spec:
+            description: 'Configuration affecting edge load balancer. See more details at: https://istio.io/docs/reference/config/networking/gateway.html'
+            properties:
+              selector:
+                additionalProperties:
+                  format: string
+                  type: string
+                type: object
+              servers:
+                description: A list of server specifications.
+                items:
+                  properties:
+                    bind:
+                      format: string
+                      type: string
+                    defaultEndpoint:
+                      format: string
+                      type: string
+                    hosts:
+                      description: One or more hosts exposed by this gateway.
+                      items:
+                        format: string
+                        type: string
+                      type: array
+                    name:
+                      description: An optional name of the server, when set must be unique across all servers.
+                      format: string
+                      type: string
+                    port:
+                      properties:
+                        name:
+                          description: Label assigned to the port.
+                          format: string
+                          type: string
+                        number:
+                          description: A valid non-negative integer port number.
+                          type: integer
+                        protocol:
+                          description: The protocol exposed on the port.
+                          format: string
+                          type: string
+                        targetPort:
+                          type: integer
+                      type: object
+                    tls:
+                      description: Set of TLS related options that govern the server's behavior.
+                      properties:
+                        caCertificates:
+                          description: REQUIRED if mode is `MUTUAL`.
+                          format: string
+                          type: string
+                        cipherSuites:
+                          description: 'Optional: If specified, only support the specified cipher list.'
+                          items:
+                            format: string
+                            type: string
+                          type: array
+                        credentialName:
+                          format: string
+                          type: string
+                        httpsRedirect:
+                          type: boolean
+                        maxProtocolVersion:
+                          description: 'Optional: Maximum TLS protocol version.'
+                          enum:
+                          - TLS_AUTO
+                          - TLSV1_0
+                          - TLSV1_1
+                          - TLSV1_2
+                          - TLSV1_3
+                          type: string
+                        minProtocolVersion:
+                          description: 'Optional: Minimum TLS protocol version.'
+                          enum:
+                          - TLS_AUTO
+                          - TLSV1_0
+                          - TLSV1_1
+                          - TLSV1_2
+                          - TLSV1_3
+                          type: string
+                        mode:
+                          enum:
+                          - PASSTHROUGH
+                          - SIMPLE
+                          - MUTUAL
+                          - AUTO_PASSTHROUGH
+                          - ISTIO_MUTUAL
+                          type: string
+                        privateKey:
+                          description: REQUIRED if mode is `SIMPLE` or `MUTUAL`.
+                          format: string
+                          type: string
+                        serverCertificate:
+                          description: REQUIRED if mode is `SIMPLE` or `MUTUAL`.
+                          format: string
+                          type: string
+                        subjectAltNames:
+                          items:
+                            format: string
+                            type: string
+                          type: array
+                        verifyCertificateHash:
+                          items:
+                            format: string
+                            type: string
+                          type: array
+                        verifyCertificateSpki:
+                          items:
+                            format: string
+                            type: string
+                          type: array
+                      type: object
+                  type: object
+                type: array
+            type: object
+          status:
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
+        type: object
     served: true
     storage: false
+    subresources:
+      status: {}
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   labels:
-    cloudfoundry.org/istio_version: 1.9.5
+    cloudfoundry.org/istio_version: 1.10.2
     release: istio
   name: istiooperators.install.istio.io
 spec:
-  additionalPrinterColumns:
-  - JSONPath: .spec.revision
-    description: Istio control plane revision
-    name: Revision
-    type: string
-  - JSONPath: .status.status
-    description: IOP current state
-    name: Status
-    type: string
-  - JSONPath: .metadata.creationTimestamp
-    description: 'CreationTimestamp is a timestamp representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations. Clients may not set this value. It is represented in RFC3339 form and is in UTC. Populated by the system. Read-only. Null for lists. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata'
-    name: Age
-    type: date
+  conversion:
+    strategy: None
   group: install.istio.io
   names:
     kind: IstioOperator
+    listKind: IstioOperatorList
     plural: istiooperators
     shortNames:
     - iop
     - io
     singular: istiooperator
   scope: Namespaced
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-          type: string
-        spec:
-          description: 'Specification of the desired state of the istio control plane resource. More info: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#spec-and-status'
-          type: object
-        status:
-          description: 'Status describes each of istio control plane component status at the current time. 0 means NONE, 1 means UPDATING, 2 means HEALTHY, 3 means ERROR, 4 means RECONCILING. More info: https://github.com/istio/api/blob/master/operator/v1alpha1/istio.operator.v1alpha1.pb.html & https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#spec-and-status'
-          type: object
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - description: Istio control plane revision
+      jsonPath: .spec.revision
+      name: Revision
+      type: string
+    - description: IOP current state
+      jsonPath: .status.status
+      name: Status
+      type: string
+    - description: 'CreationTimestamp is a timestamp representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations. Clients may not set this value. It is represented in RFC3339 form and is in UTC. Populated by the system. Read-only. Null for lists. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata'
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        type: object
+        x-kubernetes-preserve-unknown-fields: true
     served: true
     storage: true
+    subresources:
+      status: {}
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
@@ -1788,21 +2964,12 @@ metadata:
   labels:
     app: istio-pilot
     chart: istio
-    cloudfoundry.org/istio_version: 1.9.5
+    cloudfoundry.org/istio_version: 1.10.2
     heritage: Tiller
     istio: security
     release: istio
   name: peerauthentications.security.istio.io
 spec:
-  additionalPrinterColumns:
-  - JSONPath: .spec.mtls.mode
-    description: Defines the mTLS mode used for peer authentication.
-    name: Mode
-    type: string
-  - JSONPath: .metadata.creationTimestamp
-    description: 'CreationTimestamp is a timestamp representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations. Clients may not set this value. It is represented in RFC3339 form and is in UTC. Populated by the system. Read-only. Null for lists. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata'
-    name: Age
-    type: date
   group: security.istio.io
   names:
     categories:
@@ -1814,30 +2981,26 @@ spec:
     shortNames:
     - pa
     singular: peerauthentication
-  preserveUnknownFields: false
   scope: Namespaced
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      properties:
-        spec:
-          description: PeerAuthentication defines how traffic will be tunneled (or not) to the sidecar.
-          properties:
-            mtls:
-              description: Mutual TLS settings for workload.
-              properties:
-                mode:
-                  description: Defines the mTLS mode used for peer authentication.
-                  enum:
-                  - UNSET
-                  - DISABLE
-                  - PERMISSIVE
-                  - STRICT
-                  type: string
-              type: object
-            portLevelMtls:
-              additionalProperties:
+  versions:
+  - additionalPrinterColumns:
+    - description: Defines the mTLS mode used for peer authentication.
+      jsonPath: .spec.mtls.mode
+      name: Mode
+      type: string
+    - description: 'CreationTimestamp is a timestamp representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations. Clients may not set this value. It is represented in RFC3339 form and is in UTC. Populated by the system. Read-only. Null for lists. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata'
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        properties:
+          spec:
+            description: PeerAuthentication defines how traffic will be tunneled (or not) to the sidecar.
+            properties:
+              mtls:
+                description: Mutual TLS settings for workload.
                 properties:
                   mode:
                     description: Defines the mTLS mode used for peer authentication.
@@ -1848,28 +3011,40 @@ spec:
                     - STRICT
                     type: string
                 type: object
-              description: Port specific mutual TLS settings.
-              type: object
-            selector:
-              description: The selector determines the workloads to apply the ChannelAuthentication on.
-              properties:
-                matchLabels:
-                  additionalProperties:
-                    format: string
-                    type: string
+              portLevelMtls:
+                additionalProperties:
+                  properties:
+                    mode:
+                      description: Defines the mTLS mode used for peer authentication.
+                      enum:
+                      - UNSET
+                      - DISABLE
+                      - PERMISSIVE
+                      - STRICT
+                      type: string
                   type: object
-              type: object
-          type: object
-        status:
-          type: object
-          x-kubernetes-preserve-unknown-fields: true
-      type: object
-  versions:
-  - name: v1beta1
+                description: Port specific mutual TLS settings.
+                type: object
+              selector:
+                description: The selector determines the workloads to apply the ChannelAuthentication on.
+                properties:
+                  matchLabels:
+                    additionalProperties:
+                      format: string
+                      type: string
+                    type: object
+                type: object
+            type: object
+          status:
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
+        type: object
     served: true
     storage: true
+    subresources:
+      status: {}
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
@@ -1877,7 +3052,7 @@ metadata:
   labels:
     app: istio-pilot
     chart: istio
-    cloudfoundry.org/istio_version: 1.9.5
+    cloudfoundry.org/istio_version: 1.10.2
     heritage: Tiller
     istio: security
     release: istio
@@ -1894,87 +3069,86 @@ spec:
     shortNames:
     - ra
     singular: requestauthentication
-  preserveUnknownFields: false
   scope: Namespaced
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      properties:
-        spec:
-          description: RequestAuthentication defines what request authentication methods are supported by a workload.
-          properties:
-            jwtRules:
-              description: Define the list of JWTs that can be validated at the selected workloads' proxy.
-              items:
-                properties:
-                  audiences:
-                    items:
-                      format: string
-                      type: string
-                    type: array
-                  forwardOriginalToken:
-                    description: If set to true, the orginal token will be kept for the ustream request.
-                    type: boolean
-                  fromHeaders:
-                    description: List of header locations from which JWT is expected.
-                    items:
-                      properties:
-                        name:
-                          description: The HTTP header name.
-                          format: string
-                          type: string
-                        prefix:
-                          description: The prefix that should be stripped before decoding the token.
-                          format: string
-                          type: string
-                      type: object
-                    type: array
-                  fromParams:
-                    description: List of query parameters from which JWT is expected.
-                    items:
-                      format: string
-                      type: string
-                    type: array
-                  issuer:
-                    description: Identifies the issuer that issued the JWT.
-                    format: string
-                    type: string
-                  jwks:
-                    description: JSON Web Key Set of public keys to validate signature of the JWT.
-                    format: string
-                    type: string
-                  jwks_uri:
-                    format: string
-                    type: string
-                  jwksUri:
-                    format: string
-                    type: string
-                  outputPayloadToHeader:
-                    format: string
-                    type: string
-                type: object
-              type: array
-            selector:
-              description: The selector determines the workloads to apply the RequestAuthentication on.
-              properties:
-                matchLabels:
-                  additionalProperties:
-                    format: string
-                    type: string
-                  type: object
-              type: object
-          type: object
-        status:
-          type: object
-          x-kubernetes-preserve-unknown-fields: true
-      type: object
   versions:
   - name: v1beta1
+    schema:
+      openAPIV3Schema:
+        properties:
+          spec:
+            description: RequestAuthentication defines what request authentication methods are supported by a workload.
+            properties:
+              jwtRules:
+                description: Define the list of JWTs that can be validated at the selected workloads' proxy.
+                items:
+                  properties:
+                    audiences:
+                      items:
+                        format: string
+                        type: string
+                      type: array
+                    forwardOriginalToken:
+                      description: If set to true, the orginal token will be kept for the ustream request.
+                      type: boolean
+                    fromHeaders:
+                      description: List of header locations from which JWT is expected.
+                      items:
+                        properties:
+                          name:
+                            description: The HTTP header name.
+                            format: string
+                            type: string
+                          prefix:
+                            description: The prefix that should be stripped before decoding the token.
+                            format: string
+                            type: string
+                        type: object
+                      type: array
+                    fromParams:
+                      description: List of query parameters from which JWT is expected.
+                      items:
+                        format: string
+                        type: string
+                      type: array
+                    issuer:
+                      description: Identifies the issuer that issued the JWT.
+                      format: string
+                      type: string
+                    jwks:
+                      description: JSON Web Key Set of public keys to validate signature of the JWT.
+                      format: string
+                      type: string
+                    jwks_uri:
+                      format: string
+                      type: string
+                    jwksUri:
+                      format: string
+                      type: string
+                    outputPayloadToHeader:
+                      format: string
+                      type: string
+                  type: object
+                type: array
+              selector:
+                description: The selector determines the workloads to apply the RequestAuthentication on.
+                properties:
+                  matchLabels:
+                    additionalProperties:
+                      format: string
+                      type: string
+                    type: object
+                type: object
+            type: object
+          status:
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
+        type: object
     served: true
     storage: true
+    subresources:
+      status: {}
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
@@ -1982,28 +3156,11 @@ metadata:
   labels:
     app: istio-pilot
     chart: istio
-    cloudfoundry.org/istio_version: 1.9.5
+    cloudfoundry.org/istio_version: 1.10.2
     heritage: Tiller
     release: istio
   name: serviceentries.networking.istio.io
 spec:
-  additionalPrinterColumns:
-  - JSONPath: .spec.hosts
-    description: The hosts associated with the ServiceEntry
-    name: Hosts
-    type: string
-  - JSONPath: .spec.location
-    description: Whether the service is external to the mesh or part of the mesh (MESH_EXTERNAL or MESH_INTERNAL)
-    name: Location
-    type: string
-  - JSONPath: .spec.resolution
-    description: Service discovery mode for the hosts (NONE, STATIC, or DNS)
-    name: Resolution
-    type: string
-  - JSONPath: .metadata.creationTimestamp
-    description: 'CreationTimestamp is a timestamp representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations. Clients may not set this value. It is represented in RFC3339 form and is in UTC. Populated by the system. Read-only. Null for lists. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata'
-    name: Age
-    type: date
   group: networking.istio.io
   names:
     categories:
@@ -2015,25 +3172,2455 @@ spec:
     shortNames:
     - se
     singular: serviceentry
-  preserveUnknownFields: false
   scope: Namespaced
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      properties:
-        spec:
-          description: 'Configuration affecting service registry. See more details at: https://istio.io/docs/reference/config/networking/service-entry.html'
-          properties:
-            addresses:
-              description: The virtual IP addresses associated with the service.
-              items:
+  versions:
+  - additionalPrinterColumns:
+    - description: The hosts associated with the ServiceEntry
+      jsonPath: .spec.hosts
+      name: Hosts
+      type: string
+    - description: Whether the service is external to the mesh or part of the mesh (MESH_EXTERNAL or MESH_INTERNAL)
+      jsonPath: .spec.location
+      name: Location
+      type: string
+    - description: Service discovery mode for the hosts (NONE, STATIC, or DNS)
+      jsonPath: .spec.resolution
+      name: Resolution
+      type: string
+    - description: 'CreationTimestamp is a timestamp representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations. Clients may not set this value. It is represented in RFC3339 form and is in UTC. Populated by the system. Read-only. Null for lists. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata'
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha3
+    schema:
+      openAPIV3Schema:
+        properties:
+          spec:
+            description: 'Configuration affecting service registry. See more details at: https://istio.io/docs/reference/config/networking/service-entry.html'
+            properties:
+              addresses:
+                description: The virtual IP addresses associated with the service.
+                items:
+                  format: string
+                  type: string
+                type: array
+              endpoints:
+                description: One or more endpoints associated with the service.
+                items:
+                  properties:
+                    address:
+                      format: string
+                      type: string
+                    labels:
+                      additionalProperties:
+                        format: string
+                        type: string
+                      description: One or more labels associated with the endpoint.
+                      type: object
+                    locality:
+                      description: The locality associated with the endpoint.
+                      format: string
+                      type: string
+                    network:
+                      format: string
+                      type: string
+                    ports:
+                      additionalProperties:
+                        type: integer
+                      description: Set of ports associated with the endpoint.
+                      type: object
+                    serviceAccount:
+                      format: string
+                      type: string
+                    weight:
+                      description: The load balancing weight associated with the endpoint.
+                      type: integer
+                  type: object
+                type: array
+              exportTo:
+                description: A list of namespaces to which this service is exported.
+                items:
+                  format: string
+                  type: string
+                type: array
+              hosts:
+                description: The hosts associated with the ServiceEntry.
+                items:
+                  format: string
+                  type: string
+                type: array
+              location:
+                enum:
+                - MESH_EXTERNAL
+                - MESH_INTERNAL
+                type: string
+              ports:
+                description: The ports associated with the external service.
+                items:
+                  properties:
+                    name:
+                      description: Label assigned to the port.
+                      format: string
+                      type: string
+                    number:
+                      description: A valid non-negative integer port number.
+                      type: integer
+                    protocol:
+                      description: The protocol exposed on the port.
+                      format: string
+                      type: string
+                    targetPort:
+                      type: integer
+                  type: object
+                type: array
+              resolution:
+                description: Service discovery mode for the hosts.
+                enum:
+                - NONE
+                - STATIC
+                - DNS
+                type: string
+              subjectAltNames:
+                items:
+                  format: string
+                  type: string
+                type: array
+              workloadSelector:
+                description: Applicable only for MESH_INTERNAL services.
+                properties:
+                  labels:
+                    additionalProperties:
+                      format: string
+                      type: string
+                    type: object
+                type: object
+            type: object
+          status:
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+  - additionalPrinterColumns:
+    - description: The hosts associated with the ServiceEntry
+      jsonPath: .spec.hosts
+      name: Hosts
+      type: string
+    - description: Whether the service is external to the mesh or part of the mesh (MESH_EXTERNAL or MESH_INTERNAL)
+      jsonPath: .spec.location
+      name: Location
+      type: string
+    - description: Service discovery mode for the hosts (NONE, STATIC, or DNS)
+      jsonPath: .spec.resolution
+      name: Resolution
+      type: string
+    - description: 'CreationTimestamp is a timestamp representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations. Clients may not set this value. It is represented in RFC3339 form and is in UTC. Populated by the system. Read-only. Null for lists. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata'
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        properties:
+          spec:
+            description: 'Configuration affecting service registry. See more details at: https://istio.io/docs/reference/config/networking/service-entry.html'
+            properties:
+              addresses:
+                description: The virtual IP addresses associated with the service.
+                items:
+                  format: string
+                  type: string
+                type: array
+              endpoints:
+                description: One or more endpoints associated with the service.
+                items:
+                  properties:
+                    address:
+                      format: string
+                      type: string
+                    labels:
+                      additionalProperties:
+                        format: string
+                        type: string
+                      description: One or more labels associated with the endpoint.
+                      type: object
+                    locality:
+                      description: The locality associated with the endpoint.
+                      format: string
+                      type: string
+                    network:
+                      format: string
+                      type: string
+                    ports:
+                      additionalProperties:
+                        type: integer
+                      description: Set of ports associated with the endpoint.
+                      type: object
+                    serviceAccount:
+                      format: string
+                      type: string
+                    weight:
+                      description: The load balancing weight associated with the endpoint.
+                      type: integer
+                  type: object
+                type: array
+              exportTo:
+                description: A list of namespaces to which this service is exported.
+                items:
+                  format: string
+                  type: string
+                type: array
+              hosts:
+                description: The hosts associated with the ServiceEntry.
+                items:
+                  format: string
+                  type: string
+                type: array
+              location:
+                enum:
+                - MESH_EXTERNAL
+                - MESH_INTERNAL
+                type: string
+              ports:
+                description: The ports associated with the external service.
+                items:
+                  properties:
+                    name:
+                      description: Label assigned to the port.
+                      format: string
+                      type: string
+                    number:
+                      description: A valid non-negative integer port number.
+                      type: integer
+                    protocol:
+                      description: The protocol exposed on the port.
+                      format: string
+                      type: string
+                    targetPort:
+                      type: integer
+                  type: object
+                type: array
+              resolution:
+                description: Service discovery mode for the hosts.
+                enum:
+                - NONE
+                - STATIC
+                - DNS
+                type: string
+              subjectAltNames:
+                items:
+                  format: string
+                  type: string
+                type: array
+              workloadSelector:
+                description: Applicable only for MESH_INTERNAL services.
+                properties:
+                  labels:
+                    additionalProperties:
+                      format: string
+                      type: string
+                    type: object
+                type: object
+            type: object
+          status:
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    helm.sh/resource-policy: keep
+  labels:
+    app: istio-pilot
+    chart: istio
+    cloudfoundry.org/istio_version: 1.10.2
+    heritage: Tiller
+    release: istio
+  name: sidecars.networking.istio.io
+spec:
+  group: networking.istio.io
+  names:
+    categories:
+    - istio-io
+    - networking-istio-io
+    kind: Sidecar
+    listKind: SidecarList
+    plural: sidecars
+    singular: sidecar
+  scope: Namespaced
+  versions:
+  - name: v1alpha3
+    schema:
+      openAPIV3Schema:
+        properties:
+          spec:
+            description: 'Configuration affecting network reachability of a sidecar. See more details at: https://istio.io/docs/reference/config/networking/sidecar.html'
+            properties:
+              egress:
+                items:
+                  properties:
+                    bind:
+                      format: string
+                      type: string
+                    captureMode:
+                      enum:
+                      - DEFAULT
+                      - IPTABLES
+                      - NONE
+                      type: string
+                    hosts:
+                      items:
+                        format: string
+                        type: string
+                      type: array
+                    port:
+                      description: The port associated with the listener.
+                      properties:
+                        name:
+                          description: Label assigned to the port.
+                          format: string
+                          type: string
+                        number:
+                          description: A valid non-negative integer port number.
+                          type: integer
+                        protocol:
+                          description: The protocol exposed on the port.
+                          format: string
+                          type: string
+                        targetPort:
+                          type: integer
+                      type: object
+                  type: object
+                type: array
+              ingress:
+                items:
+                  properties:
+                    bind:
+                      description: The IP to which the listener should be bound.
+                      format: string
+                      type: string
+                    captureMode:
+                      enum:
+                      - DEFAULT
+                      - IPTABLES
+                      - NONE
+                      type: string
+                    defaultEndpoint:
+                      format: string
+                      type: string
+                    port:
+                      description: The port associated with the listener.
+                      properties:
+                        name:
+                          description: Label assigned to the port.
+                          format: string
+                          type: string
+                        number:
+                          description: A valid non-negative integer port number.
+                          type: integer
+                        protocol:
+                          description: The protocol exposed on the port.
+                          format: string
+                          type: string
+                        targetPort:
+                          type: integer
+                      type: object
+                  type: object
+                type: array
+              outboundTrafficPolicy:
+                description: Configuration for the outbound traffic policy.
+                properties:
+                  egressProxy:
+                    properties:
+                      host:
+                        description: The name of a service from the service registry.
+                        format: string
+                        type: string
+                      port:
+                        description: Specifies the port on the host that is being addressed.
+                        properties:
+                          number:
+                            type: integer
+                        type: object
+                      subset:
+                        description: The name of a subset within the service.
+                        format: string
+                        type: string
+                    type: object
+                  mode:
+                    enum:
+                    - REGISTRY_ONLY
+                    - ALLOW_ANY
+                    type: string
+                type: object
+              workloadSelector:
+                properties:
+                  labels:
+                    additionalProperties:
+                      format: string
+                      type: string
+                    type: object
+                type: object
+            type: object
+          status:
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+  - name: v1beta1
+    schema:
+      openAPIV3Schema:
+        properties:
+          spec:
+            description: 'Configuration affecting network reachability of a sidecar. See more details at: https://istio.io/docs/reference/config/networking/sidecar.html'
+            properties:
+              egress:
+                items:
+                  properties:
+                    bind:
+                      format: string
+                      type: string
+                    captureMode:
+                      enum:
+                      - DEFAULT
+                      - IPTABLES
+                      - NONE
+                      type: string
+                    hosts:
+                      items:
+                        format: string
+                        type: string
+                      type: array
+                    port:
+                      description: The port associated with the listener.
+                      properties:
+                        name:
+                          description: Label assigned to the port.
+                          format: string
+                          type: string
+                        number:
+                          description: A valid non-negative integer port number.
+                          type: integer
+                        protocol:
+                          description: The protocol exposed on the port.
+                          format: string
+                          type: string
+                        targetPort:
+                          type: integer
+                      type: object
+                  type: object
+                type: array
+              ingress:
+                items:
+                  properties:
+                    bind:
+                      description: The IP to which the listener should be bound.
+                      format: string
+                      type: string
+                    captureMode:
+                      enum:
+                      - DEFAULT
+                      - IPTABLES
+                      - NONE
+                      type: string
+                    defaultEndpoint:
+                      format: string
+                      type: string
+                    port:
+                      description: The port associated with the listener.
+                      properties:
+                        name:
+                          description: Label assigned to the port.
+                          format: string
+                          type: string
+                        number:
+                          description: A valid non-negative integer port number.
+                          type: integer
+                        protocol:
+                          description: The protocol exposed on the port.
+                          format: string
+                          type: string
+                        targetPort:
+                          type: integer
+                      type: object
+                  type: object
+                type: array
+              outboundTrafficPolicy:
+                description: Configuration for the outbound traffic policy.
+                properties:
+                  egressProxy:
+                    properties:
+                      host:
+                        description: The name of a service from the service registry.
+                        format: string
+                        type: string
+                      port:
+                        description: Specifies the port on the host that is being addressed.
+                        properties:
+                          number:
+                            type: integer
+                        type: object
+                      subset:
+                        description: The name of a subset within the service.
+                        format: string
+                        type: string
+                    type: object
+                  mode:
+                    enum:
+                    - REGISTRY_ONLY
+                    - ALLOW_ANY
+                    type: string
+                type: object
+              workloadSelector:
+                properties:
+                  labels:
+                    additionalProperties:
+                      format: string
+                      type: string
+                    type: object
+                type: object
+            type: object
+          status:
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    helm.sh/resource-policy: keep
+  labels:
+    app: istio-pilot
+    chart: istio
+    cloudfoundry.org/istio_version: 1.10.2
+    heritage: Tiller
+    istio: telemetry
+    release: istio
+  name: telemetries.telemetry.istio.io
+spec:
+  group: telemetry.istio.io
+  names:
+    categories:
+    - istio-io
+    - telemetry-istio-io
+    kind: Telemetry
+    listKind: TelemetryList
+    plural: telemetries
+    shortNames:
+    - telemetry
+    singular: telemetry
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: 'CreationTimestamp is a timestamp representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations. Clients may not set this value. It is represented in RFC3339 form and is in UTC. Populated by the system. Read-only. Null for lists. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata'
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        properties:
+          spec:
+            description: Telemetry defines how the telemetry is generated for workloads within a mesh.
+            properties:
+              selector:
+                description: Optional.
+                properties:
+                  matchLabels:
+                    additionalProperties:
+                      format: string
+                      type: string
+                    type: object
+                type: object
+              tracing:
+                description: Optional.
+                items:
+                  properties:
+                    customTags:
+                      additionalProperties:
+                        oneOf:
+                        - not:
+                            anyOf:
+                            - required:
+                              - literal
+                            - required:
+                              - environment
+                            - required:
+                              - header
+                        - required:
+                          - literal
+                        - required:
+                          - environment
+                        - required:
+                          - header
+                        properties:
+                          environment:
+                            description: Environment adds the value of an environment variable to each span.
+                            properties:
+                              defaultValue:
+                                description: Optional.
+                                format: string
+                                type: string
+                              name:
+                                description: Name of the environment variable from which to extract the tag value.
+                                format: string
+                                type: string
+                            type: object
+                          header:
+                            description: RequestHeader adds the value of an header from the request to each span.
+                            properties:
+                              defaultValue:
+                                description: Optional.
+                                format: string
+                                type: string
+                              name:
+                                description: Name of the header from which to extract the tag value.
+                                format: string
+                                type: string
+                            type: object
+                          literal:
+                            description: Literal adds the same, hard-coded value to each span.
+                            properties:
+                              value:
+                                description: The tag value to use.
+                                format: string
+                                type: string
+                            type: object
+                        type: object
+                      description: Optional.
+                      type: object
+                    disableSpanReporting:
+                      description: Controls span reporting.
+                      nullable: true
+                      type: boolean
+                    providers:
+                      description: Optional.
+                      items:
+                        properties:
+                          name:
+                            description: Required.
+                            format: string
+                            type: string
+                        type: object
+                      type: array
+                    randomSamplingPercentage:
+                      nullable: true
+                      type: number
+                  type: object
+                type: array
+            type: object
+          status:
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    helm.sh/resource-policy: keep
+  labels:
+    app: istio-pilot
+    chart: istio
+    cloudfoundry.org/istio_version: 1.10.2
+    heritage: Tiller
+    release: istio
+  name: virtualservices.networking.istio.io
+spec:
+  group: networking.istio.io
+  names:
+    categories:
+    - istio-io
+    - networking-istio-io
+    kind: VirtualService
+    listKind: VirtualServiceList
+    plural: virtualservices
+    shortNames:
+    - vs
+    singular: virtualservice
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: The names of gateways and sidecars that should apply these routes
+      jsonPath: .spec.gateways
+      name: Gateways
+      type: string
+    - description: The destination hosts to which traffic is being sent
+      jsonPath: .spec.hosts
+      name: Hosts
+      type: string
+    - description: 'CreationTimestamp is a timestamp representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations. Clients may not set this value. It is represented in RFC3339 form and is in UTC. Populated by the system. Read-only. Null for lists. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata'
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha3
+    schema:
+      openAPIV3Schema:
+        properties:
+          spec:
+            description: 'Configuration affecting label/content routing, sni routing, etc. See more details at: https://istio.io/docs/reference/config/networking/virtual-service.html'
+            properties:
+              exportTo:
+                description: A list of namespaces to which this virtual service is exported.
+                items:
+                  format: string
+                  type: string
+                type: array
+              gateways:
+                description: The names of gateways and sidecars that should apply these routes.
+                items:
+                  format: string
+                  type: string
+                type: array
+              hosts:
+                description: The destination hosts to which traffic is being sent.
+                items:
+                  format: string
+                  type: string
+                type: array
+              http:
+                description: An ordered list of route rules for HTTP traffic.
+                items:
+                  properties:
+                    corsPolicy:
+                      description: Cross-Origin Resource Sharing policy (CORS).
+                      properties:
+                        allowCredentials:
+                          nullable: true
+                          type: boolean
+                        allowHeaders:
+                          items:
+                            format: string
+                            type: string
+                          type: array
+                        allowMethods:
+                          description: List of HTTP methods allowed to access the resource.
+                          items:
+                            format: string
+                            type: string
+                          type: array
+                        allowOrigin:
+                          description: The list of origins that are allowed to perform CORS requests.
+                          items:
+                            format: string
+                            type: string
+                          type: array
+                        allowOrigins:
+                          description: String patterns that match allowed origins.
+                          items:
+                            oneOf:
+                            - not:
+                                anyOf:
+                                - required:
+                                  - exact
+                                - required:
+                                  - prefix
+                                - required:
+                                  - regex
+                            - required:
+                              - exact
+                            - required:
+                              - prefix
+                            - required:
+                              - regex
+                            properties:
+                              exact:
+                                format: string
+                                type: string
+                              prefix:
+                                format: string
+                                type: string
+                              regex:
+                                description: RE2 style regex-based match (https://github.com/google/re2/wiki/Syntax).
+                                format: string
+                                type: string
+                            type: object
+                          type: array
+                        exposeHeaders:
+                          items:
+                            format: string
+                            type: string
+                          type: array
+                        maxAge:
+                          type: string
+                      type: object
+                    delegate:
+                      properties:
+                        name:
+                          description: Name specifies the name of the delegate VirtualService.
+                          format: string
+                          type: string
+                        namespace:
+                          description: Namespace specifies the namespace where the delegate VirtualService resides.
+                          format: string
+                          type: string
+                      type: object
+                    fault:
+                      description: Fault injection policy to apply on HTTP traffic at the client side.
+                      properties:
+                        abort:
+                          oneOf:
+                          - not:
+                              anyOf:
+                              - required:
+                                - httpStatus
+                              - required:
+                                - grpcStatus
+                              - required:
+                                - http2Error
+                          - required:
+                            - httpStatus
+                          - required:
+                            - grpcStatus
+                          - required:
+                            - http2Error
+                          properties:
+                            grpcStatus:
+                              format: string
+                              type: string
+                            http2Error:
+                              format: string
+                              type: string
+                            httpStatus:
+                              description: HTTP status code to use to abort the Http request.
+                              format: int32
+                              type: integer
+                            percentage:
+                              description: Percentage of requests to be aborted with the error code provided.
+                              properties:
+                                value:
+                                  format: double
+                                  type: number
+                              type: object
+                          type: object
+                        delay:
+                          oneOf:
+                          - not:
+                              anyOf:
+                              - required:
+                                - fixedDelay
+                              - required:
+                                - exponentialDelay
+                          - required:
+                            - fixedDelay
+                          - required:
+                            - exponentialDelay
+                          properties:
+                            exponentialDelay:
+                              type: string
+                            fixedDelay:
+                              description: Add a fixed delay before forwarding the request.
+                              type: string
+                            percent:
+                              description: Percentage of requests on which the delay will be injected (0-100).
+                              format: int32
+                              type: integer
+                            percentage:
+                              description: Percentage of requests on which the delay will be injected.
+                              properties:
+                                value:
+                                  format: double
+                                  type: number
+                              type: object
+                          type: object
+                      type: object
+                    headers:
+                      properties:
+                        request:
+                          properties:
+                            add:
+                              additionalProperties:
+                                format: string
+                                type: string
+                              type: object
+                            remove:
+                              items:
+                                format: string
+                                type: string
+                              type: array
+                            set:
+                              additionalProperties:
+                                format: string
+                                type: string
+                              type: object
+                          type: object
+                        response:
+                          properties:
+                            add:
+                              additionalProperties:
+                                format: string
+                                type: string
+                              type: object
+                            remove:
+                              items:
+                                format: string
+                                type: string
+                              type: array
+                            set:
+                              additionalProperties:
+                                format: string
+                                type: string
+                              type: object
+                          type: object
+                      type: object
+                    match:
+                      items:
+                        properties:
+                          authority:
+                            oneOf:
+                            - not:
+                                anyOf:
+                                - required:
+                                  - exact
+                                - required:
+                                  - prefix
+                                - required:
+                                  - regex
+                            - required:
+                              - exact
+                            - required:
+                              - prefix
+                            - required:
+                              - regex
+                            properties:
+                              exact:
+                                format: string
+                                type: string
+                              prefix:
+                                format: string
+                                type: string
+                              regex:
+                                description: RE2 style regex-based match (https://github.com/google/re2/wiki/Syntax).
+                                format: string
+                                type: string
+                            type: object
+                          gateways:
+                            description: Names of gateways where the rule should be applied.
+                            items:
+                              format: string
+                              type: string
+                            type: array
+                          headers:
+                            additionalProperties:
+                              oneOf:
+                              - not:
+                                  anyOf:
+                                  - required:
+                                    - exact
+                                  - required:
+                                    - prefix
+                                  - required:
+                                    - regex
+                              - required:
+                                - exact
+                              - required:
+                                - prefix
+                              - required:
+                                - regex
+                              properties:
+                                exact:
+                                  format: string
+                                  type: string
+                                prefix:
+                                  format: string
+                                  type: string
+                                regex:
+                                  description: RE2 style regex-based match (https://github.com/google/re2/wiki/Syntax).
+                                  format: string
+                                  type: string
+                              type: object
+                            type: object
+                          ignoreUriCase:
+                            description: Flag to specify whether the URI matching should be case-insensitive.
+                            type: boolean
+                          method:
+                            oneOf:
+                            - not:
+                                anyOf:
+                                - required:
+                                  - exact
+                                - required:
+                                  - prefix
+                                - required:
+                                  - regex
+                            - required:
+                              - exact
+                            - required:
+                              - prefix
+                            - required:
+                              - regex
+                            properties:
+                              exact:
+                                format: string
+                                type: string
+                              prefix:
+                                format: string
+                                type: string
+                              regex:
+                                description: RE2 style regex-based match (https://github.com/google/re2/wiki/Syntax).
+                                format: string
+                                type: string
+                            type: object
+                          name:
+                            description: The name assigned to a match.
+                            format: string
+                            type: string
+                          port:
+                            description: Specifies the ports on the host that is being addressed.
+                            type: integer
+                          queryParams:
+                            additionalProperties:
+                              oneOf:
+                              - not:
+                                  anyOf:
+                                  - required:
+                                    - exact
+                                  - required:
+                                    - prefix
+                                  - required:
+                                    - regex
+                              - required:
+                                - exact
+                              - required:
+                                - prefix
+                              - required:
+                                - regex
+                              properties:
+                                exact:
+                                  format: string
+                                  type: string
+                                prefix:
+                                  format: string
+                                  type: string
+                                regex:
+                                  description: RE2 style regex-based match (https://github.com/google/re2/wiki/Syntax).
+                                  format: string
+                                  type: string
+                              type: object
+                            description: Query parameters for matching.
+                            type: object
+                          scheme:
+                            oneOf:
+                            - not:
+                                anyOf:
+                                - required:
+                                  - exact
+                                - required:
+                                  - prefix
+                                - required:
+                                  - regex
+                            - required:
+                              - exact
+                            - required:
+                              - prefix
+                            - required:
+                              - regex
+                            properties:
+                              exact:
+                                format: string
+                                type: string
+                              prefix:
+                                format: string
+                                type: string
+                              regex:
+                                description: RE2 style regex-based match (https://github.com/google/re2/wiki/Syntax).
+                                format: string
+                                type: string
+                            type: object
+                          sourceLabels:
+                            additionalProperties:
+                              format: string
+                              type: string
+                            type: object
+                          sourceNamespace:
+                            description: Source namespace constraining the applicability of a rule to workloads in that namespace.
+                            format: string
+                            type: string
+                          uri:
+                            oneOf:
+                            - not:
+                                anyOf:
+                                - required:
+                                  - exact
+                                - required:
+                                  - prefix
+                                - required:
+                                  - regex
+                            - required:
+                              - exact
+                            - required:
+                              - prefix
+                            - required:
+                              - regex
+                            properties:
+                              exact:
+                                format: string
+                                type: string
+                              prefix:
+                                format: string
+                                type: string
+                              regex:
+                                description: RE2 style regex-based match (https://github.com/google/re2/wiki/Syntax).
+                                format: string
+                                type: string
+                            type: object
+                          withoutHeaders:
+                            additionalProperties:
+                              oneOf:
+                              - not:
+                                  anyOf:
+                                  - required:
+                                    - exact
+                                  - required:
+                                    - prefix
+                                  - required:
+                                    - regex
+                              - required:
+                                - exact
+                              - required:
+                                - prefix
+                              - required:
+                                - regex
+                              properties:
+                                exact:
+                                  format: string
+                                  type: string
+                                prefix:
+                                  format: string
+                                  type: string
+                                regex:
+                                  description: RE2 style regex-based match (https://github.com/google/re2/wiki/Syntax).
+                                  format: string
+                                  type: string
+                              type: object
+                            description: withoutHeader has the same syntax with the header, but has opposite meaning.
+                            type: object
+                        type: object
+                      type: array
+                    mirror:
+                      properties:
+                        host:
+                          description: The name of a service from the service registry.
+                          format: string
+                          type: string
+                        port:
+                          description: Specifies the port on the host that is being addressed.
+                          properties:
+                            number:
+                              type: integer
+                          type: object
+                        subset:
+                          description: The name of a subset within the service.
+                          format: string
+                          type: string
+                      type: object
+                    mirror_percent:
+                      description: Percentage of the traffic to be mirrored by the `mirror` field.
+                      nullable: true
+                      type: integer
+                    mirrorPercent:
+                      description: Percentage of the traffic to be mirrored by the `mirror` field.
+                      nullable: true
+                      type: integer
+                    mirrorPercentage:
+                      description: Percentage of the traffic to be mirrored by the `mirror` field.
+                      properties:
+                        value:
+                          format: double
+                          type: number
+                      type: object
+                    name:
+                      description: The name assigned to the route for debugging purposes.
+                      format: string
+                      type: string
+                    redirect:
+                      description: A HTTP rule can either redirect or forward (default) traffic.
+                      properties:
+                        authority:
+                          format: string
+                          type: string
+                        redirectCode:
+                          type: integer
+                        uri:
+                          format: string
+                          type: string
+                      type: object
+                    retries:
+                      description: Retry policy for HTTP requests.
+                      properties:
+                        attempts:
+                          description: Number of retries to be allowed for a given request.
+                          format: int32
+                          type: integer
+                        perTryTimeout:
+                          description: Timeout per attempt for a given request, including the initial call and any retries.
+                          type: string
+                        retryOn:
+                          description: Specifies the conditions under which retry takes place.
+                          format: string
+                          type: string
+                        retryRemoteLocalities:
+                          description: Flag to specify whether the retries should retry to other localities.
+                          nullable: true
+                          type: boolean
+                      type: object
+                    rewrite:
+                      description: Rewrite HTTP URIs and Authority headers.
+                      properties:
+                        authority:
+                          description: rewrite the Authority/Host header with this value.
+                          format: string
+                          type: string
+                        uri:
+                          format: string
+                          type: string
+                      type: object
+                    route:
+                      description: A HTTP rule can either redirect or forward (default) traffic.
+                      items:
+                        properties:
+                          destination:
+                            properties:
+                              host:
+                                description: The name of a service from the service registry.
+                                format: string
+                                type: string
+                              port:
+                                description: Specifies the port on the host that is being addressed.
+                                properties:
+                                  number:
+                                    type: integer
+                                type: object
+                              subset:
+                                description: The name of a subset within the service.
+                                format: string
+                                type: string
+                            type: object
+                          headers:
+                            properties:
+                              request:
+                                properties:
+                                  add:
+                                    additionalProperties:
+                                      format: string
+                                      type: string
+                                    type: object
+                                  remove:
+                                    items:
+                                      format: string
+                                      type: string
+                                    type: array
+                                  set:
+                                    additionalProperties:
+                                      format: string
+                                      type: string
+                                    type: object
+                                type: object
+                              response:
+                                properties:
+                                  add:
+                                    additionalProperties:
+                                      format: string
+                                      type: string
+                                    type: object
+                                  remove:
+                                    items:
+                                      format: string
+                                      type: string
+                                    type: array
+                                  set:
+                                    additionalProperties:
+                                      format: string
+                                      type: string
+                                    type: object
+                                type: object
+                            type: object
+                          weight:
+                            format: int32
+                            type: integer
+                        type: object
+                      type: array
+                    timeout:
+                      description: Timeout for HTTP requests, default is disabled.
+                      type: string
+                  type: object
+                type: array
+              tcp:
+                description: An ordered list of route rules for opaque TCP traffic.
+                items:
+                  properties:
+                    match:
+                      items:
+                        properties:
+                          destinationSubnets:
+                            description: IPv4 or IPv6 ip addresses of destination with optional subnet.
+                            items:
+                              format: string
+                              type: string
+                            type: array
+                          gateways:
+                            description: Names of gateways where the rule should be applied.
+                            items:
+                              format: string
+                              type: string
+                            type: array
+                          port:
+                            description: Specifies the port on the host that is being addressed.
+                            type: integer
+                          sourceLabels:
+                            additionalProperties:
+                              format: string
+                              type: string
+                            type: object
+                          sourceNamespace:
+                            description: Source namespace constraining the applicability of a rule to workloads in that namespace.
+                            format: string
+                            type: string
+                          sourceSubnet:
+                            description: IPv4 or IPv6 ip address of source with optional subnet.
+                            format: string
+                            type: string
+                        type: object
+                      type: array
+                    route:
+                      description: The destination to which the connection should be forwarded to.
+                      items:
+                        properties:
+                          destination:
+                            properties:
+                              host:
+                                description: The name of a service from the service registry.
+                                format: string
+                                type: string
+                              port:
+                                description: Specifies the port on the host that is being addressed.
+                                properties:
+                                  number:
+                                    type: integer
+                                type: object
+                              subset:
+                                description: The name of a subset within the service.
+                                format: string
+                                type: string
+                            type: object
+                          weight:
+                            format: int32
+                            type: integer
+                        type: object
+                      type: array
+                  type: object
+                type: array
+              tls:
+                items:
+                  properties:
+                    match:
+                      items:
+                        properties:
+                          destinationSubnets:
+                            description: IPv4 or IPv6 ip addresses of destination with optional subnet.
+                            items:
+                              format: string
+                              type: string
+                            type: array
+                          gateways:
+                            description: Names of gateways where the rule should be applied.
+                            items:
+                              format: string
+                              type: string
+                            type: array
+                          port:
+                            description: Specifies the port on the host that is being addressed.
+                            type: integer
+                          sniHosts:
+                            description: SNI (server name indicator) to match on.
+                            items:
+                              format: string
+                              type: string
+                            type: array
+                          sourceLabels:
+                            additionalProperties:
+                              format: string
+                              type: string
+                            type: object
+                          sourceNamespace:
+                            description: Source namespace constraining the applicability of a rule to workloads in that namespace.
+                            format: string
+                            type: string
+                        type: object
+                      type: array
+                    route:
+                      description: The destination to which the connection should be forwarded to.
+                      items:
+                        properties:
+                          destination:
+                            properties:
+                              host:
+                                description: The name of a service from the service registry.
+                                format: string
+                                type: string
+                              port:
+                                description: Specifies the port on the host that is being addressed.
+                                properties:
+                                  number:
+                                    type: integer
+                                type: object
+                              subset:
+                                description: The name of a subset within the service.
+                                format: string
+                                type: string
+                            type: object
+                          weight:
+                            format: int32
+                            type: integer
+                        type: object
+                      type: array
+                  type: object
+                type: array
+            type: object
+          status:
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+  - additionalPrinterColumns:
+    - description: The names of gateways and sidecars that should apply these routes
+      jsonPath: .spec.gateways
+      name: Gateways
+      type: string
+    - description: The destination hosts to which traffic is being sent
+      jsonPath: .spec.hosts
+      name: Hosts
+      type: string
+    - description: 'CreationTimestamp is a timestamp representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations. Clients may not set this value. It is represented in RFC3339 form and is in UTC. Populated by the system. Read-only. Null for lists. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata'
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        properties:
+          spec:
+            description: 'Configuration affecting label/content routing, sni routing, etc. See more details at: https://istio.io/docs/reference/config/networking/virtual-service.html'
+            properties:
+              exportTo:
+                description: A list of namespaces to which this virtual service is exported.
+                items:
+                  format: string
+                  type: string
+                type: array
+              gateways:
+                description: The names of gateways and sidecars that should apply these routes.
+                items:
+                  format: string
+                  type: string
+                type: array
+              hosts:
+                description: The destination hosts to which traffic is being sent.
+                items:
+                  format: string
+                  type: string
+                type: array
+              http:
+                description: An ordered list of route rules for HTTP traffic.
+                items:
+                  properties:
+                    corsPolicy:
+                      description: Cross-Origin Resource Sharing policy (CORS).
+                      properties:
+                        allowCredentials:
+                          nullable: true
+                          type: boolean
+                        allowHeaders:
+                          items:
+                            format: string
+                            type: string
+                          type: array
+                        allowMethods:
+                          description: List of HTTP methods allowed to access the resource.
+                          items:
+                            format: string
+                            type: string
+                          type: array
+                        allowOrigin:
+                          description: The list of origins that are allowed to perform CORS requests.
+                          items:
+                            format: string
+                            type: string
+                          type: array
+                        allowOrigins:
+                          description: String patterns that match allowed origins.
+                          items:
+                            oneOf:
+                            - not:
+                                anyOf:
+                                - required:
+                                  - exact
+                                - required:
+                                  - prefix
+                                - required:
+                                  - regex
+                            - required:
+                              - exact
+                            - required:
+                              - prefix
+                            - required:
+                              - regex
+                            properties:
+                              exact:
+                                format: string
+                                type: string
+                              prefix:
+                                format: string
+                                type: string
+                              regex:
+                                description: RE2 style regex-based match (https://github.com/google/re2/wiki/Syntax).
+                                format: string
+                                type: string
+                            type: object
+                          type: array
+                        exposeHeaders:
+                          items:
+                            format: string
+                            type: string
+                          type: array
+                        maxAge:
+                          type: string
+                      type: object
+                    delegate:
+                      properties:
+                        name:
+                          description: Name specifies the name of the delegate VirtualService.
+                          format: string
+                          type: string
+                        namespace:
+                          description: Namespace specifies the namespace where the delegate VirtualService resides.
+                          format: string
+                          type: string
+                      type: object
+                    fault:
+                      description: Fault injection policy to apply on HTTP traffic at the client side.
+                      properties:
+                        abort:
+                          oneOf:
+                          - not:
+                              anyOf:
+                              - required:
+                                - httpStatus
+                              - required:
+                                - grpcStatus
+                              - required:
+                                - http2Error
+                          - required:
+                            - httpStatus
+                          - required:
+                            - grpcStatus
+                          - required:
+                            - http2Error
+                          properties:
+                            grpcStatus:
+                              format: string
+                              type: string
+                            http2Error:
+                              format: string
+                              type: string
+                            httpStatus:
+                              description: HTTP status code to use to abort the Http request.
+                              format: int32
+                              type: integer
+                            percentage:
+                              description: Percentage of requests to be aborted with the error code provided.
+                              properties:
+                                value:
+                                  format: double
+                                  type: number
+                              type: object
+                          type: object
+                        delay:
+                          oneOf:
+                          - not:
+                              anyOf:
+                              - required:
+                                - fixedDelay
+                              - required:
+                                - exponentialDelay
+                          - required:
+                            - fixedDelay
+                          - required:
+                            - exponentialDelay
+                          properties:
+                            exponentialDelay:
+                              type: string
+                            fixedDelay:
+                              description: Add a fixed delay before forwarding the request.
+                              type: string
+                            percent:
+                              description: Percentage of requests on which the delay will be injected (0-100).
+                              format: int32
+                              type: integer
+                            percentage:
+                              description: Percentage of requests on which the delay will be injected.
+                              properties:
+                                value:
+                                  format: double
+                                  type: number
+                              type: object
+                          type: object
+                      type: object
+                    headers:
+                      properties:
+                        request:
+                          properties:
+                            add:
+                              additionalProperties:
+                                format: string
+                                type: string
+                              type: object
+                            remove:
+                              items:
+                                format: string
+                                type: string
+                              type: array
+                            set:
+                              additionalProperties:
+                                format: string
+                                type: string
+                              type: object
+                          type: object
+                        response:
+                          properties:
+                            add:
+                              additionalProperties:
+                                format: string
+                                type: string
+                              type: object
+                            remove:
+                              items:
+                                format: string
+                                type: string
+                              type: array
+                            set:
+                              additionalProperties:
+                                format: string
+                                type: string
+                              type: object
+                          type: object
+                      type: object
+                    match:
+                      items:
+                        properties:
+                          authority:
+                            oneOf:
+                            - not:
+                                anyOf:
+                                - required:
+                                  - exact
+                                - required:
+                                  - prefix
+                                - required:
+                                  - regex
+                            - required:
+                              - exact
+                            - required:
+                              - prefix
+                            - required:
+                              - regex
+                            properties:
+                              exact:
+                                format: string
+                                type: string
+                              prefix:
+                                format: string
+                                type: string
+                              regex:
+                                description: RE2 style regex-based match (https://github.com/google/re2/wiki/Syntax).
+                                format: string
+                                type: string
+                            type: object
+                          gateways:
+                            description: Names of gateways where the rule should be applied.
+                            items:
+                              format: string
+                              type: string
+                            type: array
+                          headers:
+                            additionalProperties:
+                              oneOf:
+                              - not:
+                                  anyOf:
+                                  - required:
+                                    - exact
+                                  - required:
+                                    - prefix
+                                  - required:
+                                    - regex
+                              - required:
+                                - exact
+                              - required:
+                                - prefix
+                              - required:
+                                - regex
+                              properties:
+                                exact:
+                                  format: string
+                                  type: string
+                                prefix:
+                                  format: string
+                                  type: string
+                                regex:
+                                  description: RE2 style regex-based match (https://github.com/google/re2/wiki/Syntax).
+                                  format: string
+                                  type: string
+                              type: object
+                            type: object
+                          ignoreUriCase:
+                            description: Flag to specify whether the URI matching should be case-insensitive.
+                            type: boolean
+                          method:
+                            oneOf:
+                            - not:
+                                anyOf:
+                                - required:
+                                  - exact
+                                - required:
+                                  - prefix
+                                - required:
+                                  - regex
+                            - required:
+                              - exact
+                            - required:
+                              - prefix
+                            - required:
+                              - regex
+                            properties:
+                              exact:
+                                format: string
+                                type: string
+                              prefix:
+                                format: string
+                                type: string
+                              regex:
+                                description: RE2 style regex-based match (https://github.com/google/re2/wiki/Syntax).
+                                format: string
+                                type: string
+                            type: object
+                          name:
+                            description: The name assigned to a match.
+                            format: string
+                            type: string
+                          port:
+                            description: Specifies the ports on the host that is being addressed.
+                            type: integer
+                          queryParams:
+                            additionalProperties:
+                              oneOf:
+                              - not:
+                                  anyOf:
+                                  - required:
+                                    - exact
+                                  - required:
+                                    - prefix
+                                  - required:
+                                    - regex
+                              - required:
+                                - exact
+                              - required:
+                                - prefix
+                              - required:
+                                - regex
+                              properties:
+                                exact:
+                                  format: string
+                                  type: string
+                                prefix:
+                                  format: string
+                                  type: string
+                                regex:
+                                  description: RE2 style regex-based match (https://github.com/google/re2/wiki/Syntax).
+                                  format: string
+                                  type: string
+                              type: object
+                            description: Query parameters for matching.
+                            type: object
+                          scheme:
+                            oneOf:
+                            - not:
+                                anyOf:
+                                - required:
+                                  - exact
+                                - required:
+                                  - prefix
+                                - required:
+                                  - regex
+                            - required:
+                              - exact
+                            - required:
+                              - prefix
+                            - required:
+                              - regex
+                            properties:
+                              exact:
+                                format: string
+                                type: string
+                              prefix:
+                                format: string
+                                type: string
+                              regex:
+                                description: RE2 style regex-based match (https://github.com/google/re2/wiki/Syntax).
+                                format: string
+                                type: string
+                            type: object
+                          sourceLabels:
+                            additionalProperties:
+                              format: string
+                              type: string
+                            type: object
+                          sourceNamespace:
+                            description: Source namespace constraining the applicability of a rule to workloads in that namespace.
+                            format: string
+                            type: string
+                          uri:
+                            oneOf:
+                            - not:
+                                anyOf:
+                                - required:
+                                  - exact
+                                - required:
+                                  - prefix
+                                - required:
+                                  - regex
+                            - required:
+                              - exact
+                            - required:
+                              - prefix
+                            - required:
+                              - regex
+                            properties:
+                              exact:
+                                format: string
+                                type: string
+                              prefix:
+                                format: string
+                                type: string
+                              regex:
+                                description: RE2 style regex-based match (https://github.com/google/re2/wiki/Syntax).
+                                format: string
+                                type: string
+                            type: object
+                          withoutHeaders:
+                            additionalProperties:
+                              oneOf:
+                              - not:
+                                  anyOf:
+                                  - required:
+                                    - exact
+                                  - required:
+                                    - prefix
+                                  - required:
+                                    - regex
+                              - required:
+                                - exact
+                              - required:
+                                - prefix
+                              - required:
+                                - regex
+                              properties:
+                                exact:
+                                  format: string
+                                  type: string
+                                prefix:
+                                  format: string
+                                  type: string
+                                regex:
+                                  description: RE2 style regex-based match (https://github.com/google/re2/wiki/Syntax).
+                                  format: string
+                                  type: string
+                              type: object
+                            description: withoutHeader has the same syntax with the header, but has opposite meaning.
+                            type: object
+                        type: object
+                      type: array
+                    mirror:
+                      properties:
+                        host:
+                          description: The name of a service from the service registry.
+                          format: string
+                          type: string
+                        port:
+                          description: Specifies the port on the host that is being addressed.
+                          properties:
+                            number:
+                              type: integer
+                          type: object
+                        subset:
+                          description: The name of a subset within the service.
+                          format: string
+                          type: string
+                      type: object
+                    mirror_percent:
+                      description: Percentage of the traffic to be mirrored by the `mirror` field.
+                      nullable: true
+                      type: integer
+                    mirrorPercent:
+                      description: Percentage of the traffic to be mirrored by the `mirror` field.
+                      nullable: true
+                      type: integer
+                    mirrorPercentage:
+                      description: Percentage of the traffic to be mirrored by the `mirror` field.
+                      properties:
+                        value:
+                          format: double
+                          type: number
+                      type: object
+                    name:
+                      description: The name assigned to the route for debugging purposes.
+                      format: string
+                      type: string
+                    redirect:
+                      description: A HTTP rule can either redirect or forward (default) traffic.
+                      properties:
+                        authority:
+                          format: string
+                          type: string
+                        redirectCode:
+                          type: integer
+                        uri:
+                          format: string
+                          type: string
+                      type: object
+                    retries:
+                      description: Retry policy for HTTP requests.
+                      properties:
+                        attempts:
+                          description: Number of retries to be allowed for a given request.
+                          format: int32
+                          type: integer
+                        perTryTimeout:
+                          description: Timeout per attempt for a given request, including the initial call and any retries.
+                          type: string
+                        retryOn:
+                          description: Specifies the conditions under which retry takes place.
+                          format: string
+                          type: string
+                        retryRemoteLocalities:
+                          description: Flag to specify whether the retries should retry to other localities.
+                          nullable: true
+                          type: boolean
+                      type: object
+                    rewrite:
+                      description: Rewrite HTTP URIs and Authority headers.
+                      properties:
+                        authority:
+                          description: rewrite the Authority/Host header with this value.
+                          format: string
+                          type: string
+                        uri:
+                          format: string
+                          type: string
+                      type: object
+                    route:
+                      description: A HTTP rule can either redirect or forward (default) traffic.
+                      items:
+                        properties:
+                          destination:
+                            properties:
+                              host:
+                                description: The name of a service from the service registry.
+                                format: string
+                                type: string
+                              port:
+                                description: Specifies the port on the host that is being addressed.
+                                properties:
+                                  number:
+                                    type: integer
+                                type: object
+                              subset:
+                                description: The name of a subset within the service.
+                                format: string
+                                type: string
+                            type: object
+                          headers:
+                            properties:
+                              request:
+                                properties:
+                                  add:
+                                    additionalProperties:
+                                      format: string
+                                      type: string
+                                    type: object
+                                  remove:
+                                    items:
+                                      format: string
+                                      type: string
+                                    type: array
+                                  set:
+                                    additionalProperties:
+                                      format: string
+                                      type: string
+                                    type: object
+                                type: object
+                              response:
+                                properties:
+                                  add:
+                                    additionalProperties:
+                                      format: string
+                                      type: string
+                                    type: object
+                                  remove:
+                                    items:
+                                      format: string
+                                      type: string
+                                    type: array
+                                  set:
+                                    additionalProperties:
+                                      format: string
+                                      type: string
+                                    type: object
+                                type: object
+                            type: object
+                          weight:
+                            format: int32
+                            type: integer
+                        type: object
+                      type: array
+                    timeout:
+                      description: Timeout for HTTP requests, default is disabled.
+                      type: string
+                  type: object
+                type: array
+              tcp:
+                description: An ordered list of route rules for opaque TCP traffic.
+                items:
+                  properties:
+                    match:
+                      items:
+                        properties:
+                          destinationSubnets:
+                            description: IPv4 or IPv6 ip addresses of destination with optional subnet.
+                            items:
+                              format: string
+                              type: string
+                            type: array
+                          gateways:
+                            description: Names of gateways where the rule should be applied.
+                            items:
+                              format: string
+                              type: string
+                            type: array
+                          port:
+                            description: Specifies the port on the host that is being addressed.
+                            type: integer
+                          sourceLabels:
+                            additionalProperties:
+                              format: string
+                              type: string
+                            type: object
+                          sourceNamespace:
+                            description: Source namespace constraining the applicability of a rule to workloads in that namespace.
+                            format: string
+                            type: string
+                          sourceSubnet:
+                            description: IPv4 or IPv6 ip address of source with optional subnet.
+                            format: string
+                            type: string
+                        type: object
+                      type: array
+                    route:
+                      description: The destination to which the connection should be forwarded to.
+                      items:
+                        properties:
+                          destination:
+                            properties:
+                              host:
+                                description: The name of a service from the service registry.
+                                format: string
+                                type: string
+                              port:
+                                description: Specifies the port on the host that is being addressed.
+                                properties:
+                                  number:
+                                    type: integer
+                                type: object
+                              subset:
+                                description: The name of a subset within the service.
+                                format: string
+                                type: string
+                            type: object
+                          weight:
+                            format: int32
+                            type: integer
+                        type: object
+                      type: array
+                  type: object
+                type: array
+              tls:
+                items:
+                  properties:
+                    match:
+                      items:
+                        properties:
+                          destinationSubnets:
+                            description: IPv4 or IPv6 ip addresses of destination with optional subnet.
+                            items:
+                              format: string
+                              type: string
+                            type: array
+                          gateways:
+                            description: Names of gateways where the rule should be applied.
+                            items:
+                              format: string
+                              type: string
+                            type: array
+                          port:
+                            description: Specifies the port on the host that is being addressed.
+                            type: integer
+                          sniHosts:
+                            description: SNI (server name indicator) to match on.
+                            items:
+                              format: string
+                              type: string
+                            type: array
+                          sourceLabels:
+                            additionalProperties:
+                              format: string
+                              type: string
+                            type: object
+                          sourceNamespace:
+                            description: Source namespace constraining the applicability of a rule to workloads in that namespace.
+                            format: string
+                            type: string
+                        type: object
+                      type: array
+                    route:
+                      description: The destination to which the connection should be forwarded to.
+                      items:
+                        properties:
+                          destination:
+                            properties:
+                              host:
+                                description: The name of a service from the service registry.
+                                format: string
+                                type: string
+                              port:
+                                description: Specifies the port on the host that is being addressed.
+                                properties:
+                                  number:
+                                    type: integer
+                                type: object
+                              subset:
+                                description: The name of a subset within the service.
+                                format: string
+                                type: string
+                            type: object
+                          weight:
+                            format: int32
+                            type: integer
+                        type: object
+                      type: array
+                  type: object
+                type: array
+            type: object
+          status:
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    helm.sh/resource-policy: keep
+  labels:
+    app: istio-pilot
+    chart: istio
+    cloudfoundry.org/istio_version: 1.10.2
+    heritage: Tiller
+    release: istio
+  name: workloadentries.networking.istio.io
+spec:
+  group: networking.istio.io
+  names:
+    categories:
+    - istio-io
+    - networking-istio-io
+    kind: WorkloadEntry
+    listKind: WorkloadEntryList
+    plural: workloadentries
+    shortNames:
+    - we
+    singular: workloadentry
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: 'CreationTimestamp is a timestamp representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations. Clients may not set this value. It is represented in RFC3339 form and is in UTC. Populated by the system. Read-only. Null for lists. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata'
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - description: Address associated with the network endpoint.
+      jsonPath: .spec.address
+      name: Address
+      type: string
+    name: v1alpha3
+    schema:
+      openAPIV3Schema:
+        properties:
+          spec:
+            description: 'Configuration affecting VMs onboarded into the mesh. See more details at: https://istio.io/docs/reference/config/networking/workload-entry.html'
+            properties:
+              address:
                 format: string
                 type: string
-              type: array
-            endpoints:
-              description: One or more endpoints associated with the service.
-              items:
+              labels:
+                additionalProperties:
+                  format: string
+                  type: string
+                description: One or more labels associated with the endpoint.
+                type: object
+              locality:
+                description: The locality associated with the endpoint.
+                format: string
+                type: string
+              network:
+                format: string
+                type: string
+              ports:
+                additionalProperties:
+                  type: integer
+                description: Set of ports associated with the endpoint.
+                type: object
+              serviceAccount:
+                format: string
+                type: string
+              weight:
+                description: The load balancing weight associated with the endpoint.
+                type: integer
+            type: object
+          status:
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+  - additionalPrinterColumns:
+    - description: 'CreationTimestamp is a timestamp representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations. Clients may not set this value. It is represented in RFC3339 form and is in UTC. Populated by the system. Read-only. Null for lists. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata'
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - description: Address associated with the network endpoint.
+      jsonPath: .spec.address
+      name: Address
+      type: string
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        properties:
+          spec:
+            description: 'Configuration affecting VMs onboarded into the mesh. See more details at: https://istio.io/docs/reference/config/networking/workload-entry.html'
+            properties:
+              address:
+                format: string
+                type: string
+              labels:
+                additionalProperties:
+                  format: string
+                  type: string
+                description: One or more labels associated with the endpoint.
+                type: object
+              locality:
+                description: The locality associated with the endpoint.
+                format: string
+                type: string
+              network:
+                format: string
+                type: string
+              ports:
+                additionalProperties:
+                  type: integer
+                description: Set of ports associated with the endpoint.
+                type: object
+              serviceAccount:
+                format: string
+                type: string
+              weight:
+                description: The load balancing weight associated with the endpoint.
+                type: integer
+            type: object
+          status:
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  labels:
+    app: istio-pilot
+    chart: istio
+    cloudfoundry.org/istio_version: 1.10.2
+    heritage: Tiller
+    release: istio
+  name: workloadgroups.networking.istio.io
+spec:
+  group: networking.istio.io
+  names:
+    categories:
+    - istio-io
+    - networking-istio-io
+    kind: WorkloadGroup
+    listKind: WorkloadGroupList
+    plural: workloadgroups
+    shortNames:
+    - wg
+    singular: workloadgroup
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: 'CreationTimestamp is a timestamp representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations. Clients may not set this value. It is represented in RFC3339 form and is in UTC. Populated by the system. Read-only. Null for lists. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata'
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha3
+    schema:
+      openAPIV3Schema:
+        properties:
+          spec:
+            description: 'Describes a collection of workload instances. See more details at: https://istio.io/docs/reference/config/networking/workload-group.html'
+            properties:
+              metadata:
+                description: Metadata that will be used for all corresponding `WorkloadEntries`.
+                properties:
+                  annotations:
+                    additionalProperties:
+                      format: string
+                      type: string
+                    type: object
+                  labels:
+                    additionalProperties:
+                      format: string
+                      type: string
+                    type: object
+                type: object
+              probe:
+                description: '`ReadinessProbe` describes the configuration the user must provide for healthchecking on their workload.'
+                oneOf:
+                - not:
+                    anyOf:
+                    - required:
+                      - httpGet
+                    - required:
+                      - tcpSocket
+                    - required:
+                      - exec
+                - required:
+                  - httpGet
+                - required:
+                  - tcpSocket
+                - required:
+                  - exec
+                properties:
+                  exec:
+                    description: Health is determined by how the command that is executed exited.
+                    properties:
+                      command:
+                        description: Command to run.
+                        items:
+                          format: string
+                          type: string
+                        type: array
+                    type: object
+                  failureThreshold:
+                    description: Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                    format: int32
+                    type: integer
+                  httpGet:
+                    properties:
+                      host:
+                        description: Host name to connect to, defaults to the pod IP.
+                        format: string
+                        type: string
+                      httpHeaders:
+                        description: Headers the proxy will pass on to make the request.
+                        items:
+                          properties:
+                            name:
+                              format: string
+                              type: string
+                            value:
+                              format: string
+                              type: string
+                          type: object
+                        type: array
+                      path:
+                        description: Path to access on the HTTP server.
+                        format: string
+                        type: string
+                      port:
+                        description: Port on which the endpoint lives.
+                        type: integer
+                      scheme:
+                        format: string
+                        type: string
+                    type: object
+                  initialDelaySeconds:
+                    description: Number of seconds after the container has started before readiness probes are initiated.
+                    format: int32
+                    type: integer
+                  periodSeconds:
+                    description: How often (in seconds) to perform the probe.
+                    format: int32
+                    type: integer
+                  successThreshold:
+                    description: Minimum consecutive successes for the probe to be considered successful after having failed.
+                    format: int32
+                    type: integer
+                  tcpSocket:
+                    description: Health is determined by if the proxy is able to connect.
+                    properties:
+                      host:
+                        format: string
+                        type: string
+                      port:
+                        type: integer
+                    type: object
+                  timeoutSeconds:
+                    description: Number of seconds after which the probe times out.
+                    format: int32
+                    type: integer
+                type: object
+              template:
+                description: Template to be used for the generation of `WorkloadEntry` resources that belong to this `WorkloadGroup`.
                 properties:
                   address:
                     format: string
@@ -2063,1271 +5650,22 @@ spec:
                     description: The load balancing weight associated with the endpoint.
                     type: integer
                 type: object
-              type: array
-            exportTo:
-              description: A list of namespaces to which this service is exported.
-              items:
-                format: string
-                type: string
-              type: array
-            hosts:
-              description: The hosts associated with the ServiceEntry.
-              items:
-                format: string
-                type: string
-              type: array
-            location:
-              enum:
-              - MESH_EXTERNAL
-              - MESH_INTERNAL
-              type: string
-            ports:
-              description: The ports associated with the external service.
-              items:
-                properties:
-                  name:
-                    description: Label assigned to the port.
-                    format: string
-                    type: string
-                  number:
-                    description: A valid non-negative integer port number.
-                    type: integer
-                  protocol:
-                    description: The protocol exposed on the port.
-                    format: string
-                    type: string
-                  targetPort:
-                    type: integer
-                type: object
-              type: array
-            resolution:
-              description: Service discovery mode for the hosts.
-              enum:
-              - NONE
-              - STATIC
-              - DNS
-              type: string
-            subjectAltNames:
-              items:
-                format: string
-                type: string
-              type: array
-            workloadSelector:
-              description: Applicable only for MESH_INTERNAL services.
-              properties:
-                labels:
-                  additionalProperties:
-                    format: string
-                    type: string
-                  type: object
-              type: object
-          type: object
-        status:
-          type: object
-          x-kubernetes-preserve-unknown-fields: true
-      type: object
-  versions:
-  - name: v1alpha3
+            type: object
+          status:
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
+        type: object
     served: true
     storage: true
-  - name: v1beta1
-    served: true
-    storage: false
----
-apiVersion: apiextensions.k8s.io/v1beta1
-kind: CustomResourceDefinition
-metadata:
-  annotations:
-    helm.sh/resource-policy: keep
-  labels:
-    app: istio-pilot
-    chart: istio
-    cloudfoundry.org/istio_version: 1.9.5
-    heritage: Tiller
-    release: istio
-  name: sidecars.networking.istio.io
-spec:
-  group: networking.istio.io
-  names:
-    categories:
-    - istio-io
-    - networking-istio-io
-    kind: Sidecar
-    listKind: SidecarList
-    plural: sidecars
-    singular: sidecar
-  preserveUnknownFields: false
-  scope: Namespaced
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      properties:
-        spec:
-          description: 'Configuration affecting network reachability of a sidecar. See more details at: https://istio.io/docs/reference/config/networking/sidecar.html'
-          properties:
-            egress:
-              items:
-                properties:
-                  bind:
-                    format: string
-                    type: string
-                  captureMode:
-                    enum:
-                    - DEFAULT
-                    - IPTABLES
-                    - NONE
-                    type: string
-                  hosts:
-                    items:
-                      format: string
-                      type: string
-                    type: array
-                  port:
-                    description: The port associated with the listener.
-                    properties:
-                      name:
-                        description: Label assigned to the port.
-                        format: string
-                        type: string
-                      number:
-                        description: A valid non-negative integer port number.
-                        type: integer
-                      protocol:
-                        description: The protocol exposed on the port.
-                        format: string
-                        type: string
-                      targetPort:
-                        type: integer
-                    type: object
-                type: object
-              type: array
-            ingress:
-              items:
-                properties:
-                  bind:
-                    description: The IP to which the listener should be bound.
-                    format: string
-                    type: string
-                  captureMode:
-                    enum:
-                    - DEFAULT
-                    - IPTABLES
-                    - NONE
-                    type: string
-                  defaultEndpoint:
-                    format: string
-                    type: string
-                  port:
-                    description: The port associated with the listener.
-                    properties:
-                      name:
-                        description: Label assigned to the port.
-                        format: string
-                        type: string
-                      number:
-                        description: A valid non-negative integer port number.
-                        type: integer
-                      protocol:
-                        description: The protocol exposed on the port.
-                        format: string
-                        type: string
-                      targetPort:
-                        type: integer
-                    type: object
-                type: object
-              type: array
-            outboundTrafficPolicy:
-              description: Configuration for the outbound traffic policy.
-              properties:
-                egressProxy:
-                  properties:
-                    host:
-                      description: The name of a service from the service registry.
-                      format: string
-                      type: string
-                    port:
-                      description: Specifies the port on the host that is being addressed.
-                      properties:
-                        number:
-                          type: integer
-                      type: object
-                    subset:
-                      description: The name of a subset within the service.
-                      format: string
-                      type: string
-                  type: object
-                mode:
-                  enum:
-                  - REGISTRY_ONLY
-                  - ALLOW_ANY
-                  type: string
-              type: object
-            workloadSelector:
-              properties:
-                labels:
-                  additionalProperties:
-                    format: string
-                    type: string
-                  type: object
-              type: object
-          type: object
-        status:
-          type: object
-          x-kubernetes-preserve-unknown-fields: true
-      type: object
-  versions:
-  - name: v1alpha3
-    served: true
-    storage: true
-  - name: v1beta1
-    served: true
-    storage: false
----
-apiVersion: apiextensions.k8s.io/v1beta1
-kind: CustomResourceDefinition
-metadata:
-  annotations:
-    helm.sh/resource-policy: keep
-  labels:
-    app: istio-pilot
-    chart: istio
-    cloudfoundry.org/istio_version: 1.9.5
-    heritage: Tiller
-    release: istio
-  name: virtualservices.networking.istio.io
-spec:
-  additionalPrinterColumns:
-  - JSONPath: .spec.gateways
-    description: The names of gateways and sidecars that should apply these routes
-    name: Gateways
-    type: string
-  - JSONPath: .spec.hosts
-    description: The destination hosts to which traffic is being sent
-    name: Hosts
-    type: string
-  - JSONPath: .metadata.creationTimestamp
-    description: 'CreationTimestamp is a timestamp representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations. Clients may not set this value. It is represented in RFC3339 form and is in UTC. Populated by the system. Read-only. Null for lists. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata'
-    name: Age
-    type: date
-  group: networking.istio.io
-  names:
-    categories:
-    - istio-io
-    - networking-istio-io
-    kind: VirtualService
-    listKind: VirtualServiceList
-    plural: virtualservices
-    shortNames:
-    - vs
-    singular: virtualservice
-  preserveUnknownFields: false
-  scope: Namespaced
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      properties:
-        spec:
-          description: 'Configuration affecting label/content routing, sni routing, etc. See more details at: https://istio.io/docs/reference/config/networking/virtual-service.html'
-          properties:
-            exportTo:
-              description: A list of namespaces to which this virtual service is exported.
-              items:
-                format: string
-                type: string
-              type: array
-            gateways:
-              description: The names of gateways and sidecars that should apply these routes.
-              items:
-                format: string
-                type: string
-              type: array
-            hosts:
-              description: The destination hosts to which traffic is being sent.
-              items:
-                format: string
-                type: string
-              type: array
-            http:
-              description: An ordered list of route rules for HTTP traffic.
-              items:
-                properties:
-                  corsPolicy:
-                    description: Cross-Origin Resource Sharing policy (CORS).
-                    properties:
-                      allowCredentials:
-                        nullable: true
-                        type: boolean
-                      allowHeaders:
-                        items:
-                          format: string
-                          type: string
-                        type: array
-                      allowMethods:
-                        description: List of HTTP methods allowed to access the resource.
-                        items:
-                          format: string
-                          type: string
-                        type: array
-                      allowOrigin:
-                        description: The list of origins that are allowed to perform CORS requests.
-                        items:
-                          format: string
-                          type: string
-                        type: array
-                      allowOrigins:
-                        description: String patterns that match allowed origins.
-                        items:
-                          oneOf:
-                          - not:
-                              anyOf:
-                              - required:
-                                - exact
-                              - required:
-                                - prefix
-                              - required:
-                                - regex
-                          - required:
-                            - exact
-                          - required:
-                            - prefix
-                          - required:
-                            - regex
-                          properties:
-                            exact:
-                              format: string
-                              type: string
-                            prefix:
-                              format: string
-                              type: string
-                            regex:
-                              description: RE2 style regex-based match (https://github.com/google/re2/wiki/Syntax).
-                              format: string
-                              type: string
-                          type: object
-                        type: array
-                      exposeHeaders:
-                        items:
-                          format: string
-                          type: string
-                        type: array
-                      maxAge:
-                        type: string
-                    type: object
-                  delegate:
-                    properties:
-                      name:
-                        description: Name specifies the name of the delegate VirtualService.
-                        format: string
-                        type: string
-                      namespace:
-                        description: Namespace specifies the namespace where the delegate VirtualService resides.
-                        format: string
-                        type: string
-                    type: object
-                  fault:
-                    description: Fault injection policy to apply on HTTP traffic at the client side.
-                    properties:
-                      abort:
-                        oneOf:
-                        - not:
-                            anyOf:
-                            - required:
-                              - httpStatus
-                            - required:
-                              - grpcStatus
-                            - required:
-                              - http2Error
-                        - required:
-                          - httpStatus
-                        - required:
-                          - grpcStatus
-                        - required:
-                          - http2Error
-                        properties:
-                          grpcStatus:
-                            format: string
-                            type: string
-                          http2Error:
-                            format: string
-                            type: string
-                          httpStatus:
-                            description: HTTP status code to use to abort the Http request.
-                            format: int32
-                            type: integer
-                          percentage:
-                            description: Percentage of requests to be aborted with the error code provided.
-                            properties:
-                              value:
-                                format: double
-                                type: number
-                            type: object
-                        type: object
-                      delay:
-                        oneOf:
-                        - not:
-                            anyOf:
-                            - required:
-                              - fixedDelay
-                            - required:
-                              - exponentialDelay
-                        - required:
-                          - fixedDelay
-                        - required:
-                          - exponentialDelay
-                        properties:
-                          exponentialDelay:
-                            type: string
-                          fixedDelay:
-                            description: Add a fixed delay before forwarding the request.
-                            type: string
-                          percent:
-                            description: Percentage of requests on which the delay will be injected (0-100).
-                            format: int32
-                            type: integer
-                          percentage:
-                            description: Percentage of requests on which the delay will be injected.
-                            properties:
-                              value:
-                                format: double
-                                type: number
-                            type: object
-                        type: object
-                    type: object
-                  headers:
-                    properties:
-                      request:
-                        properties:
-                          add:
-                            additionalProperties:
-                              format: string
-                              type: string
-                            type: object
-                          remove:
-                            items:
-                              format: string
-                              type: string
-                            type: array
-                          set:
-                            additionalProperties:
-                              format: string
-                              type: string
-                            type: object
-                        type: object
-                      response:
-                        properties:
-                          add:
-                            additionalProperties:
-                              format: string
-                              type: string
-                            type: object
-                          remove:
-                            items:
-                              format: string
-                              type: string
-                            type: array
-                          set:
-                            additionalProperties:
-                              format: string
-                              type: string
-                            type: object
-                        type: object
-                    type: object
-                  match:
-                    items:
-                      properties:
-                        authority:
-                          oneOf:
-                          - not:
-                              anyOf:
-                              - required:
-                                - exact
-                              - required:
-                                - prefix
-                              - required:
-                                - regex
-                          - required:
-                            - exact
-                          - required:
-                            - prefix
-                          - required:
-                            - regex
-                          properties:
-                            exact:
-                              format: string
-                              type: string
-                            prefix:
-                              format: string
-                              type: string
-                            regex:
-                              description: RE2 style regex-based match (https://github.com/google/re2/wiki/Syntax).
-                              format: string
-                              type: string
-                          type: object
-                        gateways:
-                          description: Names of gateways where the rule should be applied.
-                          items:
-                            format: string
-                            type: string
-                          type: array
-                        headers:
-                          additionalProperties:
-                            oneOf:
-                            - not:
-                                anyOf:
-                                - required:
-                                  - exact
-                                - required:
-                                  - prefix
-                                - required:
-                                  - regex
-                            - required:
-                              - exact
-                            - required:
-                              - prefix
-                            - required:
-                              - regex
-                            properties:
-                              exact:
-                                format: string
-                                type: string
-                              prefix:
-                                format: string
-                                type: string
-                              regex:
-                                description: RE2 style regex-based match (https://github.com/google/re2/wiki/Syntax).
-                                format: string
-                                type: string
-                            type: object
-                          type: object
-                        ignoreUriCase:
-                          description: Flag to specify whether the URI matching should be case-insensitive.
-                          type: boolean
-                        method:
-                          oneOf:
-                          - not:
-                              anyOf:
-                              - required:
-                                - exact
-                              - required:
-                                - prefix
-                              - required:
-                                - regex
-                          - required:
-                            - exact
-                          - required:
-                            - prefix
-                          - required:
-                            - regex
-                          properties:
-                            exact:
-                              format: string
-                              type: string
-                            prefix:
-                              format: string
-                              type: string
-                            regex:
-                              description: RE2 style regex-based match (https://github.com/google/re2/wiki/Syntax).
-                              format: string
-                              type: string
-                          type: object
-                        name:
-                          description: The name assigned to a match.
-                          format: string
-                          type: string
-                        port:
-                          description: Specifies the ports on the host that is being addressed.
-                          type: integer
-                        queryParams:
-                          additionalProperties:
-                            oneOf:
-                            - not:
-                                anyOf:
-                                - required:
-                                  - exact
-                                - required:
-                                  - prefix
-                                - required:
-                                  - regex
-                            - required:
-                              - exact
-                            - required:
-                              - prefix
-                            - required:
-                              - regex
-                            properties:
-                              exact:
-                                format: string
-                                type: string
-                              prefix:
-                                format: string
-                                type: string
-                              regex:
-                                description: RE2 style regex-based match (https://github.com/google/re2/wiki/Syntax).
-                                format: string
-                                type: string
-                            type: object
-                          description: Query parameters for matching.
-                          type: object
-                        scheme:
-                          oneOf:
-                          - not:
-                              anyOf:
-                              - required:
-                                - exact
-                              - required:
-                                - prefix
-                              - required:
-                                - regex
-                          - required:
-                            - exact
-                          - required:
-                            - prefix
-                          - required:
-                            - regex
-                          properties:
-                            exact:
-                              format: string
-                              type: string
-                            prefix:
-                              format: string
-                              type: string
-                            regex:
-                              description: RE2 style regex-based match (https://github.com/google/re2/wiki/Syntax).
-                              format: string
-                              type: string
-                          type: object
-                        sourceLabels:
-                          additionalProperties:
-                            format: string
-                            type: string
-                          type: object
-                        sourceNamespace:
-                          description: Source namespace constraining the applicability of a rule to workloads in that namespace.
-                          format: string
-                          type: string
-                        uri:
-                          oneOf:
-                          - not:
-                              anyOf:
-                              - required:
-                                - exact
-                              - required:
-                                - prefix
-                              - required:
-                                - regex
-                          - required:
-                            - exact
-                          - required:
-                            - prefix
-                          - required:
-                            - regex
-                          properties:
-                            exact:
-                              format: string
-                              type: string
-                            prefix:
-                              format: string
-                              type: string
-                            regex:
-                              description: RE2 style regex-based match (https://github.com/google/re2/wiki/Syntax).
-                              format: string
-                              type: string
-                          type: object
-                        withoutHeaders:
-                          additionalProperties:
-                            oneOf:
-                            - not:
-                                anyOf:
-                                - required:
-                                  - exact
-                                - required:
-                                  - prefix
-                                - required:
-                                  - regex
-                            - required:
-                              - exact
-                            - required:
-                              - prefix
-                            - required:
-                              - regex
-                            properties:
-                              exact:
-                                format: string
-                                type: string
-                              prefix:
-                                format: string
-                                type: string
-                              regex:
-                                description: RE2 style regex-based match (https://github.com/google/re2/wiki/Syntax).
-                                format: string
-                                type: string
-                            type: object
-                          description: withoutHeader has the same syntax with the header, but has opposite meaning.
-                          type: object
-                      type: object
-                    type: array
-                  mirror:
-                    properties:
-                      host:
-                        description: The name of a service from the service registry.
-                        format: string
-                        type: string
-                      port:
-                        description: Specifies the port on the host that is being addressed.
-                        properties:
-                          number:
-                            type: integer
-                        type: object
-                      subset:
-                        description: The name of a subset within the service.
-                        format: string
-                        type: string
-                    type: object
-                  mirror_percent:
-                    description: Percentage of the traffic to be mirrored by the `mirror` field.
-                    nullable: true
-                    type: integer
-                  mirrorPercent:
-                    description: Percentage of the traffic to be mirrored by the `mirror` field.
-                    nullable: true
-                    type: integer
-                  mirrorPercentage:
-                    description: Percentage of the traffic to be mirrored by the `mirror` field.
-                    properties:
-                      value:
-                        format: double
-                        type: number
-                    type: object
-                  name:
-                    description: The name assigned to the route for debugging purposes.
-                    format: string
-                    type: string
-                  redirect:
-                    description: A HTTP rule can either redirect or forward (default) traffic.
-                    properties:
-                      authority:
-                        format: string
-                        type: string
-                      redirectCode:
-                        type: integer
-                      uri:
-                        format: string
-                        type: string
-                    type: object
-                  retries:
-                    description: Retry policy for HTTP requests.
-                    properties:
-                      attempts:
-                        description: Number of retries to be allowed for a given request.
-                        format: int32
-                        type: integer
-                      perTryTimeout:
-                        description: Timeout per attempt for a given request, including the initial call and any retries.
-                        type: string
-                      retryOn:
-                        description: Specifies the conditions under which retry takes place.
-                        format: string
-                        type: string
-                      retryRemoteLocalities:
-                        description: Flag to specify whether the retries should retry to other localities.
-                        nullable: true
-                        type: boolean
-                    type: object
-                  rewrite:
-                    description: Rewrite HTTP URIs and Authority headers.
-                    properties:
-                      authority:
-                        description: rewrite the Authority/Host header with this value.
-                        format: string
-                        type: string
-                      uri:
-                        format: string
-                        type: string
-                    type: object
-                  route:
-                    description: A HTTP rule can either redirect or forward (default) traffic.
-                    items:
-                      properties:
-                        destination:
-                          properties:
-                            host:
-                              description: The name of a service from the service registry.
-                              format: string
-                              type: string
-                            port:
-                              description: Specifies the port on the host that is being addressed.
-                              properties:
-                                number:
-                                  type: integer
-                              type: object
-                            subset:
-                              description: The name of a subset within the service.
-                              format: string
-                              type: string
-                          type: object
-                        headers:
-                          properties:
-                            request:
-                              properties:
-                                add:
-                                  additionalProperties:
-                                    format: string
-                                    type: string
-                                  type: object
-                                remove:
-                                  items:
-                                    format: string
-                                    type: string
-                                  type: array
-                                set:
-                                  additionalProperties:
-                                    format: string
-                                    type: string
-                                  type: object
-                              type: object
-                            response:
-                              properties:
-                                add:
-                                  additionalProperties:
-                                    format: string
-                                    type: string
-                                  type: object
-                                remove:
-                                  items:
-                                    format: string
-                                    type: string
-                                  type: array
-                                set:
-                                  additionalProperties:
-                                    format: string
-                                    type: string
-                                  type: object
-                              type: object
-                          type: object
-                        weight:
-                          format: int32
-                          type: integer
-                      type: object
-                    type: array
-                  timeout:
-                    description: Timeout for HTTP requests, default is disabled.
-                    type: string
-                type: object
-              type: array
-            tcp:
-              description: An ordered list of route rules for opaque TCP traffic.
-              items:
-                properties:
-                  match:
-                    items:
-                      properties:
-                        destinationSubnets:
-                          description: IPv4 or IPv6 ip addresses of destination with optional subnet.
-                          items:
-                            format: string
-                            type: string
-                          type: array
-                        gateways:
-                          description: Names of gateways where the rule should be applied.
-                          items:
-                            format: string
-                            type: string
-                          type: array
-                        port:
-                          description: Specifies the port on the host that is being addressed.
-                          type: integer
-                        sourceLabels:
-                          additionalProperties:
-                            format: string
-                            type: string
-                          type: object
-                        sourceNamespace:
-                          description: Source namespace constraining the applicability of a rule to workloads in that namespace.
-                          format: string
-                          type: string
-                        sourceSubnet:
-                          description: IPv4 or IPv6 ip address of source with optional subnet.
-                          format: string
-                          type: string
-                      type: object
-                    type: array
-                  route:
-                    description: The destination to which the connection should be forwarded to.
-                    items:
-                      properties:
-                        destination:
-                          properties:
-                            host:
-                              description: The name of a service from the service registry.
-                              format: string
-                              type: string
-                            port:
-                              description: Specifies the port on the host that is being addressed.
-                              properties:
-                                number:
-                                  type: integer
-                              type: object
-                            subset:
-                              description: The name of a subset within the service.
-                              format: string
-                              type: string
-                          type: object
-                        weight:
-                          format: int32
-                          type: integer
-                      type: object
-                    type: array
-                type: object
-              type: array
-            tls:
-              items:
-                properties:
-                  match:
-                    items:
-                      properties:
-                        destinationSubnets:
-                          description: IPv4 or IPv6 ip addresses of destination with optional subnet.
-                          items:
-                            format: string
-                            type: string
-                          type: array
-                        gateways:
-                          description: Names of gateways where the rule should be applied.
-                          items:
-                            format: string
-                            type: string
-                          type: array
-                        port:
-                          description: Specifies the port on the host that is being addressed.
-                          type: integer
-                        sniHosts:
-                          description: SNI (server name indicator) to match on.
-                          items:
-                            format: string
-                            type: string
-                          type: array
-                        sourceLabels:
-                          additionalProperties:
-                            format: string
-                            type: string
-                          type: object
-                        sourceNamespace:
-                          description: Source namespace constraining the applicability of a rule to workloads in that namespace.
-                          format: string
-                          type: string
-                      type: object
-                    type: array
-                  route:
-                    description: The destination to which the connection should be forwarded to.
-                    items:
-                      properties:
-                        destination:
-                          properties:
-                            host:
-                              description: The name of a service from the service registry.
-                              format: string
-                              type: string
-                            port:
-                              description: Specifies the port on the host that is being addressed.
-                              properties:
-                                number:
-                                  type: integer
-                              type: object
-                            subset:
-                              description: The name of a subset within the service.
-                              format: string
-                              type: string
-                          type: object
-                        weight:
-                          format: int32
-                          type: integer
-                      type: object
-                    type: array
-                type: object
-              type: array
-          type: object
-        status:
-          type: object
-          x-kubernetes-preserve-unknown-fields: true
-      type: object
-  versions:
-  - name: v1alpha3
-    served: true
-    storage: true
-  - name: v1beta1
-    served: true
-    storage: false
----
-apiVersion: apiextensions.k8s.io/v1beta1
-kind: CustomResourceDefinition
-metadata:
-  annotations:
-    helm.sh/resource-policy: keep
-  labels:
-    app: istio-pilot
-    chart: istio
-    cloudfoundry.org/istio_version: 1.9.5
-    heritage: Tiller
-    release: istio
-  name: workloadentries.networking.istio.io
-spec:
-  additionalPrinterColumns:
-  - JSONPath: .metadata.creationTimestamp
-    description: 'CreationTimestamp is a timestamp representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations. Clients may not set this value. It is represented in RFC3339 form and is in UTC. Populated by the system. Read-only. Null for lists. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata'
-    name: Age
-    type: date
-  - JSONPath: .spec.address
-    description: Address associated with the network endpoint.
-    name: Address
-    type: string
-  group: networking.istio.io
-  names:
-    categories:
-    - istio-io
-    - networking-istio-io
-    kind: WorkloadEntry
-    listKind: WorkloadEntryList
-    plural: workloadentries
-    shortNames:
-    - we
-    singular: workloadentry
-  preserveUnknownFields: false
-  scope: Namespaced
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      properties:
-        spec:
-          description: 'Configuration affecting VMs onboarded into the mesh. See more details at: https://istio.io/docs/reference/config/networking/workload-entry.html'
-          properties:
-            address:
-              format: string
-              type: string
-            labels:
-              additionalProperties:
-                format: string
-                type: string
-              description: One or more labels associated with the endpoint.
-              type: object
-            locality:
-              description: The locality associated with the endpoint.
-              format: string
-              type: string
-            network:
-              format: string
-              type: string
-            ports:
-              additionalProperties:
-                type: integer
-              description: Set of ports associated with the endpoint.
-              type: object
-            serviceAccount:
-              format: string
-              type: string
-            weight:
-              description: The load balancing weight associated with the endpoint.
-              type: integer
-          type: object
-        status:
-          type: object
-          x-kubernetes-preserve-unknown-fields: true
-      type: object
-  versions:
-  - name: v1alpha3
-    served: true
-    storage: true
-  - name: v1beta1
-    served: true
-    storage: false
----
-apiVersion: apiextensions.k8s.io/v1beta1
-kind: CustomResourceDefinition
-metadata:
-  labels:
-    app: istio-pilot
-    chart: istio
-    cloudfoundry.org/istio_version: 1.9.5
-    heritage: Tiller
-    release: istio
-  name: workloadgroups.networking.istio.io
-spec:
-  additionalPrinterColumns:
-  - JSONPath: .metadata.creationTimestamp
-    description: 'CreationTimestamp is a timestamp representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations. Clients may not set this value. It is represented in RFC3339 form and is in UTC. Populated by the system. Read-only. Null for lists. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata'
-    name: Age
-    type: date
-  group: networking.istio.io
-  names:
-    categories:
-    - istio-io
-    - networking-istio-io
-    kind: WorkloadGroup
-    listKind: WorkloadGroupList
-    plural: workloadgroups
-    shortNames:
-    - wg
-    singular: workloadgroup
-  preserveUnknownFields: false
-  scope: Namespaced
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      properties:
-        spec:
-          description: 'Describes a collection of workload instances. See more details at: https://istio.io/docs/reference/config/networking/workload-group.html'
-          properties:
-            metadata:
-              description: Metadata that will be used for all corresponding `WorkloadEntries`.
-              properties:
-                annotations:
-                  additionalProperties:
-                    format: string
-                    type: string
-                  type: object
-                labels:
-                  additionalProperties:
-                    format: string
-                    type: string
-                  type: object
-              type: object
-            probe:
-              description: '`ReadinessProbe` describes the configuration the user must provide for healthchecking on their workload.'
-              oneOf:
-              - not:
-                  anyOf:
-                  - required:
-                    - httpGet
-                  - required:
-                    - tcpSocket
-                  - required:
-                    - exec
-              - required:
-                - httpGet
-              - required:
-                - tcpSocket
-              - required:
-                - exec
-              properties:
-                exec:
-                  description: Health is determined by how the command that is executed exited.
-                  properties:
-                    command:
-                      description: Command to run.
-                      items:
-                        format: string
-                        type: string
-                      type: array
-                  type: object
-                failureThreshold:
-                  description: Minimum consecutive failures for the probe to be considered failed after having succeeded.
-                  format: int32
-                  type: integer
-                httpGet:
-                  properties:
-                    host:
-                      description: Host name to connect to, defaults to the pod IP.
-                      format: string
-                      type: string
-                    httpHeaders:
-                      description: Headers the proxy will pass on to make the request.
-                      items:
-                        properties:
-                          name:
-                            format: string
-                            type: string
-                          value:
-                            format: string
-                            type: string
-                        type: object
-                      type: array
-                    path:
-                      description: Path to access on the HTTP server.
-                      format: string
-                      type: string
-                    port:
-                      description: Port on which the endpoint lives.
-                      type: integer
-                    scheme:
-                      format: string
-                      type: string
-                  type: object
-                initialDelaySeconds:
-                  description: Number of seconds after the container has started before readiness probes are initiated.
-                  format: int32
-                  type: integer
-                periodSeconds:
-                  description: How often (in seconds) to perform the probe.
-                  format: int32
-                  type: integer
-                successThreshold:
-                  description: Minimum consecutive successes for the probe to be considered successful after having failed.
-                  format: int32
-                  type: integer
-                tcpSocket:
-                  description: Health is determined by if the proxy is able to connect.
-                  properties:
-                    host:
-                      format: string
-                      type: string
-                    port:
-                      type: integer
-                  type: object
-                timeoutSeconds:
-                  description: Number of seconds after which the probe times out.
-                  format: int32
-                  type: integer
-              type: object
-            template:
-              description: Template to be used for the generation of `WorkloadEntry` resources that belong to this `WorkloadGroup`.
-              properties:
-                address:
-                  format: string
-                  type: string
-                labels:
-                  additionalProperties:
-                    format: string
-                    type: string
-                  description: One or more labels associated with the endpoint.
-                  type: object
-                locality:
-                  description: The locality associated with the endpoint.
-                  format: string
-                  type: string
-                network:
-                  format: string
-                  type: string
-                ports:
-                  additionalProperties:
-                    type: integer
-                  description: Set of ports associated with the endpoint.
-                  type: object
-                serviceAccount:
-                  format: string
-                  type: string
-                weight:
-                  description: The load balancing weight associated with the endpoint.
-                  type: integer
-              type: object
-          type: object
-        status:
-          type: object
-          x-kubernetes-preserve-unknown-fields: true
-      type: object
-  versions:
-  - name: v1alpha3
-    served: true
-    storage: true
+    subresources:
+      status: {}
 ---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   labels:
     app: istio-ingressgateway
-    cloudfoundry.org/istio_version: 1.9.5
+    cloudfoundry.org/istio_version: 1.10.2
     install.operator.istio.io/owning-resource: unknown
     istio: ingressgateway
     istio.io/rev: default
@@ -3341,7 +5679,7 @@ kind: ServiceAccount
 metadata:
   labels:
     app: istio-reader
-    cloudfoundry.org/istio_version: 1.9.5
+    cloudfoundry.org/istio_version: 1.10.2
     release: istio
   name: istio-reader-service-account
   namespace: istio-system
@@ -3351,7 +5689,7 @@ kind: ServiceAccount
 metadata:
   labels:
     app: istiod
-    cloudfoundry.org/istio_version: 1.9.5
+    cloudfoundry.org/istio_version: 1.10.2
     release: istio
   name: istiod-service-account
   namespace: istio-system
@@ -3361,7 +5699,7 @@ kind: ClusterRole
 metadata:
   labels:
     app: istio-reader
-    cloudfoundry.org/istio_version: 1.9.5
+    cloudfoundry.org/istio_version: 1.10.2
     release: istio
   name: istio-reader-istio-system
 rules:
@@ -3441,7 +5779,7 @@ kind: ClusterRole
 metadata:
   labels:
     app: istiod
-    cloudfoundry.org/istio_version: 1.9.5
+    cloudfoundry.org/istio_version: 1.10.2
     release: istio
   name: istiod-istio-system
 rules:
@@ -3470,6 +5808,7 @@ rules:
   - networking.istio.io
   - authentication.istio.io
   - rbac.istio.io
+  - telemetry.istio.io
   resources:
   - '*'
   verbs:
@@ -3594,6 +5933,12 @@ rules:
   - watch
   - list
 - apiGroups:
+  - networking.x-k8s.io
+  resources:
+  - '*'
+  verbs:
+  - update
+- apiGroups:
   - ""
   resources:
   - secrets
@@ -3601,13 +5946,23 @@ rules:
   - get
   - watch
   - list
+- apiGroups:
+  - multicluster.x-k8s.io
+  resources:
+  - serviceexports
+  verbs:
+  - get
+  - watch
+  - list
+  - create
+  - delete
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
     app: istio-reader
-    cloudfoundry.org/istio_version: 1.9.5
+    cloudfoundry.org/istio_version: 1.10.2
     release: istio
   name: istio-reader-istio-system
 roleRef:
@@ -3624,7 +5979,7 @@ kind: ClusterRoleBinding
 metadata:
   labels:
     app: istiod
-    cloudfoundry.org/istio_version: 1.9.5
+    cloudfoundry.org/istio_version: 1.10.2
     release: istio
   name: istiod-istio-system
 roleRef:
@@ -3636,12 +5991,12 @@ subjects:
   name: istiod-service-account
   namespace: istio-system
 ---
-apiVersion: admissionregistration.k8s.io/v1beta1
+apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
   labels:
     app: istiod
-    cloudfoundry.org/istio_version: 1.9.5
+    cloudfoundry.org/istio_version: 1.10.2
     istio: istiod
     release: istio
   name: istiod-istio-system
@@ -3674,11 +6029,11 @@ apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:
   labels:
-    cloudfoundry.org/istio_version: 1.9.5
+    cloudfoundry.org/istio_version: 1.10.2
     install.operator.istio.io/owning-resource: unknown
     istio.io/rev: default
     operator.istio.io/component: Pilot
-  name: metadata-exchange-1.8
+  name: metadata-exchange-1.10
   namespace: istio-system
 spec:
   configPatches:
@@ -3690,7 +6045,7 @@ spec:
           filter:
             name: envoy.filters.network.http_connection_manager
       proxy:
-        proxyVersion: ^1\.8.*
+        proxyVersion: ^1\.10.*
     patch:
       operation: INSERT_BEFORE
       value:
@@ -3717,7 +6072,7 @@ spec:
           filter:
             name: envoy.filters.network.http_connection_manager
       proxy:
-        proxyVersion: ^1\.8.*
+        proxyVersion: ^1\.10.*
     patch:
       operation: INSERT_BEFORE
       value:
@@ -3744,7 +6099,7 @@ spec:
           filter:
             name: envoy.filters.network.http_connection_manager
       proxy:
-        proxyVersion: ^1\.8.*
+        proxyVersion: ^1\.10.*
     patch:
       operation: INSERT_BEFORE
       value:
@@ -3768,7 +6123,7 @@ apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:
   labels:
-    cloudfoundry.org/istio_version: 1.9.5
+    cloudfoundry.org/istio_version: 1.10.2
     install.operator.istio.io/owning-resource: unknown
     istio.io/rev: default
     operator.istio.io/component: Pilot
@@ -3862,9 +6217,9 @@ apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:
   labels:
-    cloudfoundry.org/istio_version: 1.9.5
+    cloudfoundry.org/istio_version: 1.10.2
     istio.io/rev: default
-  name: stats-filter-1.8
+  name: stats-filter-1.10
   namespace: istio-system
 spec:
   configPatches:
@@ -3878,7 +6233,7 @@ spec:
             subFilter:
               name: envoy.filters.http.router
       proxy:
-        proxyVersion: ^1\.8.*
+        proxyVersion: ^1\.10.*
     patch:
       operation: INSERT_BEFORE
       value:
@@ -3892,6 +6247,8 @@ spec:
                 '@type': type.googleapis.com/google.protobuf.StringValue
                 value: |
                   {
+                    "debug": "false",
+                    "stat_prefix": "istio"
                   }
               root_id: stats_outbound
               vm_config:
@@ -3910,7 +6267,7 @@ spec:
             subFilter:
               name: envoy.filters.http.router
       proxy:
-        proxyVersion: ^1\.8.*
+        proxyVersion: ^1\.10.*
     patch:
       operation: INSERT_BEFORE
       value:
@@ -3924,6 +6281,16 @@ spec:
                 '@type': type.googleapis.com/google.protobuf.StringValue
                 value: |
                   {
+                    "debug": "false",
+                    "stat_prefix": "istio",
+                    "metrics": [
+                      {
+                        "dimensions": {
+                          "destination_cluster": "node.metadata['CLUSTER_ID']",
+                          "source_cluster": "downstream_peer.cluster_id"
+                        }
+                      }
+                    ]
                   }
               root_id: stats_inbound
               vm_config:
@@ -3942,7 +6309,7 @@ spec:
             subFilter:
               name: envoy.filters.http.router
       proxy:
-        proxyVersion: ^1\.8.*
+        proxyVersion: ^1\.10.*
     patch:
       operation: INSERT_BEFORE
       value:
@@ -3956,6 +6323,8 @@ spec:
                 '@type': type.googleapis.com/google.protobuf.StringValue
                 value: |
                   {
+                    "debug": "false",
+                    "stat_prefix": "istio",
                     "disable_host_header_fallback": true
                   }
               root_id: stats_outbound
@@ -3970,7 +6339,7 @@ apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:
   labels:
-    cloudfoundry.org/istio_version: 1.9.5
+    cloudfoundry.org/istio_version: 1.10.2
     istio.io/rev: default
   name: stats-filter-1.9
   namespace: istio-system
@@ -4108,9 +6477,9 @@ apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:
   labels:
-    cloudfoundry.org/istio_version: 1.9.5
+    cloudfoundry.org/istio_version: 1.10.2
     istio.io/rev: default
-  name: tcp-metadata-exchange-1.8
+  name: tcp-metadata-exchange-1.10
   namespace: istio-system
 spec:
   configPatches:
@@ -4119,7 +6488,7 @@ spec:
       context: SIDECAR_INBOUND
       listener: {}
       proxy:
-        proxyVersion: ^1\.8.*
+        proxyVersion: ^1\.10.*
     patch:
       operation: INSERT_BEFORE
       value:
@@ -4134,7 +6503,7 @@ spec:
       cluster: {}
       context: SIDECAR_OUTBOUND
       proxy:
-        proxyVersion: ^1\.8.*
+        proxyVersion: ^1\.10.*
     patch:
       operation: MERGE
       value:
@@ -4150,7 +6519,7 @@ spec:
       cluster: {}
       context: GATEWAY
       proxy:
-        proxyVersion: ^1\.8.*
+        proxyVersion: ^1\.10.*
     patch:
       operation: MERGE
       value:
@@ -4166,7 +6535,7 @@ apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:
   labels:
-    cloudfoundry.org/istio_version: 1.9.5
+    cloudfoundry.org/istio_version: 1.10.2
     istio.io/rev: default
   name: tcp-metadata-exchange-1.9
   namespace: istio-system
@@ -4224,9 +6593,9 @@ apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:
   labels:
-    cloudfoundry.org/istio_version: 1.9.5
+    cloudfoundry.org/istio_version: 1.10.2
     istio.io/rev: default
-  name: tcp-stats-filter-1.8
+  name: tcp-stats-filter-1.10
   namespace: istio-system
 spec:
   configPatches:
@@ -4238,7 +6607,7 @@ spec:
           filter:
             name: envoy.filters.network.tcp_proxy
       proxy:
-        proxyVersion: ^1\.8.*
+        proxyVersion: ^1\.10.*
     patch:
       operation: INSERT_BEFORE
       value:
@@ -4252,6 +6621,16 @@ spec:
                 '@type': type.googleapis.com/google.protobuf.StringValue
                 value: |
                   {
+                    "debug": "false",
+                    "stat_prefix": "istio",
+                    "metrics": [
+                      {
+                        "dimensions": {
+                          "destination_cluster": "node.metadata['CLUSTER_ID']",
+                          "source_cluster": "downstream_peer.cluster_id"
+                        }
+                      }
+                    ]
                   }
               root_id: stats_inbound
               vm_config:
@@ -4268,7 +6647,7 @@ spec:
           filter:
             name: envoy.filters.network.tcp_proxy
       proxy:
-        proxyVersion: ^1\.8.*
+        proxyVersion: ^1\.10.*
     patch:
       operation: INSERT_BEFORE
       value:
@@ -4282,6 +6661,8 @@ spec:
                 '@type': type.googleapis.com/google.protobuf.StringValue
                 value: |
                   {
+                    "debug": "false",
+                    "stat_prefix": "istio"
                   }
               root_id: stats_outbound
               vm_config:
@@ -4298,7 +6679,7 @@ spec:
           filter:
             name: envoy.filters.network.tcp_proxy
       proxy:
-        proxyVersion: ^1\.8.*
+        proxyVersion: ^1\.10.*
     patch:
       operation: INSERT_BEFORE
       value:
@@ -4312,6 +6693,8 @@ spec:
                 '@type': type.googleapis.com/google.protobuf.StringValue
                 value: |
                   {
+                    "debug": "false",
+                    "stat_prefix": "istio"
                   }
               root_id: stats_outbound
               vm_config:
@@ -4325,7 +6708,7 @@ apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:
   labels:
-    cloudfoundry.org/istio_version: 1.9.5
+    cloudfoundry.org/istio_version: 1.10.2
     istio.io/rev: default
   name: tcp-stats-filter-1.9
   namespace: istio-system
@@ -4507,7 +6890,7 @@ data:
 kind: ConfigMap
 metadata:
   labels:
-    cloudfoundry.org/istio_version: 1.9.5
+    cloudfoundry.org/istio_version: 1.10.2
     install.operator.istio.io/owning-resource: unknown
     istio.io/rev: default
     operator.istio.io/component: Pilot
@@ -4540,6 +6923,7 @@ data:
           annotations: {
             {{- if eq (len $containers) 1 }}
             kubectl.kubernetes.io/default-logs-container: "{{ index $containers 0 }}",
+            kubectl.kubernetes.io/default-container: "{{ index $containers 0 }}",
             {{ end }}
         {{- if .Values.istio_cni.enabled }}
             {{- if not .Values.istio_cni.chained }}
@@ -4611,7 +6995,7 @@ data:
             - "--run-validation"
             - "--skip-rule-apply"
             {{ end -}}
-            imagePullPolicy: "{{ valueOrDefault .Values.global.imagePullPolicy `Always` }}"
+            {{with .Values.global.imagePullPolicy }}imagePullPolicy: "{{.}}"{{end}}
           {{- if .ProxyConfig.ProxyMetadata }}
             env:
             {{- range $key, $value := .ProxyConfig.ProxyMetadata }}
@@ -4680,7 +7064,7 @@ data:
           {{- else }}
             image: "{{ .Values.global.hub }}/{{ .Values.global.proxy_init.image }}:{{ .Values.global.tag }}"
           {{- end }}
-            imagePullPolicy: "{{ valueOrDefault .Values.global.imagePullPolicy `Always` }}"
+            {{with .Values.global.imagePullPolicy }}imagePullPolicy: "{{.}}"{{end}}
             resources: {}
             securityContext:
               allowPrivilegeEscalation: true
@@ -4742,6 +7126,10 @@ data:
                   - wait
           {{- end }}
             env:
+            {{- if eq (env "PILOT_ENABLE_INBOUND_PASSTHROUGH" "true") "false" }}
+            - name: REWRITE_PROBE_LEGACY_LOCALHOST_DESTINATION
+              value: "true"
+            {{- end }}
             - name: JWT_POLICY
               value: {{ .Values.global.jwtPolicy }}
             - name: PILOT_CERT_PROVIDER
@@ -4844,7 +7232,7 @@ data:
             - name: {{ $key }}
               value: "{{ $value }}"
             {{- end }}
-            imagePullPolicy: "{{ valueOrDefault .Values.global.imagePullPolicy `Always` }}"
+            {{with .Values.global.imagePullPolicy }}imagePullPolicy: "{{.}}"{{end}}
             {{ if ne (annotation .ObjectMeta `status.sidecar.istio.io/port` .Values.global.proxy.statusPort) `0` }}
             readinessProbe:
               httpGet:
@@ -5031,6 +7419,7 @@ data:
           annotations: {
             {{- if eq (len $containers) 1 }}
             kubectl.kubernetes.io/default-logs-container: "{{ index $containers 0 }}",
+            kubectl.kubernetes.io/default-container: "{{ index $containers 0 }}",
             {{ end }}
           }
         spec:
@@ -5257,11 +7646,6 @@ data:
   values: |-
     {
       "global": {
-        "arch": {
-          "amd64": 2,
-          "ppc64le": 2,
-          "s390x": 2
-        },
         "caAddress": "",
         "configValidation": true,
         "defaultNodeSelector": {},
@@ -5352,7 +7736,7 @@ data:
         "sts": {
           "servicePort": 0
         },
-        "tag": "1.9.5",
+        "tag": "1.10.2",
         "tracer": {
           "datadog": {
             "address": "$(HOST_IP):8126"
@@ -5371,7 +7755,6 @@ data:
             "address": ""
           }
         },
-        "trustDomain": "",
         "useMCP": false
       },
       "istio_cni": {
@@ -5390,13 +7773,13 @@ data:
         },
         "rewriteAppHTTPProbe": true,
         "templates": {},
-        "useLegacySelectors": true
+        "useLegacySelectors": false
       }
     }
 kind: ConfigMap
 metadata:
   labels:
-    cloudfoundry.org/istio_version: 1.9.5
+    cloudfoundry.org/istio_version: 1.10.2
     install.operator.istio.io/owning-resource: unknown
     istio.io/rev: default
     operator.istio.io/component: Pilot
@@ -5404,12 +7787,12 @@ metadata:
   name: istio-sidecar-injector
   namespace: istio-system
 ---
-apiVersion: admissionregistration.k8s.io/v1beta1
+apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
 metadata:
   labels:
     app: sidecar-injector
-    cloudfoundry.org/istio_version: 1.9.5
+    cloudfoundry.org/istio_version: 1.10.2
     install.operator.istio.io/owning-resource: unknown
     istio.io/rev: default
     operator.istio.io/component: Pilot
@@ -5424,17 +7807,128 @@ webhooks:
       name: istiod
       namespace: istio-system
       path: /inject
+      port: 443
   failurePolicy: Fail
-  name: sidecar-injector.istio.io
+  name: rev.namespace.sidecar-injector.istio.io
   namespaceSelector:
-    matchLabels:
-      istio-injection: enabled
+    matchExpressions:
+    - key: istio.io/rev
+      operator: In
+      values:
+      - default
+    - key: istio-injection
+      operator: DoesNotExist
   objectSelector:
     matchExpressions:
     - key: sidecar.istio.io/inject
       operator: NotIn
       values:
       - "false"
+  rules:
+  - apiGroups:
+    - ""
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    resources:
+    - pods
+  sideEffects: None
+- admissionReviewVersions:
+  - v1beta1
+  - v1
+  clientConfig:
+    service:
+      name: istiod
+      namespace: istio-system
+      path: /inject
+      port: 443
+  failurePolicy: Fail
+  name: rev.object.sidecar-injector.istio.io
+  namespaceSelector:
+    matchExpressions:
+    - key: istio.io/rev
+      operator: DoesNotExist
+    - key: istio-injection
+      operator: DoesNotExist
+  objectSelector:
+    matchExpressions:
+    - key: sidecar.istio.io/inject
+      operator: NotIn
+      values:
+      - "false"
+    - key: istio.io/rev
+      operator: In
+      values:
+      - default
+  rules:
+  - apiGroups:
+    - ""
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    resources:
+    - pods
+  sideEffects: None
+- admissionReviewVersions:
+  - v1beta1
+  - v1
+  clientConfig:
+    service:
+      name: istiod
+      namespace: istio-system
+      path: /inject
+      port: 443
+  failurePolicy: Fail
+  name: namespace.sidecar-injector.istio.io
+  namespaceSelector:
+    matchExpressions:
+    - key: istio-injection
+      operator: In
+      values:
+      - enabled
+  objectSelector:
+    matchExpressions:
+    - key: sidecar.istio.io/inject
+      operator: NotIn
+      values:
+      - "false"
+  rules:
+  - apiGroups:
+    - ""
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    resources:
+    - pods
+  sideEffects: None
+- admissionReviewVersions:
+  - v1beta1
+  - v1
+  clientConfig:
+    service:
+      name: istiod
+      namespace: istio-system
+      path: /inject
+      port: 443
+  failurePolicy: Fail
+  name: object.sidecar-injector.istio.io
+  namespaceSelector:
+    matchExpressions:
+    - key: istio-injection
+      operator: DoesNotExist
+    - key: istio.io/rev
+      operator: DoesNotExist
+  objectSelector:
+    matchExpressions:
+    - key: sidecar.istio.io/inject
+      operator: In
+      values:
+      - "true"
+    - key: istio.io/rev
+      operator: DoesNotExist
   rules:
   - apiGroups:
     - ""
@@ -5452,13 +7946,13 @@ metadata:
   annotations:
     kbld.k14s.io/images: |
       - Metas:
-        - Tag: 1.9.5
+        - Tag: 1.10.2
           Type: resolved
-          URL: index.docker.io/istio/proxyv2:1.9.5
-        URL: index.docker.io/istio/proxyv2@sha256:01fc76f6dd3665ff1dd4aa9e309e4b02380fa266763e172ca07c766e8d2fe2d7
+          URL: index.docker.io/istio/proxyv2:1.10.2
+        URL: index.docker.io/istio/proxyv2@sha256:ffbc024407c89d15b102242b7b52c589ff3618c5117585007abbdf03da7a6528
   labels:
     app: istio-ingressgateway
-    cloudfoundry.org/istio_version: 1.9.5
+    cloudfoundry.org/istio_version: 1.10.2
     install.operator.istio.io/owning-resource: unknown
     istio: ingressgateway
     istio.io/rev: default
@@ -5481,7 +7975,7 @@ spec:
       labels:
         app: istio-ingressgateway
         chart: gateways
-        cloudfoundry.org/istio_version: 1.9.5
+        cloudfoundry.org/istio_version: 1.10.2
         heritage: Tiller
         install.operator.istio.io/owning-resource: unknown
         istio: ingressgateway
@@ -5584,6 +8078,10 @@ spec:
           value: istio-ingressgateway
         - name: ISTIO_META_OWNER
           value: kubernetes://apis/apps/v1/namespaces/istio-system/deployments/istio-ingressgateway
+        - name: ISTIO_META_MESH_ID
+          value: cluster.local
+        - name: TRUST_DOMAIN
+          value: cluster.local
         - name: ISTIO_META_UNPRIVILEGED_POD
           value: "true"
         - name: ISTIO_META_ROUTER_MODE
@@ -5592,7 +8090,7 @@ spec:
           value: Kubernetes
         - name: TERMINATION_DRAIN_DURATION_SECONDS
           value: "60"
-        image: index.docker.io/istio/proxyv2@sha256:01fc76f6dd3665ff1dd4aa9e309e4b02380fa266763e172ca07c766e8d2fe2d7
+        image: index.docker.io/istio/proxyv2@sha256:ffbc024407c89d15b102242b7b52c589ff3618c5117585007abbdf03da7a6528
         lifecycle:
           preStop:
             exec:
@@ -5745,13 +8243,13 @@ metadata:
   annotations:
     kbld.k14s.io/images: |
       - Metas:
-        - Tag: 1.9.5
+        - Tag: 1.10.2
           Type: resolved
-          URL: index.docker.io/istio/pilot:1.9.5
-        URL: index.docker.io/istio/pilot@sha256:2e79d77ec78bed529f0661896904068bad0662c792b7d69287f9b00b5d5f50e0
+          URL: index.docker.io/istio/pilot:1.10.2
+        URL: index.docker.io/istio/pilot@sha256:bda5d84cf86568f6578b0c5ffdd36c6ba8ee6bbf06230e0eb452af4f1a98f7d9
   labels:
     app: istiod
-    cloudfoundry.org/istio_version: 1.9.5
+    cloudfoundry.org/istio_version: 1.10.2
     install.operator.istio.io/owning-resource: unknown
     istio: pilot
     istio.io/rev: default
@@ -5775,7 +8273,7 @@ spec:
         sidecar.istio.io/inject: "false"
       labels:
         app: istiod
-        cloudfoundry.org/istio_version: 1.9.5
+        cloudfoundry.org/istio_version: 1.10.2
         install.operator.istio.io/owning-resource: unknown
         istio: pilot
         istio.io/rev: default
@@ -5827,9 +8325,7 @@ spec:
           value: "false"
         - name: CLUSTER_ID
           value: Kubernetes
-        - name: EXTERNAL_ISTIOD
-          value: "false"
-        image: index.docker.io/istio/pilot@sha256:2e79d77ec78bed529f0661896904068bad0662c792b7d69287f9b00b5d5f50e0
+        image: index.docker.io/istio/pilot@sha256:bda5d84cf86568f6578b0c5ffdd36c6ba8ee6bbf06230e0eb452af4f1a98f7d9
         name: discovery
         ports:
         - containerPort: 8080
@@ -5857,8 +8353,6 @@ spec:
           runAsNonRoot: true
           runAsUser: 1337
         volumeMounts:
-        - mountPath: /etc/istio/config
-          name: config-volume
         - mountPath: /var/run/secrets/tokens
           name: istio-token
           readOnly: true
@@ -5869,9 +8363,6 @@ spec:
           readOnly: true
         - mountPath: /var/run/secrets/remote
           name: istio-kubeconfig
-          readOnly: true
-        - mountPath: /var/lib/istio/inject
-          name: inject
           readOnly: true
       securityContext:
         fsGroup: 1337
@@ -5895,12 +8386,6 @@ spec:
         secret:
           optional: true
           secretName: istio-kubeconfig
-      - configMap:
-          name: istio-sidecar-injector
-        name: inject
-      - configMap:
-          name: istio
-        name: config-volume
 ---
 apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
@@ -5909,7 +8394,7 @@ metadata:
     kapp.k14s.io/update-strategy: fallback-on-replace
   labels:
     app: istio-ingressgateway
-    cloudfoundry.org/istio_version: 1.9.5
+    cloudfoundry.org/istio_version: 1.10.2
     install.operator.istio.io/owning-resource: unknown
     istio: ingressgateway
     istio.io/rev: default
@@ -5931,7 +8416,7 @@ metadata:
     kapp.k14s.io/update-strategy: fallback-on-replace
   labels:
     app: istiod
-    cloudfoundry.org/istio_version: 1.9.5
+    cloudfoundry.org/istio_version: 1.10.2
     install.operator.istio.io/owning-resource: unknown
     istio: pilot
     istio.io/rev: default
@@ -5950,7 +8435,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   labels:
-    cloudfoundry.org/istio_version: 1.9.5
+    cloudfoundry.org/istio_version: 1.10.2
     install.operator.istio.io/owning-resource: unknown
     istio.io/rev: default
     operator.istio.io/component: IngressGateways
@@ -5972,7 +8457,7 @@ kind: Role
 metadata:
   labels:
     app: istiod
-    cloudfoundry.org/istio_version: 1.9.5
+    cloudfoundry.org/istio_version: 1.10.2
     release: istio
   name: istiod-istio-system
   namespace: istio-system
@@ -5999,7 +8484,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
-    cloudfoundry.org/istio_version: 1.9.5
+    cloudfoundry.org/istio_version: 1.10.2
     install.operator.istio.io/owning-resource: unknown
     istio.io/rev: default
     operator.istio.io/component: IngressGateways
@@ -6019,7 +8504,7 @@ kind: RoleBinding
 metadata:
   labels:
     app: istiod
-    cloudfoundry.org/istio_version: 1.9.5
+    cloudfoundry.org/istio_version: 1.10.2
     release: istio
   name: istiod-istio-system
   namespace: istio-system
@@ -6037,7 +8522,7 @@ kind: HorizontalPodAutoscaler
 metadata:
   labels:
     app: istio-ingressgateway
-    cloudfoundry.org/istio_version: 1.9.5
+    cloudfoundry.org/istio_version: 1.10.2
     install.operator.istio.io/owning-resource: unknown
     istio: ingressgateway
     istio.io/rev: default
@@ -6063,7 +8548,7 @@ kind: HorizontalPodAutoscaler
 metadata:
   labels:
     app: istiod
-    cloudfoundry.org/istio_version: 1.9.5
+    cloudfoundry.org/istio_version: 1.10.2
     install.operator.istio.io/owning-resource: unknown
     istio.io/rev: default
     operator.istio.io/component: Pilot
@@ -6089,7 +8574,7 @@ metadata:
   annotations: null
   labels:
     app: istio-ingressgateway
-    cloudfoundry.org/istio_version: 1.9.5
+    cloudfoundry.org/istio_version: 1.10.2
     install.operator.istio.io/owning-resource: unknown
     istio: ingressgateway
     istio.io/rev: default
@@ -6126,7 +8611,7 @@ kind: Service
 metadata:
   labels:
     app: istiod
-    cloudfoundry.org/istio_version: 1.9.5
+    cloudfoundry.org/istio_version: 1.10.2
     install.operator.istio.io/owning-resource: unknown
     istio: pilot
     istio.io/rev: default
@@ -6157,14 +8642,14 @@ apiVersion: v1
 kind: Namespace
 metadata:
   labels:
-    cloudfoundry.org/istio_version: 1.9.5
+    cloudfoundry.org/istio_version: 1.10.2
   name: istio-system
 ---
 apiVersion: security.istio.io/v1beta1
 kind: PeerAuthentication
 metadata:
   labels:
-    cloudfoundry.org/istio_version: 1.9.5
+    cloudfoundry.org/istio_version: 1.10.2
   name: default
   namespace: istio-system
 spec:

--- a/config/istio/istio-version.star
+++ b/config/istio/istio-version.star
@@ -1,3 +1,3 @@
 def istio_version():
-  return "1.9.5"
+  return "1.10.2"
 end

--- a/config/z-kapp-versioned-creds.yml
+++ b/config/z-kapp-versioned-creds.yml
@@ -5,8 +5,9 @@
 #@ not_minio_secret = overlay.not_op(overlay.subset({"kind":"Secret", "metadata":{"name": "cf-blobstore-minio"}}))
 #@ not_kpack_webhook_certs = overlay.not_op(overlay.subset({"kind":"Secret", "metadata":{"name": "webhook-certs"}}))
 #@ not_kpack_configmap = overlay.not_op(overlay.subset({"kind":"ConfigMap", "metadata":{"namespace": "kpack"}}))
+#@ not_istio_sidecar_configmap = overlay.not_op(overlay.subset({"kind":"ConfigMap", "metadata":{"name": "istio-sidecar-injector"}}))
 #@ configMap_and_secret_matcher = overlay.or_op(overlay.subset({"kind":"ConfigMap"}), overlay.subset({"kind":"Secret"}))
-#@overlay/match by=overlay.and_op(configMap_and_secret_matcher, not_eirini_app_registry_secret, not_postgres_creds, not_minio_secret, not_kpack_webhook_certs, not_kpack_configmap), expects="1+"
+#@overlay/match by=overlay.and_op(configMap_and_secret_matcher, not_eirini_app_registry_secret, not_postgres_creds, not_minio_secret, not_kpack_webhook_certs, not_kpack_configmap, not_istio_sidecar_configmap), expects="1+"
 #@overlay/match-child-defaults missing_ok=True
 ---
 metadata:

--- a/supported_k8s_versions.yml
+++ b/supported_k8s_versions.yml
@@ -1,3 +1,3 @@
 ---
 oldest_version: "1.18"
-newest_version: "1.20"
+newest_version: "1.21"


### PR DESCRIPTION
- Upgrade Istio version for further support window.
- Increases Kubernetes cluster version support range to 1.18 - 1.21.

Co-authored-by: Dave Walter <walterda@vmware.com>


## WHAT is this change about?
Bumps Istio from 1.9.5 to 1.10.2

## Does this PR introduce a change to `config/values.yml`?
No.

## Acceptance Steps
Deploy as normal and run smoke tests.