### PR TITLE
Migrate apiregistration.k8s.io for 1.22

### DIFF
--- a/config/metrics/add-metrics-server-components.yml
+++ b/config/metrics/add-metrics-server-components.yml
@@ -43,7 +43,7 @@ subjects:
   name: metrics-server
   namespace: kube-system
 ---
-apiVersion: apiregistration.k8s.io/v1beta1
+apiVersion: apiregistration.k8s.io/v1
 kind: APIService
 metadata:
   name: v1beta1.metrics.k8s.io


### PR DESCRIPTION
## WHAT is this change about?
Update resource to use supported API. `apiregistration.k8s.io/v1beta1` was removed in Kubernetes 1.22.

## Does this PR introduce a change to `config/values.yml`?
No.

## Acceptance Steps
Run tests as normal.

## Tag your pair, your PM, and/or team
@davewalter