### PR TITLE
Add network policy egress rule for IaaS metadata

### DIFF
--- a/config/networking/network-policies.yaml
+++ b/config/networking/network-policies.yaml
@@ -153,6 +153,20 @@ spec:
       port: 53
   policyTypes:
   - Egress
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-iaas-metadata-egress
+  namespace: #@ system_namespace()
+spec:
+  podSelector: {}
+  egress:
+  - to:
+    - ipBlock:
+        cidr: 169.254.169.254/32
+  policyTypes:
+  - Egress
 #@ if cfdb_enabled():
 ---
 apiVersion: networking.k8s.io/v1
@@ -170,6 +184,20 @@ spec:
       port: 53
     - protocol: TCP
       port: 53
+  policyTypes:
+  - Egress
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-iaas-metadata-egress
+  namespace: cf-db
+spec:
+  podSelector: {}
+  egress:
+  - to:
+    - ipBlock:
+        cidr: 169.254.169.254/32
   policyTypes:
   - Egress
 #@ end
@@ -190,6 +218,20 @@ spec:
       port: 53
     - protocol: TCP
       port: 53
+  policyTypes:
+  - Egress
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-iaas-metadata-egress
+  namespace: cf-blobstore
+spec:
+  podSelector: {}
+  egress:
+  - to:
+    - ipBlock:
+        cidr: 169.254.169.254/32
   policyTypes:
   - Egress
 #@ end


### PR DESCRIPTION
## WHAT is this change about?
Add a network policy egress rule to allow IaaS metadata lookup. Lookup times have been causing 2+ minute startup times for `istio-proxy`.

## Does this PR introduce a change to `config/values.yml`?
No.

## Acceptance Steps
Deploy and run tests as normal.

## Tag your pair, your PM, and/or team
@davewalter
