### PR TITLE
Revert "Revert "Increased supported k8s cluster version to 1.22""

### DIFF
--- a/supported_k8s_versions.yml
+++ b/supported_k8s_versions.yml
@@ -1,3 +1,3 @@
 ---
 oldest_version: "1.19"
-newest_version: "1.21"
+newest_version: "1.22"


### PR DESCRIPTION
## WHAT is this change about?
Increase Kubernetes cluster version support range to 1.22

## Does this PR introduce a change to `config/values.yml`?
No.

## Acceptance Steps
Smoke tests and CATS.