### PR TITLE
Revert "Increased supported k8s cluster version to 1.22"

### DIFF
--- a/supported_k8s_versions.yml
+++ b/supported_k8s_versions.yml
@@ -1,3 +1,3 @@
 ---
 oldest_version: "1.19"
-newest_version: "1.22"
+newest_version: "1.21"


### PR DESCRIPTION
- Deprecated API removal in Kubernetes 1.22 causes incompatibility.

This reverts commit 2a596ac71747f0b3774dae56bc0926284edcd60c.

## WHAT is this change about?
This reverts #682. Kubernetes 1.22 removed some deprecated APIs which are required by dependencies.

## Does this PR introduce a change to `config/values.yml`?
No.

## Acceptance Steps
Deploy and smoke test as normal.